### PR TITLE
Vim: Properly indent by two spaces (SI-4039)

### DIFF
--- a/tool-support/src/vim/indent/scala.vim
+++ b/tool-support/src/vim/indent/scala.vim
@@ -12,7 +12,7 @@ setlocal indentexpr=GetScalaIndent()
 
 setlocal indentkeys=0{,0},0),!^F,<>>,<CR>
 
-setlocal autoindent sw=2 et
+setlocal autoindent shiftwidth=2 tabstop=2 softtabstop=2 expandtab
 
 if exists("*GetScalaIndent")
   finish


### PR DESCRIPTION
The vim tool support only sets shiftwidth=2, but tabstop=2 is also
required. Additionally, softtabstop=2 makes it easy to remove a level of
indentation by pressing backspace one time, instead of two (for the two
spaces).

Without this, it's unnecessarily hard to write code using the standard
Scala 2 space indent.
