### PR TITLE
Emacs: fix for regresison on block indent

### DIFF
--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -7,10 +7,53 @@ object Foo extends Bar with Zot
 object Foo extends Bar(  1,
                          2)( 3,
                              4)
-           with Zot(3) { foo =>
+           with Zot(3) { foo:Bar =>
              foo // KNOWN ISSUE, should not be indented this far
   bar
 }
+
+class Foo[E](path: String,
+             valueClass: Class) {
+  asd
+}
+
+{
+  class SparkInput[T,B,E]
+  (path: String,
+   inputFormatClass: Class, 
+   valueClass: Class[V]) /* */ (x: String,
+                                y: String) /* */
+  (z: String) {
+    
+    def // indentation was broken, works in 7bec133395
+  }
+}
+
+{
+  private class SparkInput[T[T,C]] (path: String,
+                                    inputFormatClass: Class, 
+                                    valueClass: Class[V]) /* */ (x: String,
+                                                                 y: String) /* */
+  (z: String)
+          extends Zot[E](x,y)(z) {
+    
+    def // indentation was broken, works in 7bec133395
+  }
+}
+
+{
+  private class SparkInput (path: String,
+                            inputFormatClass: Class, 
+                            valueClass: Class[V]) /* */ (x: String,
+                                                         y: String) /* */
+  (z: String)
+          extends Zot(x,y)(z) 
+          with Bar(valueClass) {
+    
+    def // indentation was broken, works in 7bec133395
+  }
+}
+
 
 object Foo extends Bar;
 with Zot // should not be aligned with 'extends' since there is ';' above
@@ -23,12 +66,17 @@ private class Foo
         extends Bar
         with Zot 
 
-private class Foo { self =>
-  line
+{
+  private class Foo
+          extends Bar { self /* */ : /* */ Zot /* */ [A, /* */ B[C, D]] /* */ =>
+            line1
+    line2
+  }
 }
 
-private class Foo { 
-  self =>
+private class Foo {
+  
+  self: Zot =>
     line // KNOWN ISSUE, should not be indented
 
   case class Cell() 
@@ -96,14 +144,18 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
   val x = new Foo( /* */ 1,
                    2,
                    3)
-          with Bar
+          with Bar(2)(3,
+                      4
+                      5) {
+    asd
+  }
   
-  val foo = zot map (x =>
+  val foo = zot map (x: String =>
     x.toString)
   
-  val foo = zot map (x =>
+  val foo = zot map (x: Option[String] =>
     x.toString
-  ) // FIXED
+  )
   
   def zz = for (i <- 1 to 10)
            yield i
@@ -118,7 +170,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
   
   def z = x match {
       
-    case 1 =>
+    case l: String =>
       foo
       bar 
     /* foo bar*/
@@ -126,6 +178,13 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       bar
       goo
     }
+  }
+
+  val b = doSome(x,
+                 y) {
+    case x =>
+      foo
+      bar
   }
   
   do {
@@ -148,7 +207,6 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       twoline 
   }
   
-  // Scamacs works here
   def z = try {
     foo
   } catch {
@@ -206,3 +264,4 @@ private/* */class/* */Foo/* */[+T]/* */(i: X,
                   3)
           with Bar // KNOWN ISSUE: bar is in wrong font-face (should be same as Foo)  
 }
+

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -7,9 +7,19 @@ object Foo extends Bar with Zot
 object Foo extends Bar(  1,
                          2)( 3,
                              4)
-           with Zot(3) { foo:Bar =>
-  foo 
-  bar
+           with Zot(3) { foo:Bar => 
+  
+  def foo(x: String,
+          y: String) = /*
+          */
+    x + y
+  
+  foo(x,
+      y) { asd => { 
+    and some
+    more 
+  })
+  
 }
 
 class Foo[E](path: String,
@@ -17,43 +27,35 @@ class Foo[E](path: String,
   asd
 }
 
-{
-  class SparkInput[T,B,E]
-  (path: String,
-   inputFormatClass: Class, 
-   valueClass: Class[V]) /* */ (x: String,
-                                y: String) /* */
-  (z: String) {
-    
-    def // indentation was broken, works in 7bec133395
-  }
+def f(a: Foo => Bar, 
+      b: Zot)
+     (c: Kala, d: Kisa): (Foo => (Bar, Zot)
+                          Option[x] forSome { 
+                            type x <: Kissa
+                          }) = {
+  magic!
 }
+
+def f(g: => (String, Int),
+      x: String) =
+  g(x)
 
 {
   private class SparkInput[T[T,C]] (path: String,
                                     inputFormatClass: Class, 
                                     valueClass: Class[V]) /* */ (x: String,
                                                                  y: String) /* */
-  (z: String)
+                                                                (z: String)
           extends Zot[E](x,y)(z) {
     
-    def // indentation was broken, works in 7bec133395
+    def x[Foo
+          with Bar
+          forSome {
+            val Z: X
+          }]: Bar 
+    with Zot // KNOWN ISSUE: still broken
   }
 }
-
-{
-  private class SparkInput (path: String,
-                            inputFormatClass: Class, 
-                            valueClass: Class[V]) /* */ (x: String,
-                                                         y: String) /* */
-  (z: String)
-          extends Zot(x,y)(z) 
-          with Bar(valueClass) {
-    
-    def // indentation was broken, works in 7bec133395
-  }
-}
-
 
 object Foo extends Bar;
 with Zot // should not be aligned with 'extends' since there is ';' above
@@ -65,7 +67,6 @@ with Zot // should not be aligned with 'extends' since there is empty line above
 private class Foo 
         extends Bar
         with Zot 
-
 {
   private class Foo
           extends Bar { self /* */ : /* */ Zot /* */ [A, /* */ B[C, D]] /* */ =>
@@ -98,10 +99,12 @@ private class Foo(x: Int,
                   z: Int) // KNOWN ISSUE in font-lock mode
 
 private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
-                                       with Zot { self: Option[String,
-                                                               And,
-                                                               Some] =>
-  line1
+                                       with Zot { self: /* */ Option[String,
+                                                                     And,
+                                                                     Some[x] forSome {
+                                                                       type x <% String
+                                                                     }] =>
+  line1;
   
   case class Cell() 
   
@@ -114,7 +117,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
 {
   def foo(x: Int,
           y: Int)
-  (z: Int) // KNOWN ISSUE: curry is not aligned nicely
+         (z: Int) // KNOWN ISSUE: curry is not aligned nicely
   
   def x = 1
   def y = true
@@ -152,12 +155,20 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
     asd
   }
   
-  val foo = zot map (x: String =>
-    x.toString)
+  val foo = zot map (x: String => {
+    x.toString 
+  })
+
+  val foo = zot map (x: String => { some;
+                                    more; }) // KNOWN ISSUE: above is not detected as lambda since => does not end the line
   
   val foo = zot map (x: Option[String] =>
     x.toString
   )
+
+  foo map (a: String => println(a);
+           a.length) // KNOWN ISSUE: above is not detected as lambda since => does not end the line
+
   
   def zz = for (i <- 1 to 10)
            yield i
@@ -174,16 +185,17 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       
     case l: String =>
       foo
-      bar 
+      bar
     /* foo bar*/
     case a => {
       bar
       goo
     }
   }
-
+  
   val b = doSome(x,
-                 y) {
+                 y)
+                (foo, zot) {
     case x =>
       foo
       bar
@@ -262,12 +274,12 @@ private/* */class/* */Foo/* */[+T]/* */(i: X,
   def x = 1
   
   def/* */x/* */=/* */1 // KNOWN ISSUE: x is with wrong face
-  
+    
   def foo(x: String, //
           y: Int/* */, // KNOWN ISSUE: Int should be highlighted
           z: Boolean)
-  (x: Int) // KNOWN ISSUE(S): '(' is highted, curry is not highlighted when typed
-  
+         (x: Int) // KNOWN ISSUE(S): '(' is highted, curry is not highlighted when typed
+    
   def foo(@annotation // KNOWN ISSUE: annotations are in parameter name font face
           x: String)
   

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -8,7 +8,7 @@ object Foo extends Bar(  1,
                          2)( 3,
                              4)
            with Zot(3) { foo:Bar =>
-             foo // KNOWN ISSUE, should not be indented this far
+  foo 
   bar
 }
 
@@ -69,15 +69,14 @@ private class Foo
 {
   private class Foo
           extends Bar { self /* */ : /* */ Zot /* */ [A, /* */ B[C, D]] /* */ =>
-            line1
+    line1
     line2
   }
 }
 
 private class Foo {
-  
   self: Zot =>
-    line // KNOWN ISSUE, should not be indented
+  line
 
   case class Cell() 
   
@@ -99,7 +98,10 @@ private class Foo(x: Int,
                   z: Int) // KNOWN ISSUE in font-lock mode
 
 private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
-                                       with Zot {
+                                       with Zot { self: Option[String,
+                                                               And,
+                                                               Some] =>
+  line1
   
   case class Cell() 
   
@@ -239,7 +241,17 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       .bar
       .bar
       .dothat
+    g
   }
+
+  {
+    foo(x,
+        y) { z =>
+      println(z)
+      z + 1
+    }
+  }
+
 }
 
 /* font lock */

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -77,11 +77,11 @@ private class Foo
 private class Foo {
   self: Zot =>
   line
-
+  
   case class Cell() 
   
   def f(): = {}
-
+  
 }
 
 private class Foo { 
@@ -216,7 +216,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       oneline
       twoline 
   }
-
+  
   val zz = xx map {
     case (i, j) => 
       doSomething
@@ -243,7 +243,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       .dothat
     g
   }
-
+  
   {
     foo(x,
         y) { z =>
@@ -251,7 +251,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
       z + 1
     }
   }
-
+  
 }
 
 /* font lock */

--- a/tool-support/src/emacs/Test.scala
+++ b/tool-support/src/emacs/Test.scala
@@ -1,3 +1,25 @@
+def collect[L,R](futures: Seq[MappableFuture[Either[L,R]]]) =
+(futures.view map (_.apply())).foldLeft((List.empty[L], List.empty[R])) {
+  case ((ls, rs), Left(l)) => (l :: ls, rs);
+  case ((ls, rs), Right(r)) => (ls, r :: rs)
+}
+
+{
+  def ping() = {
+    execute(RestClient.asyncHttpClient.prepareGet(pingUrl)) map {
+      case None => (2, pingUrl, "Could not connect to service")
+      case Some(response) =>
+        if (response.getResponseBody() == "OK") {
+          (0, pingUrl, "OK")
+        } else {
+          (1, pingUrl, "Response was not 'OK', was " +
+           response.getResponseBody().take(60))
+        }
+    }
+  }
+}
+
+
 package foo
 
 import bar
@@ -13,12 +35,45 @@ object Foo extends Bar(  1,
           y: String) = /*
           */
     x + y
-  
+
+  def ping() =
+    execute(RestClient.asyncHttpClient.prepareGet(pingUrl)) map {
+      case None(foo) =>
+        if (foo) {
+          bar
+        } else {
+          fobar
+        }
+    }
+ 
   foo(x,
-      y) { asd => { 
-    and some
-    more 
-  })
+      y) ( asd => (  _ map { d => 
+        and some;
+        more 
+      }))
+  
+  val x = "foo"; val f = 
+    "zot"
+
+
+  val z = x match {
+    case f: Seq[Int) => 
+      f map ( i =>
+        i + 1
+      )
+  }
+
+  def foozot = 
+    x match { 
+      case x: String  =>
+        foo
+        zot
+    }
+  
+  def f: String = 
+  {
+    1
+  }
   
 }
 
@@ -31,8 +86,8 @@ def f(a: Foo => Bar,
       b: Zot)
      (c: Kala, d: Kisa): (Foo => (Bar, Zot)
                           Option[x] forSome { 
-                            type x <: Kissa
-                          }) = {
+       type x <: Kissa 
+     }) = {
   magic!
 }
 
@@ -51,8 +106,8 @@ def f(g: => (String, Int),
     def x[Foo
           with Bar
           forSome {
-            val Z: X
-          }]: Bar 
+      val Z: X
+    }]: Bar 
     with Zot // KNOWN ISSUE: still broken
   }
 }
@@ -102,8 +157,8 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
                                        with Zot { self: /* */ Option[String,
                                                                      And,
                                                                      Some[x] forSome {
-                                                                       type x <% String
-                                                                     }] =>
+                                         type x <% String
+                                       }] =>
   line1;
   
   case class Cell() 
@@ -165,7 +220,7 @@ private[Foo] class Foo(x: Int, y: Int) extends Bar(x, y)
   val foo = zot map (x: Option[String] =>
     x.toString
   )
-
+  
   foo map (a: String => println(a);
            a.length) // KNOWN ISSUE: above is not detected as lambda since => does not end the line
 

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -204,6 +204,9 @@ reserved keywords when used alone.")
 (defconst scala-declr-expr-start-re 
   "[^=]=")
 
+(defconst scala-double-arrow-re 
+  "=>\\($\\|[ _({[:alpha:]]\\)")
+
 (defconst scala-class-middle-re 
   (regexp-opt '("extends" "with") 'words))
 

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -196,7 +196,7 @@ reserved keywords when used alone.")
   (regexp-opt '("case") 'words))
 
 (defconst scala-class-re
-  (regexp-opt '("case") 'words))
+  (regexp-opt '("class") 'words))
 
 (defconst scala-value-expr-cont-re
   (regexp-opt '("else" "yield") 'words))

--- a/tool-support/src/emacs/scala-mode-constants.el
+++ b/tool-support/src/emacs/scala-mode-constants.el
@@ -202,7 +202,7 @@ reserved keywords when used alone.")
   (regexp-opt '("else" "yield") 'words))
 
 (defconst scala-declr-expr-start-re 
-  "[^=]=>?")
+  "[^=]=")
 
 (defconst scala-class-middle-re 
   (regexp-opt '("extends" "with") 'words))

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -243,10 +243,11 @@
     (let ((am-case (scala-case-line-p)))
       (scala-backward-ignorable)
       (when (not (bobp))
-	(cond ;; '=', '=>', 'yield', 'else'
+	(cond
 	 ((eq (char-syntax (char-before)) ?\()
 	  (scala-block-indentation am-case))
-	 ((or (looking-back scala-declr-expr-start-re (- (point) 3))
+         ;; '=', 'yield', 'else'
+	 ((or (looking-back scala-declr-expr-start-re (- (point) 2))
 	      (scala-looking-at-backward scala-value-expr-cont-re))
 	  (+ (current-indentation) scala-mode-indent:step))
 	 ;; 'if', 'else if'
@@ -267,9 +268,8 @@
            (block-start (nth 1 state)))
       (if (not block-start)
           0
-	(progn
-	  (goto-char (1+ block-start))
-	  (scala-block-indentation am-case))))))
+        (goto-char (1+ block-start))
+        (scala-block-indentation am-case)))))
 
 (defun scala-indent-line-to (column)
   "Indent current line to COLUMN and perhaps move point.

--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -244,8 +244,6 @@
       (scala-backward-ignorable)
       (when (not (bobp))
 	(cond
-	 ((eq (char-syntax (char-before)) ?\()
-	  (scala-block-indentation am-case))
          ;; '=', 'yield', 'else'
 	 ((or (looking-back scala-declr-expr-start-re (- (point) 2))
 	      (scala-looking-at-backward scala-value-expr-cont-re))

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -115,15 +115,6 @@
           (or (> (line-number-at-pos) line)
               (eolp))))))
 
-(defun scala-at-start-of-expression ()
-  ;; return true if we are very sure that we are at the start of expression
-  (save-excursion
-    (scala-backward-ignorable)
-    (or (scala-looking-backward-at-empty-line)
-        (= (char-syntax (char-before)) ?\()        
-        (and (= (char-before) ?\;)
-             (scala-at-line-end)))))
-
 (defun scala-looking-at-backward (re)
   (save-excursion
     (when (= 0 (skip-syntax-backward "w_")) (backward-char))

--- a/tool-support/src/emacs/scala-mode-navigation.el
+++ b/tool-support/src/emacs/scala-mode-navigation.el
@@ -82,7 +82,6 @@
          (looking-at scala-empty-line-re))))
 
 (defun scala-forward-ignorable (&optional limit)
-  (interactive)
   ;; forward over spaces and comments, but not over empty lines
   (if limit
       (save-restriction
@@ -105,6 +104,25 @@
       (save-restriction
         (narrow-to-region (point) limit)
         (looking-at "\\s)+$")))))
+
+(defun scala-at-line-end ()
+  ;; we are at end of line if after the point is
+  ;; only ignorable (comment or whitespace)
+  (save-excursion
+    (or (eolp)
+        (let ((line (line-number-at-pos)))
+          (scala-forward-ignorable)
+          (or (> (line-number-at-pos) line)
+              (eolp))))))
+
+(defun scala-at-start-of-expression ()
+  ;; return true if we are very sure that we are at the start of expression
+  (save-excursion
+    (scala-backward-ignorable)
+    (or (scala-looking-backward-at-empty-line)
+        (= (char-syntax (char-before)) ?\()        
+        (and (= (char-before) ?\;)
+             (scala-at-line-end)))))
 
 (defun scala-looking-at-backward (re)
   (save-excursion


### PR DESCRIPTION
Fixed indenting of blocks of format

```
private class Foo(x: String,
                  y: String) {
  val z = "bar" // fixed
}
```
