### PR TITLE
Computeserver tweak for nerd factor and readability.

### DIFF
--- a/examples/src/main/scala/computeserver.scala
+++ b/examples/src/main/scala/computeserver.scala
@@ -3,42 +3,53 @@ package examples
 import concurrent._
 import java.util.concurrent.{ CountDownLatch, Executors, TimeUnit }
 
-object computeServer extends App {
+object computeServer {
 
-  class ComputeServer(n: Int) {
+  class ComputeServer(n: Int, completer: Either[Throwable,Unit] => Unit)(implicit ctx: ExecutionContext) {
 
     private trait Job {
       type T
       def task: T
       def ret(x: T): Unit
+      def err(x: Throwable): Unit
     }
 
     private val openJobs = new Channel[Job]()
 
     private def processor(i: Int) {
       printf("processor %d starting\n", i)
+      // simulate failure in faulty #3
+      if (i == 3) throw new IllegalStateException("processor %d: Drat!" format i)
       while (!isDone) {
         val job = openJobs.read
         printf("processor %d read a job\n", i)
-        job.ret(job.task)
+        try {
+          job.ret(job.task)
+        } catch {
+          case x => job.err(x)
+        }
       }
       printf("processor %d terminating\n", i)
     }
 
     def submit[A](p: => A): Future[A] = future {
-      val reply = new SyncVar[A]()
+      val reply = new SyncVar[Either[Throwable, A]]()
       openJobs.write {
         new Job {
           type T = A
           def task = p
-          def ret(x: A) = reply.put(x)
+          def ret(x: A) = reply.put(Right(x))
+          def err(x: Throwable) = reply.put(Left(x))
         }
       }
-      reply.get
+      reply.get match {
+        case Right(x) => x
+        case Left(x) => throw x
+      }
     }
 
     val done = new SyncVar[Boolean]
-    def isDone = done.isSet && done.get(500).get
+    def isDone = done.isSet && done.get
     def finish() {
       done.put(true)
       val nilJob =
@@ -46,34 +57,67 @@ object computeServer extends App {
           type T = Null
           def task = null
           def ret(x: Null) { }
+          def err(x: Throwable) { }
         }
       // unblock readers
       for (i <- 1 to n) { openJobs.write(nilJob) }
     }
 
-    for (i <- 1 to n; f = future { processor(i) }) f onComplete { _ => doneLatch.countDown() }
+    // You can, too! http://www.manning.com/suereth/
+    def futured[A,B](f: A => B): A => Future[B] = { in => future(f(in)) }
+    def futureHasArrived(f: Future[Unit]) = f onComplete completer
+
+    1 to n map futured(processor) foreach futureHasArrived
+
+    // Until your book arrives in the mail, or until your Kindle arrives in the mail
+    //for (i <- 1 to n; f = future(processor(i))) f onComplete completer
   }
 
-  val Processors = 2
-  implicit val ctx = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2 * Processors))
-  val doneLatch = new CountDownLatch(Processors+1)
-  val server = new ComputeServer(Processors)
+  def main(args: Array[String]) {
+    def usage(msg: String = "scala examples.computeServer <n>"): Nothing = {
+      println(msg)
+      sys.exit(1)
+    }
+    val avail = Runtime.getRuntime.availableProcessors
+    val default = 4 min avail
+    def num(s: String): Int = try { s.toInt.min(avail) } catch { case _ => usage("Bad number "+ s) }
+    if (args.length > 1) usage()
+    val numProcessors = args.headOption.map(num).getOrElse(default)
+    if (numProcessors < 1) usage(""+ numProcessors +" processors doesn't sound very useful. Try between one and "+ avail)
 
-  val f = server.submit(42)
-  val g = server.submit(38)
-  val h = for (x <- f; y <- g) yield { x + y }
-  h onComplete {
-    case Right(v) => println(v); windDown()
-    case _ => windDown()
+    // Factor of two because this example demonstrates gross consumption of threads. Don't try this at home.
+    implicit val ctx = ExecutionContext.fromExecutorService(Executors.newFixedThreadPool(2 * numProcessors))
+    val numResults = 2
+    val doneLatch = new CountDownLatch(numProcessors + numResults)
+    def completer(e: Either[Throwable, Unit]) {
+      e.left foreach (x => println("Processor terminated in error: "+ x.getMessage))
+      doneLatch.countDown()
+    }
+    val server = new ComputeServer(numProcessors, completer _)
+
+    def dbz = 1/0
+    val k = server.submit(dbz)
+    k onComplete {
+      case Right(v) => println("k returned? "+ v); doneLatch.countDown()
+      case Left(v) => println("k failed! "+ v); doneLatch.countDown()
+    }
+
+    val f = server.submit(42)
+    val g = server.submit(38)
+    val h = for (x <- f; y <- g) yield { x + y }
+    h onComplete {
+      case Right(v) => println(v); windDown()
+      case _ => windDown()
+    }
+    def windDown() {
+      server.finish()
+      doneLatch.countDown()
+    }
+    def shutdown() {
+      ctx.shutdown()
+      ctx.awaitTermination(1, TimeUnit.SECONDS)
+    }
+    doneLatch.await()
+    shutdown()
   }
-  def windDown() {
-    server.finish()
-    doneLatch.countDown()
-  }
-  def shutdown() {
-    ctx.shutdown()
-    ctx.awaitTermination(1, TimeUnit.SECONDS)
-  }
-  doneLatch.await()
-  shutdown()
 }

--- a/examples/src/main/scala/computeserver.scala
+++ b/examples/src/main/scala/computeserver.scala
@@ -51,7 +51,7 @@ object computeServer extends App {
       for (i <- 1 to n) { openJobs.write(nilJob) }
     }
 
-    for (i <- 1 to n) { future { processor(i) } onComplete { e => doneLatch.countDown() } }
+    for (i <- 1 to n; f = future { processor(i) }) f onComplete { _ => doneLatch.countDown() }
   }
 
   val Processors = 2


### PR DESCRIPTION
Solves the problem of two trailing closing braces, which is unaesthetic.
Keeps for( because I'm a traditionalist, but future{ so that }) is easy
on the eyes. Nested parens are OK, of course, but the thorny point on the
brace keeps its neighbor visually at a distance.
