### PR TITLE
This patch fixes Scala indentation for Vim

### DIFF
--- a/tool-support/src/vim/indent/scala.vim
+++ b/tool-support/src/vim/indent/scala.vim
@@ -45,7 +45,8 @@ function! GetScalaIndent()
   " Add a 'shiftwidth' after lines that start a block
   " If if, for or while end with ), this is a one-line block
   " If val, var, def end with =, this is a one-line block
-  if prevline =~ '^\s*\<\(\(else\s\+\)\?if\|for\|while\|va[lr]\|def\)\>.*[)=]\s*$'
+  if prevline =~ '^\s*\<\(\(else\s\+\)\?if\|for\|while\)\>.*[)]\s*$'
+        \ || prevline =~ '^\s*\<\(\(va[lr]\|def\)\>.*[=]\s*$'
         \ || prevline =~ '^\s*\<else\>\s*$'
         \ || prevline =~ '{\s*$'
     let ind = ind + &shiftwidth
@@ -62,7 +63,8 @@ function! GetScalaIndent()
   
   " Dedent after if, for, while and val, var, def without block
   let pprevline = getline(prevnonblank(lnum - 1))
-  if pprevline =~ '^\s*\<\(\(else\s\+\)\?if\|for\|while\|va[lr]\|def\)\>.*[)=]\s*$'
+  if pprevline =~ '^\s*\<\(\(else\s\+\)\?if\|for\|while\)\>.*[)]\s*$'
+        \ || pprevline =~ '^\s*\<\(\va[lr]\|def\)\>.*[=]\s*$'
         \ || pprevline =~ '^\s*\<else\>\s*$'
     let ind = ind - &shiftwidth
   endif


### PR DESCRIPTION
Previous version had problems indenting after lines ending with parentheses.

Old:

```
val (foo, bar) = (getAFoo, getABar)
  var qux = 42
```

New:

```
val (foo, bar) = (getAFoo, getABar)
var qux = 42
```

Note the line "var qux ..." is improperly indented in the first example.
