### PR TITLE
doc behavior of null.## after Trac 4311 

### DIFF
--- a/documentation/src/reference/ReferencePart.tex
+++ b/documentation/src/reference/ReferencePart.tex
@@ -4039,6 +4039,8 @@ argument x is not also the ``null'' object.
 \lstinline@asInstanceOf[$T\,$]@ returns the ``null'' object itself if
 $T$ conforms to \lstinline@scala.AnyRef@, and throws a
 \lstinline@NullPointerException@ otherwise.
+\item
+\lstinline@##@ return a hash code.
 \end{itemize}
 A reference to any other member of the ``null'' object causes a
 \code{NullPointerException} to be thrown. 


### PR DESCRIPTION
I can't build the pdf on my computer so you may want to verify what this looks like first.
