### PR TITLE
Fix block indentation.

### DIFF
--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -53,6 +53,10 @@
   :type 'integer
   :group 'scala)
 
+(defcustom scala-mode-indent:align-params nil
+  "Non-nil means align class/function parameters in the same column."
+  :type 'boolean
+  :group 'scala)
 
 (defun scala-parse-partial-sexp ()
   (parse-partial-sexp (point-min) (point)))
@@ -137,15 +141,15 @@
 (defun scala-block-indentation ()
   (let ((block-start-eol (scala-point-after (end-of-line)))
         (block-after-spc (scala-point-after (scala-forward-spaces))))
-    (if (> block-after-spc block-start-eol)
-	(progn
-	  (beginning-of-line)
-	  (when (search-forward ")" block-start-eol t)
-	    (while (search-forward ")" block-start-eol t))
-	    (scala-forward-spaces)
-	    (backward-sexp))
-	  (+ (current-indentation) scala-mode-indent:step))
-      (current-column))))
+    (when (> block-after-spc block-start-eol)
+      (beginning-of-line)
+      (when (search-forward ")" block-start-eol t)
+        (while (search-forward ")" block-start-eol t))
+        (scala-forward-spaces)
+        (backward-sexp)))
+    (if (and scala-mode-indent:align-params (looking-back "("))
+        (current-column)
+      (+ (current-indentation) scala-mode-indent:step))))
 
 (defun scala-indentation-from-following ()
   ;; Return suggested indentation based on the following part of the


### PR DESCRIPTION
This has been bothering me for a while. I've tested this in all of the block-like scenarios I encounter regularly in my projects, which may or may not be exhaustive.

---

Fixes block indentation so that:

```
foo { x =>
  bar
  baz
}
```

is not incorrectly indented as:

```
foo { x =>
  bar
     baz
   }
```

Also add a custom preference to turn the old behavior back on when the current block starts with a paren, so that aligning class/def params still works:

```
class Foo(a: Int,
          b: Int)
```
