### PR TITLE
Fix issue #46.

### DIFF
--- a/tool-support/src/emacs/scala-mode.el
+++ b/tool-support/src/emacs/scala-mode.el
@@ -195,10 +195,6 @@ When started, run `scala-mode-hook'.
 	indent-line-function          'scala-indent-line
 	)
 
-  (when scala-mode-fontlock:multiline-highlight
-    (make-local-variable 'font-lock-multiline)
-    (setq font-lock-multiline t))
-
   (use-local-map scala-mode-map)
   (turn-on-font-lock)
   (scala-mode-feature-install)


### PR DESCRIPTION
Rewrite scala-font-lock-limit function to narrow down the
"font-lock-multiline" marked text to actual multiple line construct. This
change largely decrease the size of text which need to be refontify when any
modification to text happen.

A minor change is made to function scala-match-and-skip-type-param to fix the
highlight problem for the code like below:

``` scala
class A[T1,
        T2[T]
] (a: Int) { // "(a: Int)" will not be fontify as expected
}
```
