### PR TITLE
Fixes comments

### DIFF
--- a/tool-support/src/emacs/scala-mode-fontlock.el
+++ b/tool-support/src/emacs/scala-mode-fontlock.el
@@ -234,5 +234,4 @@ current context."
 
 
 (defvar scala-font-lock-syntactic-keywords
-  `((,scala-char-re (0 "\"" t nil))
-    (scala-search-special-identifier-forward (0 "w" nil nil))))
+  `((,scala-char-re (0 "\"" t nil))))


### PR DESCRIPTION
Hello.
Currently scala-mode highlights some actual code as comments. The problem is described in #8. This quick fix solves the problem. Here's the screenshot of before and after: http://i.imgur.com/OG033.png
On the left -- without the fix, on the right -- with it (using [this](https://github.com/rickynils/scalacheck/blob/master/src/main/scala/org/scalacheck/Arbitrary.scala) file for presentation).
Thanks.
