### PR TITLE
Emacs: fixes to indentation and font-lock

### DIFF
--- a/tool-support/src/emacs/AUTHORS
+++ b/tool-support/src/emacs/AUTHORS
@@ -16,3 +16,4 @@ scala emacs mode.
 ** Hemant Kumar <gethemant at gmail.com>
 ** Ulrick Müller <ulm@gentoo.org>
 ** Jarred Ward <jarred at webriots.com>
+** Heikki Vesalainen <heikki.vesalainen at gmail.com>

--- a/tool-support/src/emacs/FUTURE
+++ b/tool-support/src/emacs/FUTURE
@@ -7,12 +7,6 @@
 Automatic indentation is incredibly basic and doesn't work correctly
 in many situations, including:
 
-  - multi-line "case" statements, e.g.
-
-      case Pair(x,y) =>
-        Console.println(x);
-        Console.println(y);   // not indented correctly
-
   - multi-line "case" patterns, e.g.
 
       case 'a' | 'b' | 'c'
@@ -27,11 +21,6 @@ in many situations, including:
           kala
       else // not indented correctly (aligns with if (bar))
         koira 
-
-      val x = for { 
-        i <- 1 to 10)
-      }
-      yield i // not indented correctly (aligns with for)
 
   - other cases of single-line constructs as soon as they span
     multiple lines.

--- a/tool-support/src/emacs/FUTURE
+++ b/tool-support/src/emacs/FUTURE
@@ -4,7 +4,6 @@
 
 ** Automatic indentation should work in all cases
 
-
 Automatic indentation is incredibly basic and doesn't work correctly
 in many situations, including:
 
@@ -18,12 +17,6 @@ in many situations, including:
 
       case 'a' | 'b' | 'c'
          | 'd' | 'e' | 'f'    // not indented correctly
-
-  - multi-line comments, e.g.
-
-      /*
-       *                      // not indented correctly
-       */                     // not indented correctly
 
   - other cases of single-line constructs as soon as they span
     multiple lines.

--- a/tool-support/src/emacs/FUTURE
+++ b/tool-support/src/emacs/FUTURE
@@ -18,6 +18,21 @@ in many situations, including:
       case 'a' | 'b' | 'c'
          | 'd' | 'e' | 'f'    // not indented correctly
 
+  - matching of matching keywords in corner cases
+
+      if (foo)
+        if (bar)
+          kissa
+        else
+          kala
+      else // not indented correctly (aligns with if (bar))
+        koira 
+
+      val x = for { 
+        i <- 1 to 10)
+      }
+      yield i // not indented correctly (aligns with for)
+
   - other cases of single-line constructs as soon as they span
     multiple lines.
 

--- a/tool-support/src/emacs/README
+++ b/tool-support/src/emacs/README
@@ -61,9 +61,10 @@ From that point on, loading a file whose name ends in ".scala"
 automatically turns Scala mode on. It can also be turned on manually
 using the "scala-mode" command. 
 
-The get the best expirience from using the scala mode in emacs, please
-visit the costumization options for the scala mode.
+* Customization
 
+The get the best expirience from using the scala mode in emacs, please
+visit the customization options for the scala mode.
 
 * Future plans
 

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -30,12 +30,20 @@ private class Foo { self =>
 private class Foo { 
   self =>
     line // KNOWN ISSUE, should not be indented
+
+  case class Cell() 
+  
+  def f(): = {}
+
 }
 
 private class Foo { 
-  self =>
-    
-  line
+  
+  case/* */
+  class Cell() 
+  
+  def f(): = {}
+  
 }
 
 private class Foo(x: Int,
@@ -43,7 +51,13 @@ private class Foo(x: Int,
                   z: Int) // KNOWN ISSUE in font-lock mode
 
 private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
-                                       with Zot
+                                       with Zot {
+  
+  case class Cell() 
+  
+  def f(): = {}
+  
+}
 
 
 /* indenting */

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -1,0 +1,160 @@
+package foo
+
+import bar
+
+object Foo extends Bar with Zot
+
+object Foo extends Bar(1,
+                       2)
+           with Zot(3)
+
+object Foo extends Bar;
+with Zot // should not be aligned with 'extends' since there is ';' above
+
+object Foo extends Bar
+
+with Zot // should not be aligned with 'extends' since there is empty line above
+
+private class Foo 
+        extends Bar
+        with Zot
+
+private class Foo { self =>
+  line
+}
+
+private class Foo { 
+  self =>
+    line // KNOWN ISSUE, should not be indented
+}
+
+private class Foo { 
+  self =>
+
+  line
+}
+
+private class Foo(x: Int,
+                  y: Int) // KNOWN ISSUE in font-lock mode
+
+private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
+                                       with Zot
+
+
+/* indenting */
+{
+  def foo(x: Int,
+          y: Int)
+  (z: Int) // KNOWN ISSUE: curry is not aligned nicely
+
+  def x = 1
+  def y = true
+  def z = if (y)
+            x
+          else 
+            0
+
+  var z = if (y) 
+            if (z > 0)
+              3
+            else
+              z
+            else // KNOWN ISSUE, should be aligned with first if, but we will not parse such things
+              2
+
+  val z = if (y) {
+    2
+  } else {
+    if (false)
+      println("foo")
+    3
+  }
+
+  val foo = zot (y) {
+    bar
+  }
+
+  val x = new Foo(1,
+                  2,
+                  3)
+          with Bar
+
+  val foo = zot map (x =>
+    x.toString)
+
+  val foo = zot map (x =>
+    x.toString
+                   ) // KNOWN ISSUE
+
+  def zz = for (i <- 1 to 10)
+           yield i
+
+  def yy = for {
+    i < 1 to 10
+  } yield i
+
+  def yy = for { i <- 1 to 10
+                 j <- 2 to 3 }
+           yield i * j
+
+  def z = x match {
+    case 1 =>
+      foo
+    bar // KNOWN ISSUE, should be indented
+    case a =>
+      bar
+  }
+
+  do {
+    something
+  } while (true)
+
+  while (true) {
+    something
+  }
+
+  while (true)
+  something // KNWN ISSUE, should be indented, but we don't know if the while is end of do..while or start of plain while
+
+  def z = try {
+    foo
+  } catch {
+    case e =>
+      oneline
+    twoline // KNOWN ISSUE, should be indented
+  }
+
+  def z = foo
+    .bar
+    .zot
+
+  def z = foo {
+  }
+  .bar
+  .bar
+
+}
+
+/* font lock */
+private/* */class/* */Foo/* */[+T]/* */(i: X,
+                                        j: Y) // KNOWN ISSUE: does not highlight when typed
+
+{
+  def x = 1
+
+  def/* */x/* */=/* */1 // KNOWN ISSUE: x is with wrong face
+
+  def foo(x: String, //
+          y: Int/* */, // KNOWN ISSUE: Int should be highlighted
+          z: Boolean)
+  (x: Int) // KNOWN ISSUE(S): '(' is highted, curry is not highlighted when typed
+
+  def foo(@annotation // KNOWN ISSUE: annotations are in parameter name font face
+          x: String)
+
+  val x = new Foo(1,
+                  2,
+                  3)
+          with Bar // KNOWN ISSUE: bar is in wrong font-face (should be same as Foo)
+
+}

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -4,9 +4,13 @@ import bar
 
 object Foo extends Bar with Zot
 
-object Foo extends Bar(1,
-                       2)
-           with Zot(3)
+object Foo extends Bar(  1,
+                         2)( 3,
+                             4)
+           with Zot(3) { foo =>
+             foo // KNOWN ISSUE, should not be indented this far
+  bar
+}
 
 object Foo extends Bar;
 with Zot // should not be aligned with 'extends' since there is ';' above
@@ -17,7 +21,7 @@ with Zot // should not be aligned with 'extends' since there is empty line above
 
 private class Foo 
         extends Bar
-        with Zot
+        with Zot 
 
 private class Foo { self =>
   line
@@ -30,12 +34,13 @@ private class Foo {
 
 private class Foo { 
   self =>
-
+    
   line
 }
 
 private class Foo(x: Int,
-                  y: Int) // KNOWN ISSUE in font-lock mode
+                  y: Int,
+                  z: Int) // KNOWN ISSUE in font-lock mode
 
 private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
                                        with Zot
@@ -46,14 +51,14 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
   def foo(x: Int,
           y: Int)
   (z: Int) // KNOWN ISSUE: curry is not aligned nicely
-
+  
   def x = 1
   def y = true
   def z = if (y)
             x
           else 
             0
-
+  
   var z = if (y) 
             if (z > 0)
               3
@@ -61,7 +66,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
               z
             else // KNOWN ISSUE, should be aligned with first if, but we will not parse such things
               2
-
+  
   val z = if (y) {
     2
   } else {
@@ -69,70 +74,100 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       println("foo")
     3
   }
-
+  
   val foo = zot (y) {
     bar
   }
-
-  val x = new Foo(1,
-                  2,
-                  3)
+  
+  val x = new Foo( /* */ 1,
+                   2,
+                   3)
           with Bar
-
+  
   val foo = zot map (x =>
     x.toString)
-
+  
   val foo = zot map (x =>
     x.toString
-                   ) // KNOWN ISSUE
-
+  ) // FIXED
+  
   def zz = for (i <- 1 to 10)
            yield i
-
+  
   def yy = for {
     i < 1 to 10
   } yield i
-
+  
   def yy = for { i <- 1 to 10
                  j <- 2 to 3 }
            yield i * j
-
+  
   def z = x match {
+      
     case 1 =>
       foo
-    bar // KNOWN ISSUE, should be indented
-    case a =>
+      bar 
+    /* foo bar*/
+    case a => {
       bar
+      goo
+    }
   }
-
+  
   do {
     something
   } while (true)
-
+  
   while (true) {
     something
   }
-
+  
   while (true)
-  something // KNWN ISSUE, should be indented, but we don't know if the while is end of do..while or start of plain while
-
+  something // KNOWN ISSUE, should be indented, but we don't know if the while is end of do..while or start of plain while
+  
+  def z = try {
+    foo
+  } catch {
+    case e =>
+      abd
+      oneline
+      twoline 
+  }
+  
+  // Scamacs works here
   def z = try {
     foo
   } catch {
     case e =>
       oneline
-    twoline // KNOWN ISSUE, should be indented
+      twoline 
   }
 
+  val zz = xx map {
+    case (i, j) => 
+      doSomething
+      i+j
+    case (j, i) =>
+      doSomethingElse
+      yes!
+  }
+  
   def z = foo
     .bar
     .zot
-
+  
+  // Scamacs always does below and never the above (no configuration)
+  // Heikki, please confirm I haven't broken your dot alignment code. RPR
+  // I actually prefer the below behavior.  
+  // Since the Heikki added a custom param to support scamacs behavior, which I no longer like,
+  // should we remove the param and go with below as fixed behavior.
+  // I'm ok with removing the param.
   def z = foo {
+    g.dothis
+      .bar
+      .bar
+      .dothat
   }
-  .bar
-  .bar
-
 }
 
 /* font lock */
@@ -141,20 +176,19 @@ private/* */class/* */Foo/* */[+T]/* */(i: X,
 
 {
   def x = 1
-
+  
   def/* */x/* */=/* */1 // KNOWN ISSUE: x is with wrong face
-
+  
   def foo(x: String, //
           y: Int/* */, // KNOWN ISSUE: Int should be highlighted
           z: Boolean)
   (x: Int) // KNOWN ISSUE(S): '(' is highted, curry is not highlighted when typed
-
+  
   def foo(@annotation // KNOWN ISSUE: annotations are in parameter name font face
           x: String)
-
+  
   val x = new Foo(1,
                   2,
                   3)
-          with Bar // KNOWN ISSUE: bar is in wrong font-face (should be same as Foo)
-
+          with Bar // KNOWN ISSUE: bar is in wrong font-face (should be same as Foo)  
 }

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -183,13 +183,20 @@ reserved keywords when used alone.")
 (defconst scala-capitalized-ident-re
   (concat "\\(\\)\\([[:upper:]]" scala-ident-re "\\)"))
 
-(defconst scala-value-expr-start-re
-  (regexp-opt '("if" "for") 'words))
+(defconst scala-if-re 
+  "if")
+
+(defconst scala-else-if-re 
+  "\\<else\\s +if\\>")
+
+(defconst scala-for-re 
+  "for")
 
 (defconst scala-value-expr-cont-re
   (regexp-opt '("else" "yield") 'words))
 
-(defconst scala-declr-expr-start-re "[^=]=>?")
+(defconst scala-declr-expr-start-re 
+  "[^=]=>?")
 
 (defconst scala-expr-starter
   (mapcar (lambda (pair) (cons (car pair) (concat "\\<" (cdr pair) "\\>")))
@@ -197,14 +204,10 @@ reserved keywords when used alone.")
             ("yield" . "for")
             ("while" . "do")
             ("extends" . "class")
-            ("with" . "extends\\|new")
-            ("=>" . "case"))))
+            ("with" . "extends\\|new"))))
 
 (defconst scala-expr-middle-re
   (regexp-opt (mapcar #'car scala-expr-starter) 'words))
-
-(defconst scala-compound-expr-re
-  "\\<else\\s +if\\>")
 
 (defconst scala-comment-begin-or-end-re
   (concat "\\(" "^/\\*.*" "\\|" "^//.*" "\\|" ".*\\*/$" "\\)"))

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -184,13 +184,13 @@ reserved keywords when used alone.")
   (concat "\\(\\)\\([[:upper:]]" scala-ident-re "\\)"))
 
 (defconst scala-if-re 
-  "if")
+  (regexp-opt '("if") 'words))
 
 (defconst scala-else-if-re 
   "\\<else\\s +if\\>")
 
 (defconst scala-for-re 
-  "for")
+  (regexp-opt '("for") 'words))
 
 (defconst scala-value-expr-cont-re
   (regexp-opt '("else" "yield") 'words))
@@ -198,12 +198,18 @@ reserved keywords when used alone.")
 (defconst scala-declr-expr-start-re 
   "[^=]=>?")
 
+(defconst scala-class-middle-re 
+  (regexp-opt '("extends" "with") 'words))
+
+(defconst scala-class-head-re
+  (regexp-opt '("class" "object" "new") 'words))
+
 (defconst scala-expr-starter
   (mapcar (lambda (pair) (cons (car pair) (concat "\\<" (cdr pair) "\\>")))
           '(("else" . "if")
             ("yield" . "for")
             ("while" . "do")
-            ("extends" . "class")
+            ("extends" . "class\\|object")
             ("with" . "extends\\|new"))))
 
 (defconst scala-expr-middle-re

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -184,18 +184,18 @@ reserved keywords when used alone.")
   (concat "\\(\\)\\([[:upper:]]" scala-ident-re "\\)"))
 
 (defconst scala-value-expr-start-re
-  (regexp-opt '("if" "else" "for" "do" "yield") 'words))
+  (regexp-opt '("if" "for") 'words))
+
+(defconst scala-value-expr-cont-re
+  (regexp-opt '("else" "yield") 'words))
 
 (defconst scala-declr-expr-start-re "[^=]=>?")
-
-(defconst scala-expr-start-re
-  (concat scala-value-expr-start-re "\\|" scala-declr-expr-start-re))
 
 (defconst scala-expr-starter
   (mapcar (lambda (pair) (cons (car pair) (concat "\\<" (cdr pair) "\\>")))
           '(("else" . "if")
             ("yield" . "for")
-            ("do" . "for")
+            ("while" . "do")
             ("extends" . "class")
             ("with" . "extends\\|new")
             ("=>" . "case"))))
@@ -208,4 +208,6 @@ reserved keywords when used alone.")
 
 (defconst scala-comment-begin-or-end-re
   (concat "\\(" "^/\\*.*" "\\|" "^//.*" "\\|" ".*\\*/$" "\\)"))
+
+(defconst scala-empty-line-re  "^\\s *$")
 

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -192,6 +192,9 @@ reserved keywords when used alone.")
 (defconst scala-for-re 
   (regexp-opt '("for") 'words))
 
+(defconst scala-case-re
+  (regexp-opt '("case") 'words))
+
 (defconst scala-value-expr-cont-re
   (regexp-opt '("else" "yield") 'words))
 

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -183,10 +183,13 @@ reserved keywords when used alone.")
 (defconst scala-capitalized-ident-re
   (concat "\\(\\)\\([[:upper:]]" scala-ident-re "\\)"))
 
+(defconst scala-value-expr-start-re
+  (regexp-opt '("if" "else" "for" "do" "yield") 'words))
+
+(defconst scala-declr-expr-start-re "[^=]=>?")
+
 (defconst scala-expr-start-re
-  (concat
-   (regexp-opt '("if" "else" "for" "do" "yield") 'words) "\\|"
-   (regexp-opt '("=" "=>") t)))
+  (concat scala-value-expr-start-re "\\|" scala-declr-expr-start-re))
 
 (defconst scala-expr-starter
   (mapcar (lambda (pair) (cons (car pair) (concat "\\<" (cdr pair) "\\>")))

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -194,7 +194,7 @@ reserved keywords when used alone.")
             ("yield" . "for")
             ("do" . "for")
             ("extends" . "class")
-            ("with" . "class")
+            ("with" . "extends\\|new")
             ("=>" . "case"))))
 
 (defconst scala-expr-middle-re

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -195,6 +195,9 @@ reserved keywords when used alone.")
 (defconst scala-case-re
   (regexp-opt '("case") 'words))
 
+(defconst scala-class-re
+  (regexp-opt '("case") 'words))
+
 (defconst scala-value-expr-cont-re
   (regexp-opt '("else" "yield") 'words))
 

--- a/tool-support/src/emacs/scala-mode-fontlock.el
+++ b/tool-support/src/emacs/scala-mode-fontlock.el
@@ -111,10 +111,10 @@ current context."
            (let ((matches (scala-make-match
                            '((scala-forward-ident . t)
                              ((lambda ()
-                                (scala-forward-spaces)
+                                (scala-forward-ignorable)
                                 (when (scala-looking-at-special-identifier ":")
                                   (forward-char)
-                                  (scala-forward-spaces)
+                                  (scala-forward-ignorable)
                                   t)) . nil)
                              ((lambda ()
                                 (scala-forward-type)
@@ -125,7 +125,7 @@ current context."
          t)))
 
 (defun scala-match-and-skip-ident (limit)
-  (scala-forward-spaces)
+  (scala-forward-ignorable)
   (when (and (not (looking-at scala-keywords-re))
              (looking-at scala-qual-ident-re))
     (goto-char (match-end 0))

--- a/tool-support/src/emacs/scala-mode-fontlock.el
+++ b/tool-support/src/emacs/scala-mode-fontlock.el
@@ -85,15 +85,17 @@ current context."
     ;; multiple line construct will only start with '[' or '(', not '{'
     (when (looking-at "[ \t\n]*[\\[(]")
       (save-excursion
-        (condition-case ex
-            (forward-list)
-          ('error
-           ;; Hack: Find next keyword when parentheses are not balanced.  Here
-           ;; we assume that next keyword will not be too far from current
-           ;; position, so will not cause emacs slow down too much.
-           (unless (search-forward-regexp scala-keywords-re nil t)
-             (end-of-line))))
-        (setq p1 (point)))
+        ;; skip all parameter groups in "def foo(a: Int)(b: Int)"
+        (while (looking-at "[ \t\n]*[\\[(]")
+          (condition-case ex
+              (forward-list)
+            ('error
+             ;; Hack: Find next keyword when parentheses are not balanced.  Here
+             ;; we assume that next keyword will not be too far from current
+             ;; position, so will not cause emacs slow down too much.
+             (unless (search-forward-regexp scala-keywords-re nil t)
+               (end-of-line))))
+          (setq p1 (point))))
       (when scala-mode-fontlock:multiline-highlight
         (put-text-property p0 p1 'font-lock-multiline t)))
     p1))

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -174,7 +174,7 @@
   ;; indent params of constructors, function declarations, function
   ;; calls and multi-line for structures. Assumes we are just after
   ;; opening parentheses / brace
-  (let ((list-indent-pos (scala-point-after (skip-chars-forward "\\s "))))
+  (let ((list-indent-pos (scala-point-after (skip-syntax-forward " "))))
     (if (or (eq (char-before) ?\()
             (and (eq (char-before) ?\{)
                  (progn (backward-char)

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -196,6 +196,9 @@
       (let ((parse-sexp-ignore-comments t))
         (goto-char (1+ (scan-sexps (1+ (point)) -1))))
       (- (scala-block-indentation) scala-mode-indent:step))
+     ;; don't do any of the other stuff if the previous line was
+     ;; just a closing brackets
+     ((scala-after-brackets-line-p) nil)
      ;; indent lines that start with . as in 
      ;; foo
      ;;   .bar 
@@ -207,7 +210,7 @@
       (if (= (char-syntax (char-after)) ?\.)
           (scala-indentation-from-following)
         (+ (current-indentation) scala-mode-indent:step)))
-     ;; align 'else', 'yield', 'do', 'extends', 'with', '=>' with start of expression
+     ;; align 'else', 'yield', 'extends', 'with', '=>' with start of expression
      ((looking-at scala-expr-middle-re)
       (let* ((matching-kw (cdr (assoc (match-string-no-properties 0)
                                       scala-expr-starter)))

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -58,6 +58,11 @@
   :type 'boolean
   :group 'scala)
 
+(defcustom scala-mode-indent:dot-indent t
+  "Non-nil means indent trailing lines with . prefix."
+  :type 'boolean
+  :group 'scala)
+
 (defun scala-parse-partial-sexp ()
   (parse-partial-sexp (point-min) (point)))
 
@@ -194,7 +199,8 @@
      ;; indent lines that start with . as in 
      ;; foo
      ;;   .bar 
-     ((eq (char-after) ?\.)
+     ((and scala-mode-indent:dot-indent
+           (eq (char-after) ?\.))
       (scala-backward-ident)
       (beginning-of-line)
       (scala-forward-ignorable (line-end-position))

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -137,16 +137,22 @@
       (1+ (current-column))
     (current-column)))
 
+(defun scala-case-p ()
+  (let ((case-p (looking-at scala-case-re)))
+    (scala-forward-ignorable)
+    (and case-p
+         (not (looking-at scala-class-re)))))
+
 (defun scala-case-block-p ()
   (save-excursion
     (forward-comment (buffer-size))
-    (looking-at scala-case-re)))
+    (scala-case-p)))
 
 (defun scala-case-line-p ()
   (save-excursion
     (beginning-of-line)
     (scala-forward-ignorable)
-    (looking-at scala-case-re)))
+    (scala-case-p)))
 
 (defun scala-lambda-p () 
   (save-excursion

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -196,11 +196,14 @@
 	     (scala-block-indentation)
 	   (progn
 	     (when (eq (char-before) ?\))
-	       (backward-sexp)
+               (backward-sexp)
 	       (scala-backward-spaces))
-	     (scala-looking-at-backward scala-expr-start-re)))
-	 (+ (current-indentation) scala-mode-indent:step))))
-
+	     (cond ((scala-looking-at-backward scala-value-expr-start-re)
+                    (progn
+                      (backward-sexp)
+                      (+ (current-column) scala-mode-indent:step)))
+                   ((looking-back scala-declr-expr-start-re)
+                    (+ (current-indentation) scala-mode-indent:step))))))))
 
 (defun scala-indentation-from-block ()
   ;; Return suggested indentation based on the current block.

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -198,12 +198,15 @@
 	     (when (eq (char-before) ?\))
                (backward-sexp)
 	       (scala-backward-spaces))
-	     (cond ((scala-looking-at-backward scala-value-expr-start-re)
+             ;; note: order here is important, check "else if" before "if"
+	     (cond ((or (looking-back scala-declr-expr-start-re)
+                        (looking-back scala-compound-expr-re))
+                    (+ (current-indentation) scala-mode-indent:step))
+                   ((looking-back scala-value-expr-start-re)
                     (progn
                       (backward-sexp)
                       (+ (current-column) scala-mode-indent:step)))
-                   ((looking-back scala-declr-expr-start-re)
-                    (+ (current-indentation) scala-mode-indent:step))))))))
+                   ))))))
 
 (defun scala-indentation-from-block ()
   ;; Return suggested indentation based on the current block.

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -162,6 +162,9 @@
       (let ((parse-sexp-ignore-comments t))
         (goto-char (1+ (scan-sexps (1+ (point)) -1))))
       (- (scala-block-indentation) scala-mode-indent:step))
+     ;; indent lines that start with . as in 
+     ;; foo
+     ;;   .bar 
      ((eq (char-after) ?\.)
       (scala-backward-ident)
       (beginning-of-line)
@@ -169,6 +172,7 @@
       (if (= (char-syntax (char-after)) ?\.)
           (scala-indentation-from-following)
         (+ (current-indentation) scala-mode-indent:step)))
+     ;; align else, yield, do, extends, with, => with start of expression
      ((looking-at scala-expr-middle-re)
       ;; [...] this is a somewhat of a hack.
       (let ((matching-kw (cdr (assoc (match-string-no-properties 0)

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -97,6 +97,15 @@
   (while (and (not (scala-looking-backward-at-empty-line))
               (forward-comment -1))))
 
+(defun scala-after-brackets-line-p ()
+  (save-excursion
+    (scala-backward-ignorable)
+    (let ((limit (point)))
+      (back-to-indentation)
+      (save-restriction
+        (narrow-to-region (point) limit)
+        (looking-at "\\s)+$")))))
+
 (defun scala-looking-at-backward (re)
   (save-excursion
     (when (= 0 (skip-syntax-backward "w_")) (backward-char))

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -79,6 +79,12 @@
     (when (= 0 (skip-syntax-backward "w_")) (backward-char))
     (looking-at re)))
 
+
+(defun scala-find-in-limit (re limit)
+  ;; returns the point where re was found in limit or nil
+  (save-excursion
+    (search-forward-regexp re limit t)))
+
 (defmacro scala-point-after (&rest body)
   `(save-excursion
      ,@body

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -79,7 +79,6 @@
     (when (= 0 (skip-syntax-backward "w_")) (backward-char))
     (looking-at re)))
 
-
 (defun scala-find-in-limit (re limit)
   ;; returns the point where re was found in limit or nil
   (save-excursion

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -64,20 +64,63 @@
       `(scala-when-looking-at* ,regexp (lambda () ,@body))
     `(scala-when-looking-at* ,regexp)))
 
-(defun scala-forward-spaces (&optional limit)
+(defun scala-looking-at-empty-line ()
+  ;; return t if from the point forward is just spaces
+  ;; and next line is empty
+  (save-excursion
+   (or (bolp)
+       (skip-syntax-forward " >" (1+ (line-end-position))))
+   (looking-at scala-empty-line-re)))
+
+(defun scala-looking-backward-at-empty-line ()
+  ;; return t if from the point backward is just spaces
+  ;; and previous line is empty
+  (save-excursion
+    (skip-syntax-backward " ")
+    (and (bolp)
+         (forward-line -1)
+         (looking-at scala-empty-line-re))))
+
+(defun scala-forward-ignorable (&optional limit)
+  (interactive)
+  ;; forward over spaces and comments, but not over empty lines
   (if limit
       (save-restriction
         (narrow-to-region (point) limit)
-        (forward-comment 100000))
-    (forward-comment 100000)))
+        (scala-forward-ignorable))
+    (while (and (not (scala-looking-at-empty-line))
+                (forward-comment 1)))))
 
-(defun scala-backward-spaces ()
-  (forward-comment -100000))
+(defun scala-backward-ignorable ()
+  (interactive)
+  ;; backward over spaces and comments, but not over empty lines
+  (while (and (not (scala-looking-backward-at-empty-line))
+              (forward-comment -1))))
 
 (defun scala-looking-at-backward (re)
   (save-excursion
     (when (= 0 (skip-syntax-backward "w_")) (backward-char))
     (looking-at re)))
+
+(defun scala-search-backward-sexp (re)
+  ;; searches backward for a sexp that begins with the regular
+  ;; expression. Skips over sexps. Does not continue over
+  ;; end of expression (empty line or ';')
+  ;; returns new point or nil if not found
+  (let ((found-pos (catch 'found
+                     (save-excursion
+                       (while (not (bobp))
+                         (scala-backward-ignorable)
+                         (if (or (scala-looking-backward-at-empty-line)
+                                 (eq (char-before) ?\;)
+                                 (eq (char-syntax (char-before)) ?\())
+                             (throw 'found nil))
+                         (backward-sexp)
+                         (if (looking-at re)
+                             (throw 'found (point))))))))
+    (if found-pos
+        (goto-char found-pos))
+    found-pos))
 
 (defun scala-find-in-limit (re limit)
   ;; returns the point where re was found in limit or nil
@@ -89,7 +132,6 @@
      ,@body
      (point)))
 
-
 (defmacro scala-move-if (&rest body)
   (let ((pt-sym (make-symbol "point"))
 	(res-sym (make-symbol "result")))
@@ -100,7 +142,7 @@
 
 (defun scala-forward-ident ()
   ;; Move forward over an identifier.
-  (scala-forward-spaces)
+  (scala-forward-ignorable)
   (if (looking-at scala-ident-re)
       (goto-char (match-end 0))
     (forward-char))
@@ -108,7 +150,7 @@
 
 (defun scala-backward-ident ()
   ;; Move backward over an identifier.
-  (scala-backward-spaces)
+  (scala-backward-ignorable)
   (if (scala-looking-at-backward scala-ident-re)
       (goto-char (match-beginning 0))
     (backward-char))
@@ -116,7 +158,7 @@
 
 (defun scala-forward-qual-ident ()
   ;; Move forward over a qualifier identifier.
-  (scala-forward-spaces)
+  (scala-forward-ignorable)
   (if (looking-at scala-qual-ident-re)
       (goto-char (match-end 0))
     (forward-char))
@@ -124,7 +166,7 @@
 
 (defun scala-backward-qual-ident ()
   ;; Move backward over a qualifier identifier.
-  (scala-backward-spaces)
+  (scala-backward-ignorable)
   (if (scala-looking-at-backward scala-qual-ident-re)
       (goto-char (match-beginning 0))
     (backward-char))
@@ -142,7 +184,7 @@
         (t
          ;; Type designator
          (scala-forward-qual-ident)
-         (scala-forward-spaces)
+         (scala-forward-ignorable)
          (cond ((eobp) nil)
                ((= (char-after) ?\[)
                 ;; Type arguments
@@ -157,9 +199,9 @@
   ;; Move forward over a type1 (as defined by the grammar).
   ;; Works only when point is at the beginning of a type (modulo
   ;; initial spaces/comments).
-  (scala-forward-spaces)
+  (scala-forward-ignorable)
   (scala-when-looking-at "\\<class\\>"
-                         (forward-word 1) (scala-forward-spaces))
+                         (forward-word 1) (scala-forward-ignorable))
   (scala-forward-simple-type)
   (while (scala-when-looking-at "\\s *\\<with\\>\\s *")
     (if (and (not (eobp)) (= (char-after) ?\{))
@@ -193,6 +235,6 @@
 
 (defun scala-forward-literal ()
   ;; Move forward over an integer, float, character or string literal.
-  (scala-forward-spaces)
+  (scala-forward-ignorable)
   (scala-when-looking-at scala-literal-re)
   t)

--- a/tool-support/src/emacs/scala-mode.el
+++ b/tool-support/src/emacs/scala-mode.el
@@ -182,8 +182,8 @@ When started, run `scala-mode-hook'.
                                        nil
                                        (font-lock-syntactic-keywords . scala-font-lock-syntactic-keywords)
                                        (parse-sexp-lookup-properties . t))
-	paragraph-separate            (concat "^\\s *$\\|" page-delimiter)
-	paragraph-start               (concat "^\\s *$\\|" page-delimiter)
+	paragraph-separate            (concat scala-empty-line-re "\\|" page-delimiter)
+	paragraph-start               (concat scala-empty-line-re "\\|" page-delimiter)
 	paragraph-ignore-fill-prefix  t
 	require-final-newline         t
 	comment-start                 "// "


### PR DESCRIPTION
A lot of fixes to indentation, and some to font-lock. See commit messages for details on each commit.
