### PR TITLE
Control multiline fontlock via custom variable.

### DIFF
--- a/tool-support/src/emacs/scala-mode-fontlock.el
+++ b/tool-support/src/emacs/scala-mode-fontlock.el
@@ -54,6 +54,15 @@
 (require 'scala-mode-lib)
 (require 'scala-mode-navigation)
 
+(defcustom scala-mode-fontlock:multiline-highlight nil
+  "Non-nil means enable multiple line highlight support, which
+may cause emacs slow down in certain condition, and variable
+`font-lock-multiline' will be set to t in the buffer when scala
+mode is activated. One can always use special file local variable
+eval to set `font-lock-multiline' to t to achieve multiple line
+highlight effect, and leave this variable untouched."
+  :type 'boolean
+  :group 'scala)
 
 (defun scala-mark-borders (funs)
   (loop for (fun . flag) in funs
@@ -219,6 +228,3 @@
 (defvar scala-font-lock-syntactic-keywords
   `((,scala-char-re (0 "\"" t nil))
     (scala-search-special-identifier-forward (0 "w" nil nil))))
-
-
-

--- a/tool-support/src/emacs/scala-mode.el
+++ b/tool-support/src/emacs/scala-mode.el
@@ -182,7 +182,6 @@ When started, run `scala-mode-hook'.
                                        nil
                                        (font-lock-syntactic-keywords . scala-font-lock-syntactic-keywords)
                                        (parse-sexp-lookup-properties . t))
-    font-lock-multiline           t
 	paragraph-separate            (concat "^\\s *$\\|" page-delimiter)
 	paragraph-start               (concat "^\\s *$\\|" page-delimiter)
 	paragraph-ignore-fill-prefix  t
@@ -195,6 +194,10 @@ When started, run `scala-mode-hook'.
 ;	comment-indent-function       'scala-comment-indent-function
 	indent-line-function          'scala-indent-line
 	)
+
+  (when scala-mode-fontlock:multiline-highlight
+    (make-local-variable 'font-lock-multiline)
+    (setq font-lock-multiline t))
 
   (use-local-map scala-mode-map)
   (turn-on-font-lock)


### PR DESCRIPTION
Add custom variable scala-mode-fontlock:multiline-highlight to global enable
or disable multiline font lock support in scala-mode, this provide a quick
work aroud for issue #46.

This commit also make variable font-lock-multiline buffer local to avoid
change the global value of this variable.
