### PR TITLE
Enable vim indenting on "o" and "O" commands.

### DIFF
--- a/tool-support/src/vim/indent/scala.vim
+++ b/tool-support/src/vim/indent/scala.vim
@@ -10,7 +10,7 @@ let b:did_indent = 1
 
 setlocal indentexpr=GetScalaIndent()
 
-setlocal indentkeys=0{,0},0),!^F,<>>,<CR>
+setlocal indentkeys=0{,0},0),!^F,<>>,o,O
 
 setlocal autoindent shiftwidth=2 tabstop=2 softtabstop=2 expandtab
 


### PR DESCRIPTION
The `o` and `O` commands now indent lines correctly in Normal mode. The "o" option also enables indents on `<CR>` in Insert mode, making the "<CR>" option unnecessary.
