### PR TITLE
Fixes https://issues.scala-lang.org/browse/SI-1828 

### DIFF
--- a/tool-support/src/emacs/scala-mode.el
+++ b/tool-support/src/emacs/scala-mode.el
@@ -142,10 +142,10 @@ through `mail-user-agent'."
   
   ;; comments
   ;; the `n' means that comments can be nested
-  (modify-syntax-entry ?\/  ". 124nb" scala-mode-syntax-table)
+  (modify-syntax-entry ?\/  ". 124b" scala-mode-syntax-table)
   (modify-syntax-entry ?\*  ". 23n"   scala-mode-syntax-table)
-  (modify-syntax-entry ?\n  "> bn" scala-mode-syntax-table)
-  (modify-syntax-entry ?\r  "> bn" scala-mode-syntax-table))
+  (modify-syntax-entry ?\n  "> b" scala-mode-syntax-table)
+  (modify-syntax-entry ?\r  "> b" scala-mode-syntax-table))
 
 
 ;;; Mode


### PR DESCRIPTION
scala-mode.el had a bug that would result in the character sequence `////`
causing both the line it was on and the following line to be highlighted as
comments.

Fixes https://issues.scala-lang.org/browse/SI-1828

Credit to Suraj Acharya (@surajacharya).
