### PR TITLE
Define a <style> for "other", in language def for gedit

### DIFF
--- a/tool-support/src/gedit/scala.lang
+++ b/tool-support/src/gedit/scala.lang
@@ -34,6 +34,7 @@
     <style id="number" _name="Number" map-to="def:decimal"/>
     <style id="type" _name="Data Type" map-to="def:type"/>
     <style id="builtin" _name="Built In" map-to="def:type"/>
+    <style id="other" _name="Other" map-to="def:special-char"/>
   </styles>
 
   <definitions>


### PR DESCRIPTION
The <context> for "annotation" referenced a missing <style> "other".  This was making gedit output an error message whenever started, & it didn't highlight annotations.
