### PR TITLE
Emacs Indent Behavior

### DIFF
--- a/tool-support/src/emacs/AUTHORS
+++ b/tool-support/src/emacs/AUTHORS
@@ -15,3 +15,4 @@ scala emacs mode.
 ** ? <cwitty at newtonlabs.com>
 ** Hemant Kumar <gethemant at gmail.com>
 ** Ulrick Müller <ulm@gentoo.org>
+** Jarred Ward <jarred at webriots.com>

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -142,6 +142,13 @@
       (let ((parse-sexp-ignore-comments t))
         (goto-char (1+ (scan-sexps (1+ (point)) -1))))
       (- (scala-block-indentation) scala-mode-indent:step))
+     ((eq (char-after) ?\.)
+      (scala-backward-ident)
+      (beginning-of-line)
+      (scala-forward-spaces (scala-point-after (end-of-line)))
+      (if (= (char-syntax (char-after)) ?\.)
+          (scala-indentation-from-following)
+        (+ (current-indentation) scala-mode-indent:step)))ooo
      ((looking-at scala-expr-middle-re)
       ;; [...] this is a somewhat of a hack.
       (let ((matching-kw (cdr (assoc (match-string-no-properties 0)

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -191,7 +191,7 @@ not move."
   "Indent current line as smartly as possible.
 When called repeatedly, indent each time one stop further on the right."
   (interactive)
-  (if (or (eq last-command this-command)
+  (if (or (and (eq last-command this-command) (not (eq last-command 'scala-newline)))
           (eq last-command 'scala-undent-line))
       (scala-indent-line-to (+ (current-indentation) scala-mode-indent:step))
     (let 

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -125,6 +125,7 @@
 	(progn
 	  (beginning-of-line)
 	  (when (search-forward ")" block-start-eol t)
+	    (while (search-forward ")" block-start-eol t))
 	    (scala-forward-spaces)
 	    (backward-sexp))
 	  (+ (current-indentation) scala-mode-indent:step))


### PR DESCRIPTION
This fixes the indent behavior when there are extra parentheses in the
message signature -- such as an annotation or default value.

```
def get(
  l: List = List(1, 2, 3),
  d: List = List(2, 3, 4)) {
    val l = l
  }
```

Becomes this

```
def get(
  l: List = List(1, 2, 3),
  d: List = List(2, 3, 4)) {
  val l = l
}
```

And the same with annotations.
