### PR TITLE
Adjusts in cover and more translation work

### DIFF
--- a/documentation/README.md
+++ b/documentation/README.md
@@ -18,7 +18,7 @@ For users using Ubuntu 12.04 or anyone getting error: "Font ul9r8r not found":
 * sudo dpkg -i texlive-local_2011-1~1_all.deb
 * sudo mkdir -p /usr/share/texmf
 * sudo apt-get install auctex
-* sudo vi /var/lib/textmf/web2c/updmap.cfg and add the line `Map ul9.map`
+* sudo vi /var/lib/texmf/web2c/updmap.cfg and add the line `Map ul9.map`
 * sudo mktexlsr
 * sudo update-updmap
 * sudo updmap-sys

--- a/documentation/build.xml
+++ b/documentation/build.xml
@@ -201,9 +201,9 @@ BUILD
     <sequential>
       <!-- we use 'exec' until a 'latexmk' task is available :-) --> 
       <exec dir="${build.dir}@{locale}" executable="latexmk" output="${build.dir}@{locale}/@{name}.log.ant">
-        <env key="TEXINPUTS" value="${lib.dir}:@{srcdir}:"/>
+        <env key="TEXINPUTS" value="${lib.dir}:@{srcdir}@{locale}:"/>
         <env key="BIBINPUTS" value="@{srcdir}:"/>
-        <arg line="-g -pdf @{srcdir}/@{name}"/>
+        <arg line="-g -pdf @{srcdir}@{locale}/@{name}"/>
       </exec>
       <exec dir="${build.dir}@{locale}" executable="pdf2ps"> <!-- pdftops -->
         <arg line="@{name}.pdf @{name}.ps"/>
@@ -228,7 +228,7 @@ BUILD
   </target>
 
   <target name="build.byexample.pt-BR" depends="build.init" unless="uptodate.byexample.pt-BR">
-    <latex name="ScalaByExample" srcdir="${src.reference.dir}/pt-BR" locale="/pt-BR" />
+    <latex name="ScalaByExample" srcdir="${src.reference.dir}" locale="/pt-BR" />
   </target>
 
 

--- a/documentation/lib/scaladoc.sty
+++ b/documentation/lib/scaladoc.sty
@@ -227,6 +227,7 @@
 \newcommand{\doctitle}{Title}
 \newcommand{\docsubtitle}{DRAFT}
 \newcommand{\docdate}{\today}
+\newcommand{\translatedby}{}
 \newcommand{\makedoctitle}{%
   \begin{titlepage}%
   \begin{center}%
@@ -244,6 +245,9 @@
     \small\sc EPFL}\\[-.2ex]%
   \multicolumn{2}{>{\columncolor[gray]{.82}[\tabcolsep]}r}{%
     \small\sc Switzerland}\\[-.6ex]%
+  \rowcolor[gray]{.82} \  & \  \\ %
+  \multicolumn{2}{>{\columncolor[gray]{.82}[\tabcolsep]}c}{%
+    \small\sc \translatedby}\\[-.6ex]%    
   \rowcolor[gray]{.82} \  & \  %
   \end{tabular}%
   \end{center}%

--- a/documentation/src/reference/ExamplesPart.tex
+++ b/documentation/src/reference/ExamplesPart.tex
@@ -5118,7 +5118,7 @@ In fact, \code{filter} returns instances of a subclass of iterators
 which are ``buffered''.  A \code{BufferedIterator} object is an
 iterator which has in addition a method \code{head}. This method
 returns the element which would otherwise have been returned by
-\code{head}, but does not advance beyond that element. Hence, the
+\code{next}, but does not advance beyond that element. Hence, the
 element returned by \code{head} is returned again by the next call to
 \code{head} or \code{next}. Here is the definition of the
 \code{BufferedIterator} trait.

--- a/documentation/src/reference/ProgrammingInScala.tex
+++ b/documentation/src/reference/ProgrammingInScala.tex
@@ -21,7 +21,8 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Programming in Scala\\[33mm]\ }
+\renewcommand{\doctitle}{Programming in Scala\\  \\
+\Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
 \begin{document}

--- a/documentation/src/reference/ScalaByExample.tex
+++ b/documentation/src/reference/ScalaByExample.tex
@@ -21,11 +21,11 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala By Example\\[33mm]\ }
+\renewcommand{\doctitle}{Scala By Example\\ \\
+\Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
 \begin{document}
-
 \frontmatter
 \makedoctitle
 \clearemptydoublepage

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6363,8 +6363,7 @@ das sucessivas chamadas de \code{f}.
   }
 \end{lstlisting}
 Também relacionado à \code{map}, temos o método \code{foreach} que aplica uma
-applies a given function to all elements of an iterator, but does not
-construct a list of results
+dada função a todos elementos de um iterador, mas não constrói uma lista de resultados
 \begin{lstlisting}
   def foreach(f: A => Unit): Unit =
     while (hasNext) { f(next) }

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7708,17 +7708,17 @@ O método \code{synchronized} computa \code{e} em modo mutuamente exclusivo --
 em um dado momento qualquer, somente uma thread pode executar um argumento
 \code{synchronized} em um dado monitor.
 
-Threads can suspend inside a monitor by waiting on a signal.  Threads
-that call the \code{wait} method wait until a \code{notify} method of
-the same object is called subsequently by some other thread. Calls to
-\code{notify} with no threads waiting for the signal are ignored.
+Threads podem ser paradas dentro de um monitor e esperar por um sinal.  
+Threads podem chamar o método \code{wait} e esperar até que o método \code{notify} do mesmo
+objeto seja chamado por alguma outra thread. Chamadas ao método
+\code{notify} quando não existam threads esperando por um sinal são ignoradas.
 
-There is also a timed form of \code{wait}, which blocks only as long
-as no signal was received or the specified amount of time (given in
-milliseconds) has elapsed. Furthermore, there is a \code{notifyAll}
-method which unblocks all threads which wait for the signal.  These
-methods, as well as class \code{Monitor} are primitive in Scala; they
-are implemented in terms of the underlying runtime system.
+Existe também uma forma do método \code{wait} basead em tempo em que a
+execução é bloqueada enquanto nenhum sinal seja recebido ou um dado espaço de tempo (dado em
+milisegundos) tenha passado. Além disso, há o método \code{notifyAll} que desbloqueia todas
+as threads que estejam esperando por um sinal. Estes métodos, assim como a classe \code{Monitor} 
+são primitivos em Scala, ou seja, eles são implementados usando os mecanismos internos do sistema de execução
+dos programas.
 
 Typically, a thread waits for some condition to be established. If the
 condition does not hold at the time of the wait call, the thread

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4446,65 +4446,54 @@ def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
 }
 \end{lstlisting}
 
-%-------------xpto 
-
-further calls. Adding everything up we obtain that at each of the
-$O(log(N))$ call levels, every element of the original lists takes
-part in one split operation and in one merge operation. Hence, every
-call level has a total cost proportional to $O(N)$. Since there are
-$O(log(N))$ call levels, we obtain an overall cost of
-$O(N;log(N))$. That cost does not depend on the initial distribution
-of elements in the list, so the worst case cost is the same as the
-average case cost. This makes merge sort an attractive algorithm for
-sorting lists.
-
 A complexidade do \code{msort} é $O(N;log(N))$, onde $N$ é o tamanho da lista de entrada.
 Para ver porque, observe que dividir uma lista em duas e intercalar as duas listas 
 ordenadas leva tempo proporcional ao tamanho das listas argumentos. Cada chamada recursiva 
 de \code{msort} reduz a metade o número de elementos na sua entrada, logo há $O(log(N))$
 chamadas recursivas consecutivas, até que o caso base das listas de tamanho 1 seja 
 alcançado. Entretanto, para listas mais longas, cada chamada gera duas outras chamadas. 
-Somando tudo obtemos 
+Somando tudo acima obtemos que a cada nível $O(log(N))$ de chamada, cada elemento da lista 
+original toma parte em uma operação de divisão e em uma operação merge. Consequentemente, cada 
+nível de chamada tem um custo proporcional total de $O(N)$. Como há $O(log(N))$ níveis de
+chamada, obtemos um custo total de $O(N;log(N))$. Este custo não depende da distribuição 
+inicial dos elementos na lista, portanto o pior caso tem o mesmo custo que o caso médio.
+Isto torna o merge sort um algoritmo atraente para ordenação de listas. 
 
-
-Here is an example how \code{msort} is used.
+Aqui está um exemplo de como \code{msort} é usado.
 \begin{lstlisting}
 msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
 \end{lstlisting}
-The definition of \code{msort} is curried, to make it easy to specialize it with particular
-comparison functions. For instance,
+A definição de \code{msort} está currificada para tornar sua especialização com funções de  
+comparação. Por exemplo,
 \begin{lstlisting}
-
 val intSort = msort((x: Int, y: Int) => x < y)
 val reverseSort = msort((x: Int, y: Int) => x > y)
 \end{lstlisting}
 
-\section{Definition of class List II: Higher-Order Methods}
+\section{Definição da classe List II: Métodos de Alta Ordem}
+Os exemplos encontrados até aqui mostram que funções sobre listas frequentemente 
+tem estruturas similares. Podemos identificar vários padrões de computação sobre
+listas, tais como:
 
-The examples encountered so far show that functions over lists often
-have similar structures. We can identify several patterns of
-computation over lists, like:
 \begin{itemize}
-      \item transforming every element of a list in some way.
-      \item extracting from a list all elements satisfying a criterion.
-      \item combine the elements of a list using some operator.
+        \item transformar cada elemento de uma lista de algum modo.
+        \item extrair de uma lista todos os elementos que satisfaçam uma critério.
+        \item combinar os elementos de uma lista usando algum operador.
 \end{itemize}
-Functional programming languages enable programmers to write general
-functions which implement patterns like this by means of higher order
-functions. We now discuss a set of commonly used higher-order
-functions, which are implemented as methods in class \code{List}.
-
-\paragraph{Mapping over lists}
-A common operation is to transform each element of a list and then
-return the lists of results.  For instance, to scale each element of a
-list by a given factor.
+Linguagens de programação funcional habilitam programadores a escrever funções genéricas
+que implementam padrões como estes por meio de funções de alta ordem. Agora discutiremos
+um conjunto comumente usado em funções de alta ordem, que são implementados como métodos 
+dentro da classe \code{List}. 
+\paragraph{Mapping sobre listas}
+Um operação comum é transformar cada elemento de uma lista e então retornar a lista de
+resultados. Por exemplo, para multiplicar cada elemento de uma lista por um dado fator.
 \begin{lstlisting}
 def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
   case Nil => xs
   case x :: xs1 => x * factor :: scaleList(xs1, factor)
 }
 \end{lstlisting}
-This pattern can be generalized to the \code{map} method of class \code{List}:
+Este padrão pode ser generalizado para o método \code{map} da classe \code{List}:
 \begin{lstlisting}
 abstract class List[A] { ...
   def map[B](f: A => B): List[B] = this match {
@@ -4512,20 +4501,23 @@ abstract class List[A] { ...
     case x :: xs => f(x) :: xs.map(f)
   }
 \end{lstlisting}
-Using \code{map}, \code{scaleList} can be more concisely written as follows.
+Usando \code{map}, \code{scaleList} pode ser mais concisamente escrito como segue.
 \begin{lstlisting}
 def scaleList(xs: List[Double], factor: Double) =
   xs map (x => x * factor)
 \end{lstlisting}
 
-As another example, consider the problem of returning a given column
-of a matrix which is represented as a list of rows, where each row is
-again a list. This is done by the following function \code{column}.
+Como outro exemplo, considere o problema de retornar uma dada coluna de uma matriz 
+que é representada como uma lista de linhas, onde cada linha é novamente uma lista. 
+Isto é feito através da seguinte função \code{column}. 
 
 \begin{lstlisting}
 def column[A](xs: List[List[A]], index: Int): List[A] =
   xs map (row => row(index))
 \end{lstlisting}
+
+
+%-------------xpto
 
 Closely related to \code{map} is the \code{foreach} method, which
 applies a given function to all elements of a list, but does not

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2330,7 +2330,7 @@ println(r.square)           // prints``9/16''*
 %% becomes a computed value in the next version. Uniform access ensures
 %% that clients do not have to be rewritten because of that change.
 Ou seja, métodos sem parâmetros são acessados como campos valor, tais como 
-\code{number} são. A diferença entre valores e métodos sem parâmetros 
+\code{numer} são. A diferença entre valores e métodos sem parâmetros 
 reside em suas definições. O lado direito de um valor é avaliado quando o 
 objeto é criado, e o valor não muda depois. Um lado direito de um método sem
 parâmetros, por outro lado, é avaliado cada vez que o método é chamado. O 
@@ -2530,22 +2530,31 @@ Ou,
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% Dynamic method dispatch is analogous to higher-order function
 %% calls. In both cases, the identity of code to be executed is known
 %% only at run-time. This similarity is not just superficial. Indeed,
 %% Scala represents every function value as an object (see
 %% Section~\ref{sec:functions}).
+Envio dinâmico de métodos é análogo a chamadas para funções de alta ordem. 
+Em ambos os casos, a identidade do código  a ser executado é conhecida somente
+em tempo de execução. Essa similaridade não é apenas superficial. Na verdade, 
+Scala representa cada valor de função como um objeto (veja Seção~\ref{sec:functions}).
 %----------
 
 %----------
 %% \paragraph{Objects}
-
+\paragraph{Objetos}
 %% In the previous implementation of integer sets, empty sets were
 %% expressed with \code{new EmptySet}; so a new object was created every time
 %% an empty set value was required. We could have avoided unnecessary
 %% object creations by defining a value \code{empty} once and then using
 %% this value instead of every occurrence of \code{new EmptySet}. For example:
+Na implementação prévia de conjuntos de inteiros, conjuntos vazios eram expressos
+com \code{new EmptySet}; então um novo objeto era criado a cada vez que um valor
+conjunto vazio era requerido. Podemos evitar criações desnecessárias de objetos 
+definindo um valor \code{empty} uma vez e então, usando este valor ao invés de cada 
+ocorrência de \code{new EmptySet}. Por exemplo:
  \begin{lstlisting}
  val EmptySetVal = new EmptySet
  \end{lstlisting}
@@ -2556,6 +2565,12 @@ Ou,
 %% if we are only interested in a single object of this class? A more
 %% direct approach is to use an {\em object definition}. Here is
 %% a more streamlined alternative definition of the empty set:
+Um problema com esse tratamento é que uma definição de valor tal como a anterior
+não é uma definição top-level legal em Scala; tem de ser parte de uma outra classe 
+ou objeto. Ainda, a definição de classe \code{EmptySet} agora parece um pouco exagerada -- 
+por que definir uma classe de objetos, se somente estamos interessados em um único objeto 
+dessa classe? Um tratamento mais direto é usar uma {\em definição de objeto}. Aqui está 
+uma alternativa mais adequada para a definição de conjunto vazio:
 \begin{lstlisting}
 object EmptySet extends IntSet {
   def contains(x: Int): Boolean = false
@@ -2573,6 +2588,14 @@ object EmptySet extends IntSet {
 %% it is not possible to create other objects with the same structure
 %% using \code{new}.  Therefore, object definitions also lack constructor
 %% parameters, which might be present in class definitions.
+A sintaxe de uma definição de objeto segue a sintaxe da definição de uma 
+classe; tem uma cláusula opcional extends, bem como um corpo opcional. 
+Assim como em classes, a cláusula extends define membros herdados do objeto 
+considerando que o corpo define novos membros ou sobrecarga. Entretanto, uma 
+definição de objeto denota um único objeto somente se não for possível criar
+outros objetos com a mesma estrutura usando \code{new}. Então, definições de
+objeto também carecem de parâmetros construtores, que podem estar presentes
+nas definições das classes.
 %----------
 
 %----------
@@ -2582,17 +2605,27 @@ object EmptySet extends IntSet {
 %% object definition is created and initialized. The answer is that the
 %% object is created the first time one of its members is accessed. This
 %% strategy is called {\em lazy evaluation}.
+Definições de objetos podem aparecer em qualquer lugar em um programa Scala;
+incluindo o top-level. Como não há ordem fixa de execução de entidades
+top-level em Scala, pode-se questionar quando exatamente o objeto definido 
+pela definição de objeto é criado e inicializado. A resposta é que o objeto 
+é criado assim que seus membros são acessados. Esta estratégia é chamada 
+{\em avaliação preguiçosa}.
 %----------
 
 %----------
 %% \paragraph{Standard Classes}
-
+\paragraph{Classes Padrão}
 %% \todo{include picture}
 
 %% Scala is a pure object-oriented language. This means that every value
 %% in Scala can be regarded as an object.  In fact, even primitive types
 %% such as \code{int} or \code{boolean} are not treated specially. They
 %% are defined as type aliases of Scala classes in module \code{Predef}:
+Scala é uma linguagem orientada a objetos pura. Isso significa que cada valor 
+em Scala pode ser visto como um objeto. De fato, mesmo tipos primitivos tais como 
+\code{int} ou \code{boolean} não são tratados de modo especial. São definidos
+como apelidos de tipos de classes Scala no módulo \code{Predef}.  
 \begin{lstlisting}
 type boolean = scala.Boolean
 type int = scala.Int
@@ -2601,7 +2634,7 @@ type long = scala.Long
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% For efficiency, the compiler usually represents values of type
 %% \code{scala.Int} by 32 bit integers, values of type
 %% \code{scala.Boolean} by Java's booleans, etc.  But it converts these

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1136,7 +1136,7 @@ Entretanto, um ponto e vírgula é inserido implicitamente ao final de cada linh
 a não ser que uma das condições a seguir seja verdadeira.
 %----------
 
-%----------xpto
+%----------
 %% \begin{enumerate}
 %% \item
 %% Either the line in question ends in a word such as a period 
@@ -1147,30 +1147,42 @@ a não ser que uma das condições a seguir seja verdadeira.
 %% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
 %% because these cannot contain multiple statements anyway.
 %% \end{enumerate}
+\begin{enumerate}
+\item 
+Ou a linha em questão termina com uma palavra tal que um ponto ou um 
+operador infixo não são legais ao final da expressão.
+\item 
+Ou a próxima linha inicia com uma palavra que não pode iniciar uma expressão.
+\item
+Ou estamos dentro de parênteses \prog{$($...$)$} ou chaves \prog{}, porque 
+estes não podem conter multiplos comandos de qualquer modo.
+\end{enumerate}
 %----------
 
 %----------
 %% Therefore, the following are all legal:
-%% \begin{lstlisting}
-%% def f(x: Int) = x + 1;
-%% f(1) + f(2)
+Entretanto, os seguintes são legais:
 
-%% def g1(x: Int) = x + 1
-%% g(1) + g(2)
+\begin{lstlisting}
+def f(x: Int) = x + 1;
+f(1) + f(2)
 
-%% def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
+def g1(x: Int) = x + 1
+g(1) + g(2)
 
-%% def h1(x) = 
-%%   x + 
-%%   y
-%% h1(1) * h1(2)
+def g2(x: Int) = {x + 1};  /* `;' mandatório */ g2(1) + g2(2)
 
-%% def h2(x: Int) = (
-%%   x     // parentheses mandatory, otherwise a semicolon
-%%   + y   // would be inserted after the `x'.
-%% )
-%% h2(1) / h2(2)
-%% \end{lstlisting}
+def h1(x) = 
+  x + 
+  y
+h1(1) * h1(2)
+
+def h2(x: Int) = (
+  x     // parênteses mandatório, senão um ponto e vírgula
+  + y   // será inserido após o `x'.
+)
+h2(1) / h2(2)
+\end{lstlisting}
 %----------
 
 %----------
@@ -1180,69 +1192,84 @@ a não ser que uma das condições a seguir seja verdadeira.
 %% \code{sqrt} example. We need not pass \code{x} around as an additional parameter of
 %% the nested functions, since it is always visible in them as a
 %% parameter of the outer function \code{sqrt}. Here is the simplified code:
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = {
-%%   def sqrtIter(guess: Double): Double =
-%%     if (isGoodEnough(guess)) guess
-%%     else sqrtIter(improve(guess))
-%%   def improve(guess: Double) =
-%%     (guess + x / guess) / 2
-%%   def isGoodEnough(guess: Double) =
-%%     abs(square(guess) - x) < 0.001
-%%   sqrtIter(1.0)
-%% }
-%% \end{lstlisting}
+Scala usa as regras usuais de escopo de bloco estruturado. Um nome definido em
+algum outro bloco é também visível em algum bloco interno, desde que não tenha
+sido redefinido lá. Esta regra nos permite simplificar nosso exemplo \code{sqrt}.
+Não precisamos passar \code{x} como parâmetro adicional de funções aninhadas, dado
+que está sempre visível nelas como um parâmetro da função externa \code{sqrt}.
+Aqui está o código simplificado:
+   
+\begin{lstlisting}
+def sqrt(x: Double) = {
+  def sqrtIter(guess: Double): Double =
+    if (isGoodEnough(guess)) guess
+    else sqrtIter(improve(guess))
+  def improve(guess: Double) =
+    (guess + x / guess) / 2
+  def isGoodEnough(guess: Double) =
+    abs(square(guess) - x) < 0.001
+  sqrtIter(1.0)
+}
+\end{lstlisting}
 %----------
 
 
-%% \section{Tail Recursion}
+\section{Tail Recursion}
 
-%% Consider the following function to compute the greatest common divisor
-%% of two given numbers.
+%%Consider the following function to compute the greatest common divisor
+%%of two given numbers.
+Considere a seguinte função para calcular o maior divisor comum entre
+dois números dados.
 
-%% \begin{lstlisting}
-%% def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
-%% \end{lstlisting}
+\begin{lstlisting}
+def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+\end{lstlisting}
 
-%% Using our substitution model of function evaluation, 
-%% \code{gcd(14, 21)} evaluates as follows:
+%%Using our substitution model of function evaluation, 
+Usando nosso modelo de substituição da função de avaliação,
+\code{gcd(14, 21)} evaluates as follows:
 
-%% \begin{lstlisting}
-%% $\,\,$      gcd(14, 21)  
-%% $\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
-%% $\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
-%% $\rightarrow\!$     gcd(21, 14 % 21)
-%% $\rightarrow\!$     gcd(21, 14)
-%% $\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
-%% $\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
-%% $\rightarrow\!$     gcd(14, 7)
-%% $\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
-%% $\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
-%% $\rightarrow\!$     gcd(7, 0)
-%% $\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
-%% $\rightarrow$ $\rightarrow$  7
-%% \end{lstlisting}
+\begin{lstlisting}
+$\,\,$      gcd(14, 21)  
+$\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
+$\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
+$\rightarrow\!$     gcd(21, 14 % 21)
+$\rightarrow\!$     gcd(21, 14)
+$\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
+$\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
+$\rightarrow\!$     gcd(14, 7)
+$\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
+$\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
+$\rightarrow\!$     gcd(7, 0)
+$\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
+$\rightarrow$ $\rightarrow$  7
+\end{lstlisting}
 
-%% Contrast this with the evaluation of another recursive function, 
-%% \code{factorial}:
+%%Contrast this with the evaluation of another recursive function, 
+Contraste isto com a avaliação de uma outra função recursiva,
+\code{factorial}:
 
-%% \begin{lstlisting}
-%% def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
-%% \end{lstlisting}
+\begin{lstlisting}
+def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
+\end{lstlisting}
 
-%% The application \code{factorial(5)} rewrites as follows:
-%% \begin{lstlisting}
-%% $\,\,\,$       factorial(5)
-%% $\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
-%% $\rightarrow$      5 * factorial(5 - 1)
-%% $\rightarrow$      5 * factorial(4)
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
-%% $\rightarrow\ldots\rightarrow$  120
-%% \end{lstlisting}
+%%The application \code{factorial(5)} rewrites as follows:
+A aplicação de \code{factorial(5)} é reescrita como segue: 
+
+\begin{lstlisting}
+$\,\,\,$       factorial(5)
+$\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
+$\rightarrow$      5 * factorial(5 - 1)
+$\rightarrow$      5 * factorial(4)
+$\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
+$\rightarrow\ldots\rightarrow$  120
+\end{lstlisting}
+
+%----------xpto
 %% There is an important difference between the two rewrite sequences:
 %% The terms in the rewrite sequence of \code{gcd} have again and again
 %% the same form. As evaluation proceeds, their size is bounded by a

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7708,9 +7708,9 @@ da chamada de um ou mais dos métodos apresentados a seguir.
   def notify()
   def notifyAll()
 \end{lstlisting}
-O método \code{synchronized} method executes its argument computation
-\code{e} in mutual exclusive mode -- at any one time, only one thread
-can execute a \code{synchronized} argument of a given monitor.
+O método \code{synchronized} computa \code{e} em modo mutuamente exclusivo --
+em um dado momento qualquer, somente uma thread pode executar um argumento
+\code{synchronized} em um dado monitor.
 
 Threads can suspend inside a monitor by waiting on a signal.  Threads
 that call the \code{wait} method wait until a \code{notify} method of

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3759,45 +3759,45 @@ A biblioteca Scala predefine conversões implícitas para vários tipos, incluin
 os tipos primitivos e \lstinline@String@. Entretanto, o redesenho da abstração conjunto 
 pode ser, do mesmo modo,  instanciada com estes tipos. Mais explicações sobre 
 conversões implicitas e ligações visão são dadas na Seção~\ref{sec:implicits}.
-%----------xpto
 
-\section{Variance Annotations}\label{sec:first-arrays}
+\section{Anotações de Variância}\label{sec:first-arrays}
 
-The combination of type parameters and subtyping poses some
-interesting questions. For instance, should \code{Stack[String]} be a
-subtype of \code{Stack[AnyRef]}? Intuitively, this seems OK, since a
-stack of \code{String}s is a special case of a stack of
-\code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
-then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
-This property is called {\em co-variant} subtyping.
+A combinação de tipos parâmetros e subtipos levantam algumas questões interessantes.
+Por exemplo, \code{Stack[String]} deve ser um subtipo de \code{Stack[AnyRef]}? 
+Intuitivamente, isto parece OK, pois uma pilha de \code{String}s é um caso 
+especial de uma pilha de \code{AnyRef}s. Mais genericamente, se \code{T} é um
+subtipo do tipo \code{S}, então, \code{Stack[T]} deve ser um subtipo de 
+\code{Stack[S]}. Essa propriedade é chamada subtipificação {\em co-variante}.
 
-In Scala, generic types have by default non-variant subtyping. That
-is, with \code{Stack} defined as above, stacks with different element
-types would never be in a subtype relation. However, we can enforce
-co-variant subtyping of stacks by changing the first line of the
-definition of class \code{Stack} as follows.
+Em Scala, tipos genéricos tem por padrão subtipificação não variante. Ou seja, 
+com \code{Stack} definido conforme acima, pilhas com tipos de elementos diferentes
+nunca estarão numa relação de subtipo. Entretanto, podemos forçar a subtipificação 
+co-variante das pilhas mudando a primeira linha da definição da classe \code{Stack}
+como segue.
+
 \begin{lstlisting}
 class Stack[+A] {
 \end{lstlisting}
-Prefixing a formal type parameter with a \code{+} indicates that
-subtyping is covariant in that parameter. 
-Besides \code{+}, there is also a prefix \code{-} which indicates
-contra-variant subtyping. If \code{Stack} was defined \code{class
-Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
-that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
-case of stacks would be rather surprising!).
+Prefixando um parâmetro tipo formal com um \code{+} indica que aquela 
+subtipificação é covariante naquele parâmetro. Além do \code{+}, há também um
+prefixo \code{-} que indica subtipificação contra-variante. Se \code{Stack}
+foi definida \code{class Stack[-A] ...}, então \code{T}, um subtipo do tipo
+\code{S}, poderia implicar que \code{Stack[S]} é um subtipo de \code{Stack[T]}
+(o que no caso de pilhas seria um tanto quanto surpreendente!). 
 
-In a purely functional world, all types could be co-variant. However,
-the situation changes once we introduce mutable data. Consider the
-case of arrays in Java or .NET. Such arrays are represented in Scala
-by a generic class \code{Array}. Here is a partial definition of this
-class.
+Em um mundo puramente funcional, todos os tipos podem ser covariantes. Entretanto, 
+a situação muda quando introduzimos dados mutantes. Considere o caso de vetores 
+em Java ou .NET. Tais vetores são representados em Scala por uma classe genérica 
+\code{Array}. Aqui está uma definição parcial desta classe.
 \begin{lstlisting}
 class Array[A] {
   def apply(index: Int): A
   def update(index: Int, elem: A)
 }
 \end{lstlisting}
+
+%----------xpto
+
 The class above defines the way Scala arrays are seen from Scala user
 programs. The Scala compiler will map this abstraction to the
 underlying arrays of the host system in most cases where this

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3882,33 +3882,34 @@ do tipo \code{S}. (Pode-se também combinar ligações fracas e fortes, como em 
 
 Usando ligações fracas, podemos generalizar o método \code{push} dentro de \code{Stack}
 como segue.
-%----------xpto
 
 \begin{lstlisting}
 class Stack[+A] {
   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
 \end{lstlisting}
-Technically, this solves our variance problem since now the type
-parameter \code{A} appears no longer as a parameter type of method
-\code{push}. Instead, it appears as lower bound for another type
-parameter of a method, which is classified as a co-variant position.
-Hence, the Scala compiler accepts the new definition of \code{push}.
 
-In fact, we have not only solved the technical variance problem but
-also have generalized the definition of \code{push}.  Before, we were
-required to push only elements with types that conform to the declared
-element type of the stack. Now, we can push also elements of a
-supertype of this type, but the type of the returned stack will change
-accordingly. For instance, we can now push an \code{AnyRef} onto a
-stack of \code{String}s, but the resulting stack will be a stack of
-\code{AnyRef}s instead of a stack of \code{String}s!
+Tecnicamente isso resolve nosso problema de variância, pois agora o tipo parâmetro 
+\code{A} não mais aparece como um tipo parâmetro do método \code{push}. Ao invés, 
+aparece como ligação fraca para um outro tipo parâmetro de um método, que é 
+classificado como uma posição covariante. Logo, o compilador Scala aceita
+a nova definição de \code{push}. 
 
-In summary, one should not hesitate to add variance annotations to
-your data structures, as this yields rich natural subtyping
-relationships. The compiler will detect potential soundness
-problems. Even if the compiler's approximation is too conservative, as
-in the case of method \code{push} of class \code{Stack}, this will
-often suggest a useful generalization of the contested method.
+De fato, não apenas resolvemos o problema técnico da variância, mas também 
+generalizamos a definição de \code{push}. Antes, só podíamos efetuar push em
+elementos com tipos que estivessem em conformidade com o tipo do elemento
+declarado da pilha. Agora, também podemos efetuar push sobre elementos de um
+supertipo deste tipo, mas o tipo da pilha retornada será alterado de acordo. 
+Por exemplo, podemos agora efetuar push de \code{AnyRef} sobre uma pilha de 
+\code{String}s, mas a pilha resultante será uma pilha de \code{AnyRef}s ao 
+invés de uma pilha de \code{String}s! 
+
+Em resumo, não devemos hesitar em adicionar anotações de variância às estruturas de dados, 
+pois isso enriquece naturalmente relacionamentos de subtipificação. O compilador detectará
+problemas de integridade potenciais. Mesmo se a aproximação do compilador for muito 
+conservadora, frequentemente sugerirá uma generalização útil do método contestado.
+
+%----------xpto
+
 
 \section{Least Types}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3733,20 +3733,19 @@ val s = new EmptySet[java.io.File]
                     ^ java.io.File $\mbox{\sl does not conform to type}$
                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
 \end{lstlisting}
+
+Um problema com ligações para parâmetros tipo é que elas requerem antecipação:
+se não declaramos \lstinline@Num@ uma subclasse de\lstinline@Ordered@, 
+não estaremos aptos a usar elementos  \lstinline@Num@ dentro dos conjuntos.
+A partir do mesmo token, tipos herdados do Java, tais como \lstinline@Int@, 
+\lstinline@Double@, ou \lstinline@String@ não são subclasses de  \lstinline@Ordered@,
+portanto valores destes tipos não podem ser usados como elementos de conjuntos.
+
+Um desenho mais flexível, que admite elementos destes tipos, usam {\em ligações de visão} 
+ao invés de ligações plenas a tipos como temos visto. A única mudança que isto
+no leva no exemplo abaixo está nos parâmetros tipo:
 %----------xpto
 
-One probem with type parameter bounds is that they require
-forethought: if we had not declared \lstinline@Num@ a subclass of
-\lstinline@Ordered@, we would not have been able to use \lstinline@Num@
-elements in sets. By the same token, types inherited from Java, 
-such as \lstinline@Int@, \lstinline@Double@, or
-\lstinline@String@ are not subclasses of \lstinline@Ordered@, so
-values of these types cannot be used as set elements.
-
-A more flexible design, which admits elements of these types, uses
-{\em view bounds} instead of the plain type bounds we have seen so
-far. The only change this entails in the example above is in the type
-parameters:
 \begin{lstlisting}
 trait Set[A <% Ordered[A]] ...
 class EmptySet[A <% Ordered[A]] ...

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -440,7 +440,7 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 }
 \end{lstlisting}
 
-%----------xpto
+%----------
 %% For each base class, there are a number of {\em case classes} which
 %% define the format of particular messages in the class. These messages
 %% might well be ultimately mapped to small XML documents. We expect
@@ -452,9 +452,13 @@ podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
 que hajam ferramentas automáticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
 % Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
+%
+% Resp: por que trata-se de um modelo de concorrência (o nome do modelo) 
+% usado por Scala que foi inspirado no modelo do Erlang:
+%      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
 
-%----------
+%----------xpto
 %% Figure~\ref{fig:simple-auction} presents a Scala implementation of a
 %% class \code{Auction} for auction actors that coordinate the bidding
 %% on one item. Objects of this class are created by indicating
@@ -469,6 +473,19 @@ estruturas de dados internas, tais como as definidas acima.
 %% message. Before finally stopping, it stays active for another period
 %% determined by the \code{timeToShutdown} constant and replies to
 %% further offers that the auction is closed.
+A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
+\code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
+para esta classe são criados pela indicação
+\begin{itemize}
+\item Um actor vendedor que precisa ser notificado quando o leilão terminou,
+\item o lance mínimo,
+\item a data de quando o leilão foi fechado.
+\end{itemize}  
+O comportamento do actor é definido por seu método \code{act}. Este método seleciona
+repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, até que o 
+leilão seja fechado, o que é sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
+finalmente parar, permanece ativo para um outro período determinado pela constante 
+\code{timeToShutdown} e replica para ofertas posteriores que o leilão está fechado.    
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -246,6 +246,9 @@ elementos da lista \code{xs} que são menores que \code{pivot}.
 %% Looking again in detail at the first, imperative implementation of
 %% Quicksort, we find that many of the language constructs used in the
 %% second solution are also present, albeit in a disguised form.
+Olhando novamente em detalhes para a primeira, implementação imperativa
+do Quicksort, percebemos que muitos dos construtores da linguagem 
+usados na segunda solução estão presentes, embora de modo distinto.
 %----------
 
 
@@ -259,6 +262,14 @@ elementos da lista \code{xs} que são menores que \code{pivot}.
 %% Of course, a compiler is free (if it is moderately smart, even expected)
 %% to recognize the special case of calling the \code{+} method over
 %% integer arguments and to generate efficient inline code for it.
+Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
+ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
+são métodos de seus operandos esquerdos. Consequentemente, a expressão 
+\code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
+do valor inteiro de \code{x}. De fato, um compilador é livre (se 
+moderadamente esperto, ainda que  esperado) para reconhecer o caso 
+especial da chamada de método \code{+} sobre argumentos inteiros e 
+para gerar código inline eficiente para isso.  
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6554,13 +6554,11 @@ object Db {
 Ao rodar o programa, a saída confirma que ele retorna um empregado e que
 o banco somente é acessado quando é feita uma referência ao valor preguiçoso.
 
-Another use of lazy values is to resolve the
-initialization order of applications composed of several
-modules. Before lazy values were introduced, the same effect was
-achieved by using \lstinline@object@ definitions. As a second example,
-we consider a compiler composed of several modules. We look first at a
-simple symbol table that defines a class for symbols and two
-predefined functions.
+Um outro uso dos valores preguiçosos é para resolver a ordem de inicialização
+de aplicações compostas de muitos módulos. Antes dos valores preguiçosos serem
+criados, o mesmo efeito era conquistado usando definições do tipo \lstinline@object@. 
+Como um segundo exemplo considere um compilador composto de diversos módulos. Olhamos
+primeiro para uma tabela de símbolos que definie uma classe para símbolos e duas funções pré-definidas.
 \begin{lstlisting}
 class Symbols(val compiler: Compiler) {
   import compiler.types._
@@ -6573,11 +6571,9 @@ class Symbols(val compiler: Compiler) {
   }
 }
 \end{lstlisting}
-The \lstinline@symbols@ module is parameterized with a \lstinline@Compiler@
-instance, which provides access to other services, such as the types
-module. In our example there are only two predefined functions,
-addition and subtraction, and their definitions depend on the \lstinline@types@
-module.
+O módulo  \lstinline@Symbols@ é parametrizado com uma instância de  \lstinline@Compiler@
+que permite o acesso a outros serviços, tais como o módulo de tipos. Em nosso exemplo, há somente
+duas funções pré-definidas, adição e subtração e suas definições dependem do módulo \lstinline@types@.
 \begin{lstlisting}
 class Types(val compiler: Compiler) {
   import compiler.symtab._
@@ -6588,36 +6584,35 @@ class Types(val compiler: Compiler) {
   case object IntType extends Type
 }
 \end{lstlisting}
-In order to hook the two components together a compiler object is
-created and passed as an argument to the two components. 
+Para conectar os dois componentes, um objeto do tipo compilador é criado e passado com parâmetro para os
+dois componentes.
 \begin{lstlisting}
 class Compiler {
   val symtab = new Symbols(this)
   val types  = new Types(this)
 }
 \end{lstlisting}
-Unfortunately, the straight-forward approach fails at runtime because
-the \lstinline@symtab@ module needs the \lstinline@types@
-module. In general, the dependency between modules can be complicated
-and getting the right initialization order is difficult, or even
-impossible when there are cycles. The easy fix is to make such fields
-\lstinline@lazy@ and let the compiler figure out the right order.
+Infelizmente, esta abordagem falha em tempo de execução, pois o módulo 
+\lstinline@symtab@ depende do módulo  \lstinline@types@. De maneira geral,
+a dependência entre os módulos pode ficar complicada e conseguir a ordem correta
+de inicialização é difícil ou, até mesmo, impossível, quando existem dependências cíclicas.
+A maneira mais simples de corrigir este erro é tornar estes campos 
+\lstinline@lazy@ e deixar o compilador descobrir qual é a ordem correta de inicialização.
 \begin{lstlisting}
 class Compiler {
   lazy val symtab = new Symbols(this)
   lazy val types  = new Types(this)
 }
 \end{lstlisting}
-Now the two modules are initialized on first access, and the compiler
-may run as expected. 
+Aogra os dois módulos são inicializados no primeiro acesso e o compilador pode executar da forma
+esperada.
 
-\subsection*{Syntax}
-The \lstinline@lazy@ modifier is allowed only on concrete value
-definitions. All typing rules for value definitions apply for
-\lstinline@lazy@ values as well, with one restriction removed:
-recursive local values are allowed.
+\subsection*{Sintaxe}
+O modificador \lstinline@lazy@ é permitido apenas na definição de valores concretos.
+Todas as regras válidas para definição de valores se aplicam também para valores do tipo 
+\lstinline@lazy@, com uma restrição a menos: valores locais recursivos são permitidos.
 
-\chapter{Implicit Parameters and Conversions}\label{sec:implicits}
+\chapter{Parâmetros Implícitos e Conversões}\label{sec:implicits}
 
 Implicit parameters and conversions are powerful tools for
 custimizing existing libraries and for creating high-level

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -967,32 +967,53 @@ que computa a raiz quadrada de \code{x}.
 %% example, the next three columns indicate the guess \code{y}, the
 %% quotient \code{x/y}, and their average for the first approximations of
 %% $\sqrt 2$.
-%% \begin{lstlisting}
-%% 1            2/1 = 2               1.5
-%% 1.5          2/1.5 = 1.3333        1.4167
-%% 1.4167       2/1.4167 = 1.4118     1.4142
-%% 1.4142       ...                   ...
+Um modo comum de se computar raizes quadradas é pelo método das aproximações
+sucessivas de Newton. Inicia-se com um palpite inicial \code{y} (digamos:
+\code{y = 1}). Então melhora-se repetidamente o atual palpite \code{y} 
+tomando-se a média de \code{y} e \code{x/y}. Como um exemplo, as próximas
+três colunas indicam o palpite \code{y}, o quociente \code{x/y}, e suas
+médias para as primeiras aproximações para $\sqrt 2$.       
 
-%% $y$            $x/y$                   $(y + x/y)/2$
-%% \end{lstlisting}
+\begin{lstlisting}
+1            2/1 = 2               1.5
+1.5          2/1.5 = 1.3333        1.4167
+1.4167       2/1.4167 = 1.4118     1.4142
+1.4142       ...                   ...
+
+$y$            $x/y$                   $(y + x/y)/2$
+\end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% One can implement this algorithm in Scala by a set of small functions,
 %% which each represent one of the elements of the algorithm.  
 
 %% We first define a function for iterating from a guess to the result:
-%% \begin{lstlisting}
-%% def sqrtIter(guess: Double, x: Double): Double =
-%%   if (isGoodEnough(guess, x)) guess
-%%   else sqrtIter(improve(guess, x), x)
-%% \end{lstlisting}
+
+Este algoritmo pode ser implementado em Scala por um conjunto de pequenas funções,
+onde cada uma representa um dos elementos do algoritmo.
+
+Primeiro definimos uma função para iterar do palpite para o resultado:
+%-----------
+
+
+\begin{lstlisting}
+def sqrtIter(guess: Double, x: Double): Double =
+  if (isGoodEnough(guess, x)) guess
+  else sqrtIter(improve(guess, x), x)
+\end{lstlisting}
+
+%-----------
 %% Note that \code{sqrtIter} calls itself recursively.  Loops in
 %% imperative programs can always be modeled by recursion in functional
-%% programs. 
+%% programs.
+ 
+Observe que \code{sqrtIter} chama a si mesmo recursivamente. Laços em 
+programas imperativos podem sempre ser modelados por recursão em 
+programas funcionais. 
 %----------
 
-%----------
+%----------xpto
 %% Note also that the definition of \code{sqrtIter} contains a return
 %% type, which follows the parameter section. Such return types are
 %% mandatory for recursive functions. For a non-recursive function, the

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3414,44 +3414,45 @@ correspondentes argumentos construtores. Se nenhum dos padrões casar, a express
 de casamento de padrões é abortada com um erro \code{MatchError}.  
 
 
-%----------xpto
-\example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
+\example Nosso modelo de substituição de avaliação de programa estende de modo natural o casamento de padrões. Por exemplo, aqui temos como \code{eval} aplicado a uma única expressão é reescrito:
+
+
 \begin{lstlisting}
      eval(Sum(Number(1), Number(2)))
 
-->   $\mbox{\tab\tab\rm(by rewriting the application)}$
+->   $\mbox{\tab\tab\rm(através da reescrita da aplicação)}$
 
      Sum(Number(1), Number(2)) match {
          case Number(n) => n
          case Sum(e1, e2) => eval(e1) + eval(e2)
      }
 
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+->   $\mbox{\tab\tab\rm(através da reescrita do casamento de padrões)}$
 
      eval(Number(1)) + eval(Number(2))
 
-->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
+->   $\mbox{\tab\tab\rm(através da reescrita da primeira aplicação)}$
 
      Number(1) match {
          case Number(n) => n
          case Sum(e1, e2) => eval(e1) + eval(e2)
      } + eval(Number(2))
 
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+->   $\mbox{\tab\tab\rm(através da reescrita do casamento de padrões)}$
 
      1 + eval(Number(2))
 
 ->$^*$ 1 + 2 -> 3
 \end{lstlisting}
-%----------
 
-\paragraph{Pattern Matching and Methods}
-In the previous example, we have used pattern
-matching in a function which was defined outside the class hierarchy
-over which it matches.  Of course, it is also possible to define a
-pattern matching function in that class hierarchy itself. For
-instance, we could have defined
-\code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
+
+\paragraph{Casamento de Padrões e Métodos}
+No exemplo anterior, usamos casamento de padrões numa função que era definida fora da 
+hierarquia de classes da qual pertencia. De fato, é também possível definir uma função 
+de casamento de padrões na sua própria hierarquia de classes. Por exemplo, podíamos 
+ter definido \code{eval} como um método da classe base \code{Expr}, e ainda assim usar o 
+casamento de padrões na sua implementação:
+
 \begin{lstlisting}
 abstract class Expr { 
   def eval: Int = this match {
@@ -3460,9 +3461,8 @@ abstract class Expr {
   } 
 }
 \end{lstlisting}
-%----------
 
-
+%----------xpto
 \begin{exercise} Consider the following definitions representing trees
 of integers.  These definitions can be seen as an alternative
 representation of \code{IntSet}:

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -544,7 +544,7 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par�
 \end{itemize}    
 %----------
 
-%----------xpto
+%----------
 %% The preceding discussion gave a flavor of distributed programming in
 %% Scala. It might seem that Scala has a rich set of language constructs
 %% that support actor processes, message sending and receiving,
@@ -564,7 +564,7 @@ hospedeira (Java ou .NET). A implementação de todas as características da
 classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
 %----------
 
-%----------
+%----------xpto
 %% The advantages of the library-based approach are relative simplicity
 %% of the core language and flexibility for library designers. Because
 %% the core language need not specify details of high-level process
@@ -579,7 +579,20 @@ classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
-
+As vantagens da abordagem baseada em biblioteca são a relativa simplicidade
+da linguagem núcleo e a flexibilidade para os criadores de biblioteca. Como 
+a linguagem núcleo não precisa especificar detalhes da comunicação dos 
+processos de alto nível, pode ser mantida mais simples e geral. Como
+um modelo particular de mensagens numa caixa de correio é um módulo biblioteca, 
+pode ser modificado livremente se um diferente modelo for necessário em algumas 
+aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
+o suficiente para prover as abstrações linguísticas necessárias de um modo 
+conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
+design foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
+hospedeira para domínios de linguagens específicos implementados por módulos de 
+biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
+pode ser vista como um desses domínios específicos de linguagem, que conceitualmente
+estendem o núcleo Scala.  
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3109,9 +3109,12 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
+Consequentemente, decomposição orientada a objetos clássica requer modificação 
+de todas as classes existentes quando um sistema for estendido com novas
+operações.
 
 %% As yet another way we might want to extend the interpreter, consider
 %% expression simplification. For instance, we might want to write a
@@ -3123,6 +3126,16 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 %% forced to have classification and access methods in this case. This
 %% seems to bring us back to square one, with all the problems of
 %% verbosity and extensibility.
+
+Ainda como uma outra forma, podemos querer estender o interpretador. 
+Considere a simplificação de expressões. Por exemplo, podemos querer criar 
+uma função que reescreve expressões da forma \code{a * b + a * c} para 
+\code{a * (b + c)}. Esta operação requer inspeção de mais de um nó para a 
+árvore de expressões ao mesmo tempo. Consequentemente, não pode ser implementada
+por um método dentro de cada tipo de expressão, a não ser que tal método também 
+possa inspecionar outros nós. Portanto somos forçados a ter métodos de acesso e 
+classificação neste caso. Isto parece nos levar para a casa inicial, com todos os 
+problemas de estensibilidade e expressividade.
 %----------
 
 %----------
@@ -3132,9 +3145,14 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 %% of an abstract base class was used and, second, what were the
 %% constructor arguments. Since this situation is quite common, Scala has
 %% a way to automate it with case classes. 
+Olhando mais de perto, observa-se que o único propósito das funções de acesso
+e classificação  é {\em reverter} o processo de construção de dados. Elas nos 
+permitem determinar, primeiro, qual subclasse de uma classe base abstrata foi 
+usada e, segundo, quais foram os argumentos construtores. Como essa situação é 
+bem comum, Scala tem um modo de automatizá-lo para classes case.
 %----------
 
-%----------
+%----------xpto
 %% \section{Case Classes and Case Objects}
 
 %% {\em Case classes} and {\em case objects} are defined like a normal

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -339,7 +339,7 @@ que retornam um valor explícito sempre precisam de um ``='' antes de
 seus corpos ou expressões de definição.
 %----------
 
-\chapter{Programming with Actors and Messages}
+\chapter{Programando com Atores e Mensagens}
 \label{chap:example-auction}
 %----------
 %% Here's an example that shows an application area for which Scala is

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1462,30 +1462,38 @@ anterior, definimos \code{id}, \code{square} e \code{power} como funções
 separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}.    
 %----------
 
-%----------xpto
+%----------
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a
 %% function; the function is defined without giving it a name. As an
 %% example consider the anonymous square function:
-%% \begin{lstlisting}
-%%   (x: Int) => x * x
-%% \end{lstlisting}
+
+Ao invés de usarmos definições de funções nomeadas para estas pequenas funções 
+argumentos, podemos formulá-las de um modo abreviado como {\em funções anônimas}.
+Uma função anônima é uma expressão que é avaliada para uma função; a função é 
+definida sem receber um nome. Como exemplo considere a função anônima quadrado:
+\begin{lstlisting}
+  (x: Int) => x * x
+\end{lstlisting}
 %----------
-
-
+  
+%----------xpto
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.
-%% \begin{lstlisting}
-%%   (x: Int, y: Int) => x * y
-%% \end{lstlisting}
+\begin{lstlisting}
+  (x: Int, y: Int) => x * y
+\end{lstlisting}
 %% Using anonymous functions, we can reformulate the first two summation
 %% functions without named auxiliary functions:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
+def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
+\end{lstlisting}
+%----------
+
+%----------
 %% Often, the Scala compiler can deduce the parameter type(s) from the
 %% context of the anonymous function in which case they can be omitted.
 %% For instance, in the case of \code{sumInts} or \code{sumSquares}, one
@@ -1493,11 +1501,13 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% function of type \code{Int => Int}.  Hence, the parameter type
 %% \code{Int} is redundant and may be omitted. If there is a single
 %% parameter without a type, we may also omit the parentheses around it:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
+def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
+\end{lstlisting}
+%----------
 
+%----------
 %% Generally, the Scala term
 %% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
 %% defines a function which maps its parameters
@@ -1506,16 +1516,18 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% functions are not essential language elements of Scala, as they can
 %% always be expressed in terms of named functions. Indeed, the 
 %% anonymous function
-%% \begin{lstlisting}
-%% (x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
-%% \end{lstlisting}
+\begin{lstlisting}
+(x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
+\end{lstlisting}
 %% is equivalent to the block
-%% \begin{lstlisting}
-%% { def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
-%% \end{lstlisting}
+\begin{lstlisting}
+{ def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
+\end{lstlisting}
 %% where \code{f} is fresh name which is used nowhere else in the program.
 %% We also say, anonymous functions are ``syntactic sugar''.
+%----------
 
+%----------
 %% \section{Currying}
 
 %% The latest formulation of the summing functions is already quite
@@ -1526,13 +1538,16 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 
 %% Let's try to rewrite \code{sum} so that it does not take the bounds
 %% \code{a} and \code{b} as parameters:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int): (Int, Int) => Int = {
-%%   def sumF(a: Int, b: Int): Int =
-%%     if (a > b) 0 else f(a) + sumF(a + 1, b)
-%%   sumF
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def sum(f: Int => Int): (Int, Int) => Int = {
+  def sumF(a: Int, b: Int): Int =
+    if (a > b) 0 else f(a) + sumF(a + 1, b)
+  sumF
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% In this formulation, \code{sum} is a function which returns another
 %% function, namely the specialized summing function \code{sumF}. This
 %% latter function does all the work; it takes the bounds \code{a} and
@@ -1540,32 +1555,36 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% integers between them, and sums up the results. 
 
 %% Using this new formulation of \code{sum}, we can now define:
-%% \begin{lstlisting}
-%% def sumInts  =  sum(x => x)
-%% def sumSquares  =  sum(x => x * x)
-%% def sumPowersOfTwo  =  sum(powerOfTwo)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sumInts  =  sum(x => x)
+def sumSquares  =  sum(x => x * x)
+def sumPowersOfTwo  =  sum(powerOfTwo)
+\end{lstlisting}
 %% Or, equivalently, with value definitions:
-%% \begin{lstlisting}
-%% val sumInts  =  sum(x => x)
-%% val sumSquares  =  sum(x => x * x)
-%% val sumPowersOfTwo  =  sum(powerOfTwo)
-%% \end{lstlisting}
+\begin{lstlisting}
+val sumInts  =  sum(x => x)
+val sumSquares  =  sum(x => x * x)
+val sumPowersOfTwo  =  sum(powerOfTwo)
+\end{lstlisting}
+%----------
 
+%----------
 %% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
 %% applied like any other function. For instance,
-%% \begin{lstlisting}
-%% scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
-%% unnamed0: Int = 2096513
-%% \end{lstlisting}
+\begin{lstlisting}
+scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
+unnamed0: Int = 2096513
+\end{lstlisting}
 %% How are function-returning functions applied? As an example, in the expression
-%% \begin{lstlisting}
-%% sum(x => x * x)(1, 10) ,
-%% \end{lstlisting}
+\begin{lstlisting}
+sum(x => x * x)(1, 10) ,
+\end{lstlisting}
 %% the function \code{sum} is applied to the squaring function 
 %% \code{(x => x * x)}. The resulting function is then 
 %% applied to the second argument list, \code{(1, 10)}.
+%----------
 
+%----------
 %% This notation is possible because function application associates to the left.
 %% That is, if $\mbox{args}_1$ and $\mbox{args}_2$ are argument lists, then 
 %% \bda{lcl}
@@ -1574,155 +1593,170 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
 %% following expression:
 %% \code{(sum(x => x * x))(1, 10)}.
+%----------
 
+%----------
 %% The style of function-returning functions is so useful that Scala has
 %% special syntax for it. For instance, the next definition of \code{sum}
 %% is equivalent to the previous one, but is shorter:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int)(a: Int, b: Int): Int =
-%%   if (a > b) 0 else f(a) + sum(f)(a + 1, b)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sum(f: Int => Int)(a: Int, b: Int): Int =
+  if (a > b) 0 else f(a) + sum(f)(a + 1, b)
+\end{lstlisting}
 %% Generally, a curried function definition 
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_n$) = E
-%% \end{lstlisting}
-%% where $n > 1$ expands to
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
-%% \end{lstlisting}
-%% where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
-%% \end{lstlisting}
-%% Performing this step $n$ times yields that
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_n$) = E
-%% \end{lstlisting}
-%% is equivalent to
-%% \begin{lstlisting}
-%% def f = (args$_1$) => ... => (args$_n$) => E .
-%% \end{lstlisting}
-%% Or, equivalently, using a value definition:
-%% \begin{lstlisting}
-%% val f = (args$_1$) => ... => (args$_n$) => E .
-%% \end{lstlisting}
+\begin{lstlisting}
+def f (args$_1$) ... (args$_n$) = E
+\end{lstlisting}
+%%where $n > 1$ expands to
+\begin{lstlisting}
+def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
+\end{lstlisting}
+%%where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
+\begin{lstlisting}
+def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
+\end{lstlisting}
+%%Performing this step $n$ times yields that
+\begin{lstlisting}
+def f (args$_1$) ... (args$_n$) = E
+\end{lstlisting}
+%%is equivalent to
+\begin{lstlisting}
+def f = (args$_1$) => ... => (args$_n$) => E .
+\end{lstlisting}
+%%Or, equivalently, using a value definition:
+\begin{lstlisting}
+val f = (args$_1$) => ... => (args$_n$) => E .
+\end{lstlisting}
 %% This style of function definition and application is called {\em
 %% currying} after its promoter, Haskell B.\ Curry, a logician of the
 %% 20th century, even though the idea goes back further to Moses
 %% Sch\"onfinkel and Gottlob Frege.
+%----------
 
+%----------
 %% The type of a function-returning function is expressed analogously to
 %% its parameter list. Taking the last formulation of \code{sum} as an example,
 %% the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
 %% This is possible because function types associate to the right. I.e.
-%% \begin{lstlisting}
-%% T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
-%% \end{lstlisting}
+\begin{lstlisting}
+T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
+\end{lstlisting}
+%----------
 
-
-%% \begin{exercise}
+%----------
+\begin{exercise}
 %% 1. The \code{sum} function uses a linear recursion. Can you write a
 %% tail-recursive one by filling in the ??'s?
 
-%% \begin{lstlisting}
-%% def sum(f: Int => Int)(a: Int, b: Int): Int = {
-%%   def iter(a: Int, result: Int): Int = {
-%%     if (??) ??
-%%     else iter(??, ??)
-%%   }
-%%   iter(??, ??)
-%% }
-%% \end{lstlisting}
-%% \end{exercise}
+\begin{lstlisting}
+def sum(f: Int => Int)(a: Int, b: Int): Int = {
+  def iter(a: Int, result: Int): Int = {
+    if (??) ??
+    else iter(??, ??)
+  }
+  iter(??, ??)
+}
+\end{lstlisting}
+\end{exercise}
+%----------
 
-%% \begin{exercise}
+%----------
+\begin{exercise}
 %% Write a function \code{product} that computes the product of the
 %% values of functions at points over a given range.
-%% \end{exercise}
+\end{exercise}
 
-%% \begin{exercise}
+\begin{exercise}
 %% Write \code{factorial} in terms of \code{product}.
-%% \end{exercise}
+\end{exercise}
 
-%% \begin{exercise}
+\begin{exercise}
 %% Can you write an even more general function which generalizes both
 %% \code{sum} and \code{product}?
-%% \end{exercise}
+\end{exercise}
+%----------
 
+%----------
 %% \section{Example: Finding Fixed Points of Functions}
 
 %% A number \code{x} is called a {\em fixed point} of a function \code{f} if
-%% \begin{lstlisting}
-%% f(x) = x .
-%% \end{lstlisting}
+\begin{lstlisting}
+f(x) = x .
+\end{lstlisting}
 %% For some functions \code{f} we can locate the fixed point by beginning
 %% with an initial guess and then applying \code{f} repeatedly, until the
 %% value does not change anymore (or the change is within a small
 %% tolerance). This is possible if the sequence
-%% \begin{lstlisting}
-%% x, f(x), f(f(x)), f(f(f(x))), ...
-%% \end{lstlisting}
-%% converges to fixed point of $f$. This idea is captured in
-%% the following ``fixed-point finding function'':
-%% \begin{lstlisting}
-%% val tolerance = 0.0001
-%% def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
-%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-%%   def iterate(guess: Double): Double = {
-%%     val next = f(guess)
-%%     if (isCloseEnough(guess, next)) next
-%%     else iterate(next)
-%%   }
-%%   iterate(firstGuess)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+x, f(x), f(f(x)), f(f(f(x))), ...
+\end{lstlisting}
+%%converges to fixed point of $f$. This idea is captured in
+%%the following ``fixed-point finding function'':
+\begin{lstlisting}
+val tolerance = 0.0001
+def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
+def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+  def iterate(guess: Double): Double = {
+    val next = f(guess)
+    if (isCloseEnough(guess, next)) next
+    else iterate(next)
+  }
+  iterate(firstGuess)
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% We now apply this idea in a reformulation of the square root function.
 %% Let's start with a specification of \code{sqrt}:
-%% \begin{lstlisting}
-%% sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
-%%          =  $\mbox{the {\sl y} such that}$  y = x / y
-%% \end{lstlisting}
+\begin{lstlisting}
+sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
+         =  $\mbox{the {\sl y} such that}$  y = x / y
+\end{lstlisting}
 %% Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
 %% This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
-%% \begin{lstlisting}
-%% def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
+\end{lstlisting}
 %% But if we try this, we find that the computation does not
 %% converge. Let's instrument the fixed point function with a print
 %% statement which keeps track of the current \code{guess} value:
-%% \begin{lstlisting}
-%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-%%   def iterate(guess: Double): Double = {
-%%     val next = f(guess)
-%%     println(next)
-%%     if (isCloseEnough(guess, next)) next
-%%     else iterate(next)
-%%   }
-%%   iterate(firstGuess)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+  def iterate(guess: Double): Double = {
+    val next = f(guess)
+    println(next)
+    if (isCloseEnough(guess, next)) next
+    else iterate(next)
+  }
+  iterate(firstGuess)
+}
+\end{lstlisting}
 %% Then, \code{sqrt(2)} yields:
-%% \begin{lstlisting}
-%%   2.0
-%%   1.0
-%%   2.0
-%%   1.0
-%%   2.0
-%%   ...
-%% \end{lstlisting}
+\begin{lstlisting}
+  2.0
+  1.0
+  2.0
+  1.0
+  2.0
+  ...
+\end{lstlisting}
+%----------
+
+%----------
 %% One way to control such oscillations is to prevent the guess from changing too much. 
 %% This can be achieved by {\em averaging} successive values of the original sequence:
-%% \begin{lstlisting}
-%% scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
-%% sqrt: (Double)Double
+\begin{lstlisting}
+scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
+sqrt: (Double)Double
 
-%% scala> sqrt(2.0)
-%%   1.5
-%%   1.4166666666666665
-%%   1.4142156862745097
-%%   1.4142135623746899
-%%   1.4142135623746899
-%% \end{lstlisting}
+scala> sqrt(2.0)
+  1.5
+  1.4166666666666665
+  1.4142156862745097
+  1.4142135623746899
+  1.4142135623746899
+\end{lstlisting}
 %% In fact, expanding the \code{fixedPoint} function yields exactly our 
 %% previous definition of fixed point from Section~\ref{sec:sqrt}.
 
@@ -1730,26 +1764,31 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% is considerably enhanced if functions can be passed as arguments.  The
 %% next example shows that functions which return functions can also be
 %% very useful.
+%----------
 
+%----------
 %% Consider again fixed point iterations. We started with the observation
 %% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
 %% Then we made the iteration converge by averaging successive values.
 %% This technique of {\em average damping} is so general that it
 %% can be wrapped in another function.
-%% \begin{lstlisting}
-%% def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
-%% \end{lstlisting}
+\begin{lstlisting}
+def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
+\end{lstlisting}
 %% Using \code{averageDamp}, we can reformulate the square root function
 %% as follows.
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
-%% \end{lstlisting}
+\begin{lstlisting}
+def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
+\end{lstlisting}
 %% This expresses the elements of the algorithm as clearly as possible.
 
-%% \begin{exercise} Write a function for cube roots using \code{fixedPoint} and 
+\begin{exercise} 
+%%Write a function for cube roots using \code{fixedPoint} and 
 %% \code{averageDamp}.
-%% \end{exercise}
+\end{exercise}
+%----------
 
+%----------
 %% \section{Summary}
 
 %% We have seen in the previous chapter that functions are essential
@@ -1761,7 +1800,9 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% reuse. The highest possible level of abstraction is not always the
 %% best, but it is important to know abstraction techniques, so that one
 %% can use abstractions where appropriate.
+%----------
 
+%----------
 %% \section{Language Elements Seen So Far}
 
 %% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
@@ -1776,34 +1817,33 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 
 %% Scala programs are sequences of (Unicode) characters. We distinguish the
 %% following character sets:
-%% \begin{itemize}
-%% \item
+ \begin{itemize}
+ \item
 %% whitespace, such as `\code{ }', tabulator, or newline characters,
-%% \item
+ \item
 %% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
-%% \item
+ \item
 %% digits \code{`0'} to `\code{9}',
-%% \item
+ \item
 %% the delimiter characters
 
-%% \begin{lstlisting}
-%% .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
-%% \end{lstlisting}
-
-%% \item
+ \begin{lstlisting}
+ .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
+ \end{lstlisting}
+ \item
 %% operator characters, such as `\code{#}' `\code{+}',
 %% `\code{:}'. Essentially, these are printable characters which are
 %% in none of the character sets above.
-%% \end{itemize}
+ \end{itemize}
 
 %% \subsection*{Lexemes:}
 
-%% \begin{lstlisting}
-%% ident    =  letter {letter | digit}
-%%          |  operator { operator }
-%%          |  ident '_' ident
-%% literal  =  $\mbox{``as in Java''}$
-%% \end{lstlisting}
+\begin{lstlisting}
+ident    =  letter {letter | digit}
+         |  operator { operator }
+         |  ident '_' ident
+literal  =  $\mbox{``as in Java''}$
+\end{lstlisting}
 
 %% Literals are as in Java. They define numbers, characters, strings, or
 %% boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
@@ -1816,64 +1856,70 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% identifiers may contain underscore characters `\code{_}'. Furthermore,
 %% an underscore character may be followed by either sort of
 %% identifier. Hence, the following are all legal identifiers:
-%% \begin{lstlisting}
-%% x     Room10a     +     --     foldl_:     +_vector
-%% \end{lstlisting}
+ \begin{lstlisting}
+ x     Room10a     +     --     foldl_:     +_vector
+ \end{lstlisting}
 %% It follows from this rule that subsequent operator-identifiers need to
 %% be separated by whitespace. For instance, the input
 %% \code{x+-y} is parsed as the three token sequence \code{x}, \code{+-},
 %% \code{y}. If we want to express the sum of \code{x} with the
 %% negated value of \code{y}, we need to add at least one space,
 %% e.g. \code{x+ -y}.
+%----------
 
+%----------
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
 
 %% The following are reserved words, they may not be used as identifiers:
-%% \begin{lstlisting}
-%% abstract    case        catch       class       def    
-%% do          else        extends     false       final    
-%% finally     for         if          implicit    import      
-%% match       new         null        object      override    
-%% package     private     protected   requires    return      
-%% sealed      super       this        throw       trait
-%% try         true        type        val         var         
-%% while       with        yield
-%% _    :    =    =>    <-    <:    <%     >:    #    @
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract    case        catch       class       def    
+do          else        extends     false       final    
+finally     for         if          implicit    import      
+match       new         null        object      override    
+package     private     protected   requires    return      
+sealed      super       this        throw       trait
+try         true        type        val         var         
+while       with        yield
+_    :    =    =>    <-    <:    <%     >:    #    @
+\end{lstlisting}
+%----------
 
+%----------
 %% \subsection*{Types:}
 
-%% \begin{lstlisting}
-%% Type          =  SimpleType | FunctionType
-%% FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
-%% SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
-%%                  Boolean | Unit | String
-%% Types         =  Type {`,' Type}
-%% \end{lstlisting}
+\begin{lstlisting}
+Type          =  SimpleType | FunctionType
+FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
+SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
+                 Boolean | Unit | String
+Types         =  Type {`,' Type}
+\end{lstlisting}
 
 %% Types can be:
-%% \begin{itemize}
+ \begin{itemize}
 %% \item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
 %% \item the type \code{Boolean} with values \code{true} and \code{false},
 %% \item the type \code{Unit} with the only value \lstinline@()@,
 %% \item the type \code{String},
 %% \item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
-%% \end{itemize}
+ \end{itemize}
+%----------
 
+%----------
 %% \subsection*{Expressions:}
 
-%% \begin{lstlisting}
-%% Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
-%% InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
-%% Operator     = ident
-%% PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
-%% SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
-%% FunctionExpr = (Bindings | Id) '=>' Expr
-%% Bindings     = `(' Binding {`,' Binding} `)'
-%% Binding      = ident [':' Type]
-%% Block        = '{' {Def ';'} Expr '}'
-%% \end{lstlisting}
+\begin{lstlisting}
+Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
+InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
+Operator     = ident
+PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
+SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
+FunctionExpr = (Bindings | Id) '=>' Expr
+Bindings     = `(' Binding {`,' Binding} `)'
+Binding      = ident [':' Type]
+Block        = '{' {Def ';'} Expr '}'
+\end{lstlisting}
 
 %% Expressions can be:
 %% \begin{itemize}
@@ -1894,7 +1940,9 @@ separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}
 %% \item
 %% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
 %% \end{itemize}
+%----------
 
+%----------
 %% \subsection*{Definitions:}
 
 \begin{lstlisting}
@@ -1904,14 +1952,16 @@ ValDef       =  'val' ident [':' Type] '=' Expr
 Parameters   =  Parameter {',' Parameter}
 Parameter    =  ident ':' ['=>'] Type
 \end{lstlisting}
-Definitions can be:
+%%Definitions can be:
 \begin{itemize}
 \item
-function definitions such as \code{def square(x: Int): Int = x * x},
+%%function definitions such as \code{def square(x: Int): Int = x * x},
 \item
-value definitions such as \code{val y = square(2)}.
+%%value definitions such as \code{val y = square(2)}.
 \end{itemize}
+%----------
 
+%----------
 \chapter{Classes and Objects}
 \label{chap:classes}
 
@@ -1949,7 +1999,9 @@ class Rational(n: Int, d: Int) {
 %% arithmetic method takes as parameter the right operand of the
 %% operation. The left operand of the operation is always the rational
 %% number of which the method is a member.
+%----------
 
+%----------
 %% \paragraph{Private members}
 %% The implementation of rational numbers defines a private method
 %% \code{gcd} which computes the greatest common denominator of two
@@ -1959,23 +2011,27 @@ class Rational(n: Int, d: Int) {
 %% the class to eliminate common factors in the constructor arguments in
 %% order to ensure that numerator and denominator are always in
 %% normalized form.
+%----------
 
+%----------
 %% \paragraph{Creating and Accessing Objects}
 %% As an example of how rational numbers can be used, here's a program
 %% that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
-%% \begin{lstlisting}
-%% var i = 1
-%% var x = new Rational(0, 1)
-%% while (i <= 10) {
-%%   x += new Rational(1, i)
-%%   i += 1
-%% }
-%% println("" + x.numer + "/" + x.denom)
-%% \end{lstlisting}
+\begin{lstlisting}
+var i = 1
+var x = new Rational(0, 1)
+while (i <= 10) {
+  x += new Rational(1, i)
+  i += 1
+}
+println("" + x.numer + "/" + x.denom)
+\end{lstlisting}
 %% The \code{+} takes as left operand a string and as right operand a
 %% value of arbitrary type. It returns the result of converting its right
 %% operand to a string and appending it to its left operand. 
-  
+%----------
+
+%----------
 %% \paragraph{Inheritance and Overriding}
 %% Every class in Scala has a superclass which it extends.  
 %% \comment{Excepted is
@@ -1986,63 +2042,76 @@ class Rational(n: Int, d: Int) {
 %% \code{scala.AnyRef} is implicitly assumed (for Java implementations,
 %% this type is an alias for \code{java.lang.Object}. For instance, class
 %% \code{Rational} could equivalently be defined as
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // as before
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% A class inherits all members from its superclass. It may also redefine
 %% (or: {\em override}) some inherited members. For instance, class
 %% \code{java.lang.Object} defines
 %% a method
 %% \code{toString} which returns a representation of the object as a string:
-%% \begin{lstlisting}
-%% class Object {
-%%   ...
-%%   def toString: String = ...
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Object {
+  ...
+  def toString: String = ...
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% The implementation of \code{toString} in \code{Object}
 %% forms a string consisting of the object's class name and a number. It
 %% makes sense to redefine this method for objects that are rational
 %% numbers:
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%%   override def toString = "" + numer + "/" + denom
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // as before
+  override def toString = "" + numer + "/" + denom
+}
+\end{lstlisting}
 %% Note that, unlike in Java, redefining definitions need to be preceded
 %% by an \code{override} modifier.
+%----------
 
+%----------
 %% If class $A$ extends class $B$, then objects of type $A$ may be used
 %% wherever objects of type $B$ are expected. We say in this case that
 %% type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
 %% conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
 %% value to a variable of type \code{AnyRef}:
-%% \begin{lstlisting}
-%% var x: AnyRef = new Rational(1, 2)
-%% \end{lstlisting}
+ \begin{lstlisting}
+ var x: AnyRef = new Rational(1, 2)
+ \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Parameterless Methods}
 %% %Also unlike in Java, methods in Scala do not necessarily take a
 %% %parameter list. An example is \code{toString}; the method is invoked
 %% %by simply mentioning its name. For instance:
-%% %\begin{lstlisting}
-%% %val r = new Rational(1,2)
-%% %System.out.println(r.toString);      // prints``1/2''
-%% %\end{lstlisting}
+\begin{lstlisting}
+val r = new Rational(1,2)
+System.out.println(r.toString);      // prints``1/2''
+\end{lstlisting}
 %% Unlike in Java, methods in Scala do not necessarily take a
 %% parameter list. An example is the \code{square} method below. This
 %% method is invoked by simply mentioning its name. 
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%%   def square = new Rational(numer*numer, denom*denom)
-%% }
-%% val r = new Rational(3, 4)
-%% println(r.square)           // prints``9/16''*
-%% \end{lstlisting}
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // as before
+  def square = new Rational(numer*numer, denom*denom)
+}
+val r = new Rational(3, 4)
+println(r.square)           // prints``9/16''*
+\end{lstlisting}
+%----------
+
+%----------
 %% That is, parameterless methods are accessed just as value fields such
 %% as \code{numer} are. The difference between values and parameterless
 %% methods lies in their definition. The right-hand side of a value is
@@ -2053,7 +2122,9 @@ class Rational(n: Int, d: Int) {
 %% the implementer of a class. Often, a field in one version of a class
 %% becomes a computed value in the next version. Uniform access ensures
 %% that clients do not have to be rewritten because of that change.
+%----------
 
+%----------
 %% \paragraph{Abstract Classes}
 
 %% Consider the task of writing a class for sets of integer numbers with
@@ -2063,12 +2134,15 @@ class Rational(n: Int, d: Int) {
 %% return true if the set \code{s} contains the element \code{x}, and
 %% should return \code{false} otherwise. The interface of such sets is
 %% given by:  
-%% \begin{lstlisting}
-%% abstract class IntSet {
-%%   def incl(x: Int): IntSet
-%%   def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class IntSet {
+  def incl(x: Int): IntSet
+  def contains(x: Int): Boolean
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% \code{IntSet} is labeled as an \emph{abstract class}. This has two
 %% consequences.  First, abstract classes may have {\em deferred} members
 %% which are declared but which do not have an implementation. In our
@@ -2077,7 +2151,9 @@ class Rational(n: Int, d: Int) {
 %% of that class may be created using \code{new}. By contrast, an
 %% abstract class may be used as a base class of some other class, which
 %% implements the deferred members.
+%----------
 
+%----------
 %% \paragraph{Traits}
 
 %% Instead of \code{abstract class} one also often uses the keyword
@@ -2091,13 +2167,15 @@ class Rational(n: Int, d: Int) {
 
 %% Since \code{IntSet} falls in this category, one can alternatively
 %% define it as a trait:
-%% \begin{lstlisting}
-%% trait IntSet {
-%%   def incl(x: Int): IntSet
-%%   def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+trait IntSet {
+  def incl(x: Int): IntSet
+  def contains(x: Int): Boolean
+}
+\end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Implementing Abstract Classes}
 
 %% Let's say, we plan to implement sets as binary trees.  There are two
@@ -2105,45 +2183,49 @@ class Rational(n: Int, d: Int) {
 %% consisting of an integer and two subtrees. Here are their
 %% implementations.
 
-%% \begin{lstlisting}
-%% class EmptySet extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class EmptySet extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
+}
+\end{lstlisting}
 
-%% \begin{lstlisting}
-%% class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: Int): IntSet =
-%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
-%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: Int): IntSet =
+    if (x < elem) new NonEmptySet(elem, left incl x, right)
+    else if (x > elem) new NonEmptySet(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
 %% Both \code{EmptySet} and \code{NonEmptySet} extend class
 %% \code{IntSet}.  This implies that types \code{EmptySet} and
 %% \code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
+%----------
 
+%----------
 %% \begin{exercise} Write methods \code{union} and \code{intersection} to form
 %% the union and intersection between two sets.
 %% \end{exercise}
 
 %% \begin{exercise} Add a method 
-%% \begin{lstlisting}
-%% def excl(x: Int)
-%% \end{lstlisting}
+ \begin{lstlisting}
+ def excl(x: Int)
+ \end{lstlisting}
 %% to return the given set without the element \code{x}. To accomplish this,
 %% it is useful to also implement a test method
-%% \begin{lstlisting}
-%% def isEmpty: Boolean
-%% \end{lstlisting}
+ \begin{lstlisting}
+ def isEmpty: Boolean
+ \end{lstlisting}
 %% for sets.
 %% \end{exercise}
+%----------
 
+%----------
 %% \paragraph{Dynamic Binding}
 
 %% Object-oriented languages (Scala included) use \emph{dynamic dispatch}
@@ -2154,40 +2236,46 @@ class Rational(n: Int, d: Int) {
 %% \code{contains} is executed depends on the type of value of \code{s} at run-time.
 %% If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
 %% This behavior is a direct consequence of our substitution model of evaluation.
+%----------
+
+%----------
 %% For instance,
-%% \begin{lstlisting}
-%%     (new EmptySet).contains(7) 
+\begin{lstlisting}
+    (new EmptySet).contains(7) 
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-%%     false
-%% \end{lstlisting}
-%% Or,
-%% \begin{lstlisting}
-%%     new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
+    false
+\end{lstlisting}
+Ou,
+\begin{lstlisting}
+    new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
 
-%%     if (1 < 7) new EmptySet contains 1
-%%     else if (1 > 7) new EmptySet contains 1
-%%     else true
+    if (1 < 7) new EmptySet contains 1
+    else if (1 > 7) new EmptySet contains 1
+    else true
 
-%% ->  $\rewriteby{by rewriting the conditional}$
+->  $\rewriteby{by rewriting the conditional}$
 
-%%     new EmptySet contains 1
+    new EmptySet contains 1
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-%%     false .
-%% \end{lstlisting}
+    false .
+\end{lstlisting}
+%----------
 
+%----------
 %% Dynamic method dispatch is analogous to higher-order function
 %% calls. In both cases, the identity of code to be executed is known
 %% only at run-time. This similarity is not just superficial. Indeed,
 %% Scala represents every function value as an object (see
 %% Section~\ref{sec:functions}).
+%----------
 
-
+%----------
 %% \paragraph{Objects}
 
 %% In the previous implementation of integer sets, empty sets were
@@ -2195,9 +2283,9 @@ class Rational(n: Int, d: Int) {
 %% an empty set value was required. We could have avoided unnecessary
 %% object creations by defining a value \code{empty} once and then using
 %% this value instead of every occurrence of \code{new EmptySet}. For example:
-%% \begin{lstlisting}
-%% val EmptySetVal = new EmptySet
-%% \end{lstlisting}
+ \begin{lstlisting}
+ val EmptySetVal = new EmptySet
+ \end{lstlisting}
 %% One problem with this approach is that a value definition such as the
 %% one above is not a legal top-level definition in Scala; it has to be
 %% part of another class or object. Also, the definition of class
@@ -2205,12 +2293,15 @@ class Rational(n: Int, d: Int) {
 %% if we are only interested in a single object of this class? A more
 %% direct approach is to use an {\em object definition}. Here is
 %% a more streamlined alternative definition of the empty set:
-%% \begin{lstlisting}
-%% object EmptySet extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+object EmptySet extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% The syntax of an object definition follows the syntax of a class
 %% definition; it has an optional extends clause as well as an optional
 %% body. As is the case for classes, the extends clause defines inherited
@@ -2219,14 +2310,18 @@ class Rational(n: Int, d: Int) {
 %% it is not possible to create other objects with the same structure
 %% using \code{new}.  Therefore, object definitions also lack constructor
 %% parameters, which might be present in class definitions.
+%----------
 
+%----------
 %% Object definitions can appear anywhere in a Scala program; including
 %% at top-level.  Since there is no fixed execution order of top-level
 %% entities in Scala, one might ask exactly when the object defined by an
 %% object definition is created and initialized. The answer is that the
 %% object is created the first time one of its members is accessed. This
 %% strategy is called {\em lazy evaluation}.
+%----------
 
+%----------
 %% \paragraph{Standard Classes}
 
 %% \todo{include picture}
@@ -2235,12 +2330,15 @@ class Rational(n: Int, d: Int) {
 %% in Scala can be regarded as an object.  In fact, even primitive types
 %% such as \code{int} or \code{boolean} are not treated specially. They
 %% are defined as type aliases of Scala classes in module \code{Predef}:
-%% \begin{lstlisting}
-%% type boolean = scala.Boolean
-%% type int = scala.Int
-%% type long = scala.Long
-%% ...
-%% \end{lstlisting}
+\begin{lstlisting}
+type boolean = scala.Boolean
+type int = scala.Int
+type long = scala.Long
+...
+\end{lstlisting}
+%----------
+
+%----------
 %% For efficiency, the compiler usually represents values of type
 %% \code{scala.Int} by 32 bit integers, values of type
 %% \code{scala.Boolean} by Java's booleans, etc.  But it converts these
@@ -2249,142 +2347,164 @@ class Rational(n: Int, d: Int) {
 %% parameter of type \code{AnyRef}.  Hence, the special representation of
 %% primitive values is just an optimization, it does not change the
 %% meaning of a program.
+%----------
 
+%----------
 %% Here is a specification of class \code{Boolean}.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Boolean {
-%%   def && (x: => Boolean): Boolean
-%%   def || (x: => Boolean): Boolean
-%%   def !                 : Boolean
+\begin{lstlisting}
+package scala
+abstract class Boolean {
+  def && (x: => Boolean): Boolean
+  def || (x: => Boolean): Boolean
+  def !                 : Boolean
 
-%%   def == (x: Boolean)   : Boolean
-%%   def != (x: Boolean)   : Boolean
-%%   def <  (x: Boolean)   : Boolean
-%%   def >  (x: Boolean)   : Boolean
-%%   def <= (x: Boolean)   : Boolean
-%%   def >= (x: Boolean)   : Boolean
-%% }
-%% \end{lstlisting}
+  def == (x: Boolean)   : Boolean
+  def != (x: Boolean)   : Boolean
+  def <  (x: Boolean)   : Boolean
+  def >  (x: Boolean)   : Boolean
+  def <= (x: Boolean)   : Boolean
+  def >= (x: Boolean)   : Boolean
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Booleans can be defined using only classes and objects, without
 %% reference to a built-in type of booleans or numbers. A possible
 %% implementation of class \code{Boolean} is given below.  This is not
 %% the actual implementation in the standard Scala library. For
 %% efficiency reasons the standard implementation uses built-in
 %% booleans.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Boolean {
-%%   def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
+\begin{lstlisting}
+package scala
+abstract class Boolean {
+  def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
 
-%%   def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
-%%   def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
-%%   def !                 : Boolean  =  ifThenElse(false, true)
+  def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
+  def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
+  def !                 : Boolean  =  ifThenElse(false, true)
 
-%%   def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
-%%   def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
-%%   def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
-%%   def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
-%%   def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
-%%   def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
-%% }
-%% case object True extends Boolean {
-%%   def ifThenElse(t: => Boolean, e: => Boolean) = t
-%% }
-%% case object False extends Boolean {
-%%   def ifThenElse(t: => Boolean, e: => Boolean) = e
-%% }
-%% \end{lstlisting}
+  def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
+  def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
+  def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
+  def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
+  def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
+  def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
+}
+case object True extends Boolean {
+  def ifThenElse(t: => Boolean, e: => Boolean) = t
+}
+case object False extends Boolean {
+  def ifThenElse(t: => Boolean, e: => Boolean) = e
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Here is a partial specification of class \code{Int}.
 
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Int extends AnyVal {
-%%   def toLong: Long
-%%   def toFloat: Float
-%%   def toDouble: Double
+\begin{lstlisting}
+package scala
+abstract class Int extends AnyVal {
+  def toLong: Long
+  def toFloat: Float
+  def toDouble: Double
 
-%%   def + (that: Double): Double
-%%   def + (that: Float): Float
-%%   def + (that: Long): Long
-%%   def + (that: Int): Int         // analogous for -, *, /, %
+  def + (that: Double): Double
+  def + (that: Float): Float
+  def + (that: Long): Long
+  def + (that: Int): Int         // analogous for -, *, /, %
 
-%%   def << (cnt: Int): Int         // analogous for >>, >>>
+  def << (cnt: Int): Int         // analogous for >>, >>>
 
-%%   def & (that: Long): Long
-%%   def & (that: Int): Int         // analogous for |, ^
+  def & (that: Long): Long
+  def & (that: Int): Int         // analogous for |, ^
 
-%%   def == (that: Double): Boolean
-%%   def == (that: Float): Boolean
-%%   def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
-%% }
-%% \end{lstlisting}
+  def == (that: Double): Boolean
+  def == (that: Float): Boolean
+  def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
+}
+\end{lstlisting}
+%----------
 
+%----------
 %% Class \code{Int} can in principle also be implemented using just
 %% objects and classes, without reference to a built in type of
 %% integers. To see how, we consider a slightly simpler problem, namely
 %% how to implement a type \code{Nat} of natural (i.e. non-negative)
 %% numbers. Here is the definition of an abstract class \code{Nat}:
-%% \begin{lstlisting}
-%% abstract class Nat {
-%%   def isZero: Boolean
-%%   def predecessor: Nat
-%%   def successor: Nat
-%%   def + (that: Nat): Nat
-%%   def - (that: Nat): Nat
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Nat {
+  def isZero: Boolean
+  def predecessor: Nat
+  def successor: Nat
+  def + (that: Nat): Nat
+  def - (that: Nat): Nat
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% To implement the operations of class \code{Nat}, we define a sub-object
 %% \code{Zero} and a subclass \code{Succ} (for successor). Each number
 %% \code{N} is represented as \code{N} applications of the \code{Succ}
 %% constructor to \code{Zero}:
-%% \[
-%% \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
-%% \]
+ \[
+ \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
+ \]
 %% The implementation of the \code{Zero} object is straightforward:
-%% \begin{lstlisting}
-%% object Zero extends Nat {
-%%   def isZero: Boolean = true
-%%   def predecessor: Nat = error("negative number")
-%%   def successor: Nat = new Succ(Zero)
-%%   def + (that: Nat): Nat = that
-%%   def - (that: Nat): Nat = if (that.isZero) Zero
-%%                            else error("negative number")
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+object Zero extends Nat {
+  def isZero: Boolean = true
+  def predecessor: Nat = error("negative number")
+  def successor: Nat = new Succ(Zero)
+  def + (that: Nat): Nat = that
+  def - (that: Nat): Nat = if (that.isZero) Zero
+                           else error("negative number")
+}
+\end{lstlisting}
+%----------
 
+%----------
 %% The implementation of the predecessor and subtraction functions on
 %% \code{Zero} throws an \code{Error} exception, which aborts the program
 %% with the given error message.
 
 %% Here is the implementation of the successor class:
-%% \begin{lstlisting}
-%% class Succ(x: Nat) extends Nat  {
-%%   def isZero: Boolean = false
-%%   def predecessor: Nat = x
-%%   def successor: Nat = new Succ(this)
-%%   def + (that: Nat): Nat = x + that.successor
-%%   def - (that: Nat): Nat = if (that.isZero) this 
-%%                            else x - that.predecessor
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Succ(x: Nat) extends Nat  {
+  def isZero: Boolean = false
+  def predecessor: Nat = x
+  def successor: Nat = new Succ(this)
+  def + (that: Nat): Nat = x + that.successor
+  def - (that: Nat): Nat = if (that.isZero) this 
+                           else x - that.predecessor
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Note the implementation of method \code{successor}. To create the
 %% successor of a number, we need to pass the object itself as an
 %% argument to the \code{Succ} constructor.  The object itself is
 %% referenced by the reserved name \code{this}.   
+%----------
 
+%----------
 %% The implementations of \code{+} and \code{-} each contain a recursive
 %% call with the constructor argument as receiver. The recursion will
 %% terminate once the receiver is the \code{Zero} object (which is
 %% guaranteed to happen eventually because of the way numbers are formed).
+%----------
 
+%----------
 %% \begin{exercise} Write an implementation \code{Integer} of integer numbers
 %% The implementation should support all operations of class \code{Nat}
 %% while adding two methods
-%% \begin{lstlisting}
-%% def isPositive: Boolean
-%% def negate: Integer
-%% \end{lstlisting}
+\begin{lstlisting}
+def isPositive: Boolean
+def negate: Integer
+\end{lstlisting}
 %% The first method should return \code{true} if the number is positive. The second method should negate the number.
 %% Do not use any of Scala's standard numeric classes in your
 %% implementation. (Hint: There are two possible ways to implement
@@ -2394,48 +2514,50 @@ class Rational(n: Int, d: Int) {
 %% \code{Integer}, using the three subclasses \code{Zero} for 0, 
 %% \code{Succ} for positive numbers and \code{Pred} for negative numbers.)
 %% \end{exercise}
+%----------
 
-
-
+%----------
 %% \subsection*{Language Elements Introduced In This Chapter}
 
 %% \textbf{Types:}
-%% \begin{lstlisting}
-%% Type         = ...  |  ident
-%% \end{lstlisting}
+ \begin{lstlisting}
+ Type         = ...  |  ident
+ \end{lstlisting}
 
 %% Types can now be arbitrary identifiers which represent classes.
 
 %% \textbf{Expressions:}
-%% \begin{lstlisting}
-%% Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
-%% \end{lstlisting}
+ \begin{lstlisting}
+ Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
+ \end{lstlisting}
 
 %% An expression can now be an object creation, or
 %% a selection \code{E.m} of a member \code{m}
 %% from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
+%----------
 
+%----------
 %% \textbf{Definitions and Declarations:}
-%% \begin{lstlisting}
-%% Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
-%% ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
-%%                ['extends' Expr] [`{' {TemplateDef} `}']
-%% TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
-%% ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
-%% TemplateDef  = [Modifier] (Def | Dcl)
-%% ObjectDef    = [Modifier] Def
-%% Modifier     = 'private'  |  'override'
-%% Dcl          = FunDcl  |  ValDcl
-%% FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
-%% ValDcl       = 'val' ident ':' Type
-%% \end{lstlisting}
+\begin{lstlisting}
+Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
+ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
+               ['extends' Expr] [`{' {TemplateDef} `}']
+TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
+ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
+TemplateDef  = [Modifier] (Def | Dcl)
+ObjectDef    = [Modifier] Def
+Modifier     = 'private'  |  'override'
+Dcl          = FunDcl  |  ValDcl
+FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
+ValDcl       = 'val' ident ':' Type
+\end{lstlisting}
 
-%% A definition can now be a class, trait or object definition such as
-%% \begin{lstlisting}
-%% class C(params) extends B { defs }
-%% trait T extends B { defs }
-%% object O extends B { defs }
-%% \end{lstlisting}
+%%A definition can now be a class, trait or object definition such as
+\begin{lstlisting}
+class C(params) extends B { defs }
+trait T extends B { defs }
+object O extends B { defs }
+\end{lstlisting}
 %% The definitions \code{defs} in a class, trait or object may be
 %% preceded by modifiers \code{private} or \code{override}.
 
@@ -2443,6 +2565,8 @@ class Rational(n: Int, d: Int) {
 %% introduce {\em deferred} functions or values with their types, but do
 %% not give an implementation. Deferred members have to be implemented in
 %% subclasses before objects of an abstract class or trait can be created.
+%----------
+
 
 %% \chapter{Case Classes and Pattern Matching}
 
@@ -2457,37 +2581,37 @@ class Rational(n: Int, d: Int) {
 %% form it is (either \code{Sum} or \code{Number}) and also needs to
 %% access the components of the expression.  The following
 %% implementation provides all necessary methods.
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def isNumber: Boolean
-%%   def isSum: Boolean
-%%   def numValue: Int
-%%   def leftOp: Expr
-%%   def rightOp: Expr
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def isNumber: Boolean = true
-%%   def isSum: Boolean = false
-%%   def numValue: Int = n
-%%   def leftOp: Expr = error("Number.leftOp")
-%%   def rightOp: Expr = error("Number.rightOp")
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def isNumber: Boolean = false
-%%   def isSum: Boolean = true
-%%   def numValue: Int = error("Sum.numValue")
-%%   def leftOp: Expr = e1
-%%   def rightOp: Expr = e2
-%% }
-%% \end{lstlisting}
-%% With these classification and access methods, writing an evaluator function is simple:
-%% \begin{lstlisting}
-%% def eval(e: Expr): Int = {
-%%   if (e.isNumber) e.numValue
-%%   else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
-%%   else error("unrecognized expression kind")
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Expr {
+  def isNumber: Boolean
+  def isSum: Boolean
+  def numValue: Int
+  def leftOp: Expr
+  def rightOp: Expr
+}
+class Number(n: Int) extends Expr {
+  def isNumber: Boolean = true
+  def isSum: Boolean = false
+  def numValue: Int = n
+  def leftOp: Expr = error("Number.leftOp")
+  def rightOp: Expr = error("Number.rightOp")
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def isNumber: Boolean = false
+  def isSum: Boolean = true
+  def numValue: Int = error("Sum.numValue")
+  def leftOp: Expr = e1
+  def rightOp: Expr = e2
+}
+\end{lstlisting}
+%%With these classification and access methods, writing an evaluator function is simple:
+\begin{lstlisting}
+def eval(e: Expr): Int = {
+  if (e.isNumber) e.numValue
+  else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
+  else error("unrecognized expression kind")
+}
+\end{lstlisting}
 %% However, defining all these methods in classes \code{Sum} and
 %% \code{Number} is rather tedious. Furthermore, the problem becomes worse 
 %% when we want to add new forms of expressions. For instance, consider
@@ -2506,23 +2630,23 @@ class Rational(n: Int, d: Int) {
 %% outside the expression class hierarchy, as we have done
 %% before. Because \code{eval} is now a member of all expression nodes,
 %% all classification and access methods become superfluous, and the implementation is simplified considerably:
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def eval: Int
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def eval: Int = n
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval + e2.eval
-%% }
-%% \end{lstlisting}
-%% Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
-%% \begin{lstlisting}
-%% class Prod(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval * e2.eval
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Expr {
+  def eval: Int
+}
+class Number(n: Int) extends Expr {
+  def eval: Int = n
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval + e2.eval
+}
+\end{lstlisting}
+%%Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
+\begin{lstlisting}
+class Prod(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval * e2.eval
+}
+\end{lstlisting}
 
 %% The conclusion we can draw from this example is that object-oriented
 %% decomposition is the technique of choice for constructing systems that
@@ -2534,41 +2658,41 @@ class Rational(n: Int, d: Int) {
 %% If we have defined all classification and access methods, such an
 %% operation can easily be written as an external function. Here is an
 %% example:
-%% \begin{lstlisting}
-%% def print(e: Expr) {
-%%   if (e.isNumber) Console.print(e.numValue)
-%%   else if (e.isSum) {
-%%     Console.print("(")
-%%     print(e.leftOp)
-%%     Console.print("+")
-%%     print(e.rightOp)
-%%     Console.print(")")
-%%   } else error("unrecognized expression kind")
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def print(e: Expr) {
+  if (e.isNumber) Console.print(e.numValue)
+  else if (e.isSum) {
+    Console.print("(")
+    print(e.leftOp)
+    Console.print("+")
+    print(e.rightOp)
+    Console.print(")")
+  } else error("unrecognized expression kind")
+}
+\end{lstlisting}
 %% However, if we had opted for an object-oriented decomposition of
 %% expressions, we would need to add a new \code{print} procedure
 %% to each class:
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def eval: Int
-%%   def print
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def eval: Int = n
-%%   def print { Console.print(n) }
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval + e2.eval
-%%   def print {
-%%     Console.print("(")
-%%     print(e1)
-%%     Console.print("+")
-%%     print(e2)
-%%     Console.print(")")
-%%   }
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Expr {
+  def eval: Int
+  def print
+}
+class Number(n: Int) extends Expr {
+  def eval: Int = n
+  def print { Console.print(n) }
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval + e2.eval
+  def print {
+    Console.print("(")
+    print(e1)
+    Console.print("+")
+    print(e2)
+    Console.print(")")
+  }
+}
+\end{lstlisting}
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
 
@@ -2595,24 +2719,24 @@ class Rational(n: Int, d: Int) {
 %% {\em Case classes} and {\em case objects} are defined like a normal
 %% classes or objects, except that the definition is prefixed with the modifier
 %% \code{case}.  For instance, the definitions
-%% \begin{lstlisting}
-%% abstract class Expr
-%% case class Number(n: Int) extends Expr
-%% case class Sum(e1: Expr, e2: Expr) extends Expr
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Expr
+case class Number(n: Int) extends Expr
+case class Sum(e1: Expr, e2: Expr) extends Expr
+\end{lstlisting}
 %% introduce \code{Number} and \code{Sum} as case classes.
 %% The \code{case} modifier in front of a class or object 
 %% definition has the following effects.
 %% \begin{enumerate}
 %% \item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
-%% \begin{lstlisting}
-%% def Number(n: Int) = new Number(n)
-%% def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
-%% \end{lstlisting}
-%% would be added. Hence, one can now construct expression trees a bit more concisely, as in
-%% \begin{lstlisting}
-%% Sum(Sum(Number(1), Number(2)), Number(3))
-%% \end{lstlisting} 
+\begin{lstlisting}
+def Number(n: Int) = new Number(n)
+def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
+\end{lstlisting}
+%%would be added. Hence, one can now construct expression trees a bit more concisely, as in
+\begin{lstlisting}
+Sum(Sum(Number(1), Number(2)), Number(3))
+\end{lstlisting} 
 %% \item Case classes and case objects 
 %% implicitly come with implementations of methods
 %% \code{toString}, \code{equals} and \code{hashCode}, which override the
@@ -2620,9 +2744,9 @@ class Rational(n: Int, d: Int) {
 %% of these methods takes in each case the structure of a member of a
 %% case class into account. The \code{toString} method represents an
 %% expression tree the way it was constructed. So,
-%% \begin{lstlisting}
-%% Sum(Sum(Number(1), Number(2)), Number(3))
-%% \end{lstlisting} 
+\begin{lstlisting}
+Sum(Sum(Number(1), Number(2)), Number(3))
+\end{lstlisting} 
 %% would be converted to exactly that string, whereas the default
 %% implementation in class \code{AnyRef} would return a string consisting
 %% of the outermost constructor name \code{Sum} and a number.  The
@@ -2631,9 +2755,9 @@ class Rational(n: Int, d: Int) {
 %% arguments which are themselves pairwise equal. This also affects the
 %% implementation of \code{==} and \code{!=}, which are implemented in
 %% terms of \code{equals} in Scala. So,
-%% \begin{lstlisting}
-%% Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
-%% \end{lstlisting}
+ \begin{lstlisting}
+ Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
+ \end{lstlisting}
 %% will yield \code{true}. If \code{Sum} or \code{Number} were not case
 %% classes, the same expression would be \code{false}, since the standard
 %% implementation of \code{equals} in class \code{AnyRef} always treats
@@ -2646,13 +2770,13 @@ class Rational(n: Int, d: Int) {
 %% Case classes implicitly come with nullary accessor methods which
 %% retrieve the constructor arguments.
 %% In our example, \code{Number} would obtain an accessor method
-%% \begin{lstlisting}
-%% def n: Int
-%% \end{lstlisting}
+ \begin{lstlisting}
+ def n: Int
+ \end{lstlisting}
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
-%% \begin{lstlisting}
-%% def e1: Expr, e2: Expr
-%% \end{lstlisting}
+ \begin{lstlisting}
+ def e1: Expr, e2: Expr
+ \end{lstlisting}
 %% Hence, if for a value \code{s} of type \code{Sum}, say, one can now
 %% write \code{s.e1}, to access the left operand. However, for a value
 %% \code{e} of type \code{Expr}, the term \code{e.e1} would be illegal
@@ -2675,12 +2799,12 @@ class Rational(n: Int, d: Int) {
 %% The \code{match} method takes as argument a number of cases. 
 %% For instance, here is an implementation of \code{eval} using 
 %% pattern matching.
-%% \begin{lstlisting}
-%% def eval(e: Expr): Int = e match {
-%%   case Number(n) => n 
-%%   case Sum(l, r) => eval(l) + eval(r) 
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def eval(e: Expr): Int = e match {
+  case Number(n) => n 
+  case Sum(l, r) => eval(l) + eval(r) 
+}
+\end{lstlisting}
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -2709,9 +2833,9 @@ class Rational(n: Int, d: Int) {
 
 %% \paragraph{Meaning of Pattern Matching}
 %% A pattern matching expression 
-%% \begin{lstlisting}
-%% e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
-%% \end{lstlisting}
+\begin{lstlisting}
+e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
+\end{lstlisting}
 %% matches the patterns $p_1 \commadots p_n$ in the order they
 %% are written against the selector value \code{e}.
 %% \begin{itemize}
@@ -2734,33 +2858,33 @@ class Rational(n: Int, d: Int) {
 %% aborted with a \code{MatchError} exception.
 
 %% \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
-%% \begin{lstlisting}
-%%      eval(Sum(Number(1), Number(2)))
+\begin{lstlisting}
+     eval(Sum(Number(1), Number(2)))
 
-%% ->   $\mbox{\tab\tab\rm(by rewriting the application)}$
+->   $\mbox{\tab\tab\rm(by rewriting the application)}$
 
-%%      Sum(Number(1), Number(2)) match {
-%%          case Number(n) => n
-%%          case Sum(e1, e2) => eval(e1) + eval(e2)
-%%      }
+     Sum(Number(1), Number(2)) match {
+         case Number(n) => n
+         case Sum(e1, e2) => eval(e1) + eval(e2)
+     }
 
-%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
 
-%%      eval(Number(1)) + eval(Number(2))
+     eval(Number(1)) + eval(Number(2))
 
-%% ->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
+->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
 
-%%      Number(1) match {
-%%          case Number(n) => n
-%%          case Sum(e1, e2) => eval(e1) + eval(e2)
-%%      } + eval(Number(2))
+     Number(1) match {
+         case Number(n) => n
+         case Sum(e1, e2) => eval(e1) + eval(e2)
+     } + eval(Number(2))
 
-%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
 
-%%      1 + eval(Number(2))
+     1 + eval(Number(2))
 
-%% ->$^*$ 1 + 2 -> 3
-%% \end{lstlisting}
+->$^*$ 1 + 2 -> 3
+\end{lstlisting}
 
 %% \paragraph{Pattern Matching and Methods}
 %% In the previous example, we have used pattern
@@ -2769,33 +2893,33 @@ class Rational(n: Int, d: Int) {
 %% pattern matching function in that class hierarchy itself. For
 %% instance, we could have defined
 %% \code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
-%% \begin{lstlisting}
-%% abstract class Expr { 
-%%   def eval: Int = this match {
-%%     case Number(n) => n
-%%     case Sum(e1, e2) => e1.eval + e2.eval 
-%%   } 
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Expr { 
+  def eval: Int = this match {
+    case Number(n) => n
+    case Sum(e1, e2) => e1.eval + e2.eval 
+  } 
+}
+\end{lstlisting}
 
 %% \begin{exercise} Consider the following definitions representing trees
 %% of integers.  These definitions can be seen as an alternative
 %% representation of \code{IntSet}:
-%% \begin{lstlisting}
-%% abstract class IntTree
-%% case object EmptyTree extends IntTree
-%% case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class IntTree
+case object EmptyTree extends IntTree
+case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
+\end{lstlisting}
 %% Complete the following implementations of function \code{contains} and \code{insert} for 
 %% \code{IntTree}'s.
-%% \begin{lstlisting}
-%% def contains(t: IntTree, v: Int): Boolean = t match { ...
-%%   ...
-%% }
-%% def insert(t: IntTree, v: Int): IntTree = t match { ...
-%%   ...
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def contains(t: IntTree, v: Int): Boolean = t match { ...
+  ...
+}
+def insert(t: IntTree, v: Int): IntTree = t match { ...
+  ...
+}
+\end{lstlisting}
 %% \end{exercise}
 
 %% \paragraph{Pattern Matching Anonymous Functions}
@@ -2803,17 +2927,17 @@ class Rational(n: Int, d: Int) {
 %% So far, case-expressions always appeared in conjunction with a
 %% \verb@match@ operation. But it is also possible to use
 %% case-expressions by themselves. A block of case-expressions such as
-%% \begin{lstlisting}
-%% { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
-%% \end{lstlisting}
+\begin{lstlisting}
+{ case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
+\end{lstlisting}
 %% is seen by itself as a function which matches its arguments
 %% against the patterns $P_1 \commadots P_n$, and produces the result of
 %% one of $E_1 \commadots E_n$. (If no pattern matches, the function
 %% would throw a \code{MatchError} exception instead).
 %% In other words, the expression above is seen as a shorthand for the anonymous function
-%% \begin{lstlisting}
-%% (x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
-%% \end{lstlisting}
+\begin{lstlisting}
+(x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
+\end{lstlisting}
 %% where \code{x} is a fresh variable which is not used 
 %% otherwise in the expression.
 
@@ -2824,24 +2948,24 @@ class Rational(n: Int, d: Int) {
 %% write a data type of stacks of integers, with methods \code{push},
 %% \code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
 %% following class hierarchy:
-%% \begin{lstlisting}
-%% abstract class IntStack {
-%%   def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
-%%   def isEmpty: Boolean
-%%   def top: Int
-%%   def pop: IntStack
-%% }
-%% class IntEmptyStack extends IntStack {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class IntStack {
+  def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
+  def isEmpty: Boolean
+  def top: Int
+  def pop: IntStack
+}
+class IntEmptyStack extends IntStack {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
 %% Of course, it would also make sense to define an abstraction for a
 %% stack of Strings. To do that, one could take the existing abstraction
 %% for \code{IntStack}, rename it to \code{StringStack} and at the same
@@ -2854,34 +2978,34 @@ class Rational(n: Int, d: Int) {
 %% only for values, but it is available also for types. To arrive at a
 %% {\em generic} version of \code{Stack}, we equip it with a type
 %% parameter.
-%% \begin{lstlisting}
-%% abstract class Stack[A] {
-%%   def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
-%%   def isEmpty: Boolean
-%%   def top: A
-%%   def pop: Stack[A]
-%% }
-%% class EmptyStack[A] extends Stack[A] {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Stack[A] {
+  def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
+  def isEmpty: Boolean
+  def top: A
+  def pop: Stack[A]
+}
+class EmptyStack[A] extends Stack[A] {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
 %% In the definitions above, `\code{A}' is a {\em type parameter} of
 %% class \code{Stack} and its subclasses.  Type parameters are arbitrary
 %% names; they are enclosed in brackets instead of parentheses, so that
 %% they can be easily distinguished from value parameters.  Here is an
 %% example how the generic classes are used:
-%% \begin{lstlisting}
-%% val x = new EmptyStack[Int]
-%% val y = x.push(1).push(2)
-%% println(y.pop.top)
-%% \end{lstlisting}
+\begin{lstlisting}
+val x = new EmptyStack[Int]
+val y = x.push(1).push(2)
+println(y.pop.top)
+\end{lstlisting}
 %% The first line creates a new empty stack of \code{Int}'s. Note the
 %% actual type argument \code{[Int]} which replaces the formal type
 %% parameter \code{A}.
@@ -2889,22 +3013,22 @@ class Rational(n: Int, d: Int) {
 %% It is also possible to parameterize methods with types. As an example,
 %% here is a generic method which determines whether one stack is a
 %% prefix of another.
-%% \begin{lstlisting}
-%% def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
-%%   p.isEmpty ||
-%%   p.top == s.top && isPrefix[A](p.pop, s.pop)
-%% }
-%% \end{lstlisting}  
+\begin{lstlisting}
+def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
+  p.isEmpty ||
+  p.top == s.top && isPrefix[A](p.pop, s.pop)
+}
+\end{lstlisting}  
 %% The method parameters are called {\em polymorphic}.  Generic methods are
 %% also called {\em polymorphic}.  The term comes from the Greek, where it
 %% means ``having many forms''.  To apply a polymorphic method such as
 %% \code{isPrefix}, we pass type parameters as well as value parameters
 %% to it. For instance,
-%% \begin{lstlisting}
-%% val s1 = new EmptyStack[String].push("abc")
-%% val s2 = new EmptyStack[String].push("abx").push(s1.top)
-%% println(isPrefix[String](s1, s2))
-%% \end{lstlisting}
+\begin{lstlisting}
+val s1 = new EmptyStack[String].push("abc")
+val s2 = new EmptyStack[String].push("abx").push(s1.top)
+println(isPrefix[String](s1, s2))
+\end{lstlisting}
 
 %% \paragraph{Local Type Inference}
 %% Passing type parameters such as \code{[Int]} or \code{[String]} all
@@ -2928,12 +3052,12 @@ class Rational(n: Int, d: Int) {
 %% class \code{IntSet} could be generalized to sets with arbitrary
 %% element types. Let's try. The abstract class for generic sets is easily
 %% written.
-%% \begin{lstlisting}
-%% abstract class Set[A] {
-%%   def incl(x: A): Set[A]
-%%   def contains(x: A): Boolean
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Set[A] {
+  def incl(x: A): Set[A]
+  def contains(x: A): Boolean
+}
+\end{lstlisting}
 %% However, if we still want to implement sets as binary search trees, we
 %% encounter a problem. The \code{contains} and \code{incl} methods both
 %% compare elements using methods \code{<} and \code{>}. For
@@ -2941,45 +3065,45 @@ class Rational(n: Int, d: Int) {
 %% methods. But for an arbitrary type parameter \code{a}, we cannot
 %% guarantee this. Therefore, the previous implementation of, say,
 %% \code{contains} would generate a compiler error.
-%% \begin{lstlisting}
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%           ^ < $\mbox{\sl not a member of type}$ A.
-%% \end{lstlisting}
+\begin{lstlisting}
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+          ^ < $\mbox{\sl not a member of type}$ A.
+\end{lstlisting}
 %% One way to solve the problem is to restrict the legal types that can
 %% be substituted for type \code{A} to only those types that contain methods
 %% \code{<} and \code{>} of the correct types. There is a trait
 %% \code{Ordered[A]} in the standard class library Scala which represents
 %% values which are comparable (via \code{<} and \code{>}) to values of
 %% type \code{A}. This trait is defined as follows:
-%% \begin{lstlisting}
-%% /** A class for totally ordered data. */
-%% trait Ordered[A] {
+\begin{lstlisting}
+/** A class for totally ordered data. */
+trait Ordered[A] {
 
-%%   /** Result of comparing `this' with operand `that'.
-%%    *  returns `x' where
-%%    *  x < 0    iff    this < that
-%%    *  x == 0   iff    this == that
-%%    *  x > 0    iff    this > that
-%%    */
-%%   def compare(that: A): Int
+  /** Result of comparing `this' with operand `that'.
+   *  returns `x' where
+   *  x < 0    iff    this < that
+   *  x == 0   iff    this == that
+   *  x > 0    iff    this > that
+   */
+  def compare(that: A): Int
 
-%%   def <  (that: A): Boolean = (this compare that) <  0
-%%   def >  (that: A): Boolean = (this compare that) >  0
-%%   def <= (that: A): Boolean = (this compare that) <= 0
-%%   def >= (that: A): Boolean = (this compare that) >= 0
-%%   def compareTo(that: A): Int = compare(that)
-%% }
-%% \end{lstlisting}
+  def <  (that: A): Boolean = (this compare that) <  0
+  def >  (that: A): Boolean = (this compare that) >  0
+  def <= (that: A): Boolean = (this compare that) <= 0
+  def >= (that: A): Boolean = (this compare that) >= 0
+  def compareTo(that: A): Int = compare(that)
+}
+\end{lstlisting}
 %% We can enforce the comparability of a type by demanding
 %% that the type is a subtype of \code{Ordered}. This is done by giving an
 %% upper bound to the type parameter of \code{Set}:
-%% \begin{lstlisting}
-%% trait Set[A <: Ordered[A]] {
-%%   def incl(x: A): Set[A]
-%%   def contains(x: A): Boolean
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+trait Set[A <: Ordered[A]] {
+  def incl(x: A): Set[A]
+  def contains(x: A): Boolean
+}
+\end{lstlisting}
 %% The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
 %% type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
 %% must be comparable to values of the same type.
@@ -2987,26 +3111,26 @@ class Rational(n: Int, d: Int) {
 %% With this restriction, we can now implement the rest of the generic
 %% set abstraction as we did in the case of \code{IntSet}s before.
 
-%% \begin{lstlisting}
-%% class EmptySet[A <: Ordered[A]] extends Set[A] {
-%%   def contains(x: A): Boolean = false
-%%   def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class EmptySet[A <: Ordered[A]] extends Set[A] {
+  def contains(x: A): Boolean = false
+  def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
+}
+\end{lstlisting}
 
-%% \begin{lstlisting}
-%% class NonEmptySet[A <: Ordered[A]]
-%%         (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
-%%   def contains(x: A): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: A): Set[A] =
-%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
-%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class NonEmptySet[A <: Ordered[A]]
+        (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
+  def contains(x: A): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: A): Set[A] =
+    if (x < elem) new NonEmptySet(elem, left incl x, right)
+    else if (x > elem) new NonEmptySet(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
 %% Note that we have left out the type argument in the object creations
 %% \code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
 %% missing type arguments in constructor calls are inferred from value
@@ -3014,26 +3138,26 @@ class Rational(n: Int, d: Int) {
 
 %% Here is an example that uses the generic set abstraction. Let's first
 %% create a subclass of \lstinline@Ordered@, like this:
-%% \begin{lstlisting}
-%% case class Num(value: Double) extends Ordered[Num] {
-%%   def compare(that: Num): Int =
-%%     if (this.value < that.value) -1
-%%     else if (this.value > that.value) 1
-%%     else 0
-%% }
-%% \end{lstlisting}
-%% Then:
-%% \begin{lstlisting}
-%% val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
-%% s.contains(Num(1.5))
-%% \end{lstlisting}
-%% This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
-%% However, the following example is in error.
-%% \begin{lstlisting}
-%% val s = new EmptySet[java.io.File]
-%%                     ^ java.io.File $\mbox{\sl does not conform to type}$
-%%                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
-%% \end{lstlisting}
+\begin{lstlisting}
+case class Num(value: Double) extends Ordered[Num] {
+  def compare(that: Num): Int =
+    if (this.value < that.value) -1
+    else if (this.value > that.value) 1
+    else 0
+}
+\end{lstlisting}
+%%Then:
+\begin{lstlisting}
+val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
+s.contains(Num(1.5))
+\end{lstlisting}
+%%This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
+%%However, the following example is in error.
+\begin{lstlisting}
+val s = new EmptySet[java.io.File]
+                    ^ java.io.File $\mbox{\sl does not conform to type}$
+                      $\mbox{\sl parameter bound}$ Ordered[java.io.File].
+\end{lstlisting}
 %% One probem with type parameter bounds is that they require
 %% forethought: if we had not declared \lstinline@Num@ a subclass of
 %% \lstinline@Ordered@, we would not have been able to use \lstinline@Num@
@@ -3046,11 +3170,11 @@ class Rational(n: Int, d: Int) {
 %% {\em view bounds} instead of the plain type bounds we have seen so
 %% far. The only change this entails in the example above is in the type
 %% parameters:
-%% \begin{lstlisting}
-%% trait Set[A <% Ordered[A]] ...
-%% class EmptySet[A <% Ordered[A]] ...
-%% class NonEmptySet[A <% Ordered[A]] ...
-%% \end{lstlisting}
+\begin{lstlisting}
+trait Set[A <% Ordered[A]] ...
+class EmptySet[A <% Ordered[A]] ...
+class NonEmptySet[A <% Ordered[A]] ...
+\end{lstlisting}
 %% View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
 %% A view bounded type parameter clause \lstinline@[A <% T]@ only
 %% specifies that the bounded type \lstinline@A@ must be {\em convertible} to
@@ -3077,9 +3201,9 @@ class Rational(n: Int, d: Int) {
 %% types would never be in a subtype relation. However, we can enforce
 %% co-variant subtyping of stacks by changing the first line of the
 %% definition of class \code{Stack} as follows.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%% \end{lstlisting}
+\begin{lstlisting}
+class Stack[+A] {
+\end{lstlisting}
 %% Prefixing a formal type parameter with a \code{+} indicates that
 %% subtyping is covariant in that parameter. 
 %% Besides \code{+}, there is also a prefix \code{-} which indicates
@@ -3093,12 +3217,12 @@ class Rational(n: Int, d: Int) {
 %% case of arrays in Java or .NET. Such arrays are represented in Scala
 %% by a generic class \code{Array}. Here is a partial definition of this
 %% class.
-%% \begin{lstlisting}
-%% class Array[A] {
-%%   def apply(index: Int): A
-%%   def update(index: Int, elem: A)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Array[A] {
+  def apply(index: Int): A
+  def update(index: Int, elem: A)
+}
+\end{lstlisting}
 %% The class above defines the way Scala arrays are seen from Scala user
 %% programs. The Scala compiler will map this abstraction to the
 %% underlying arrays of the host system in most cases where this
@@ -3109,12 +3233,12 @@ class Rational(n: Int, d: Int) {
 %% \code{Array[T]} is a subtype of \code{Array[S]}. This might seem
 %% natural but leads to safety problems that require special runtime
 %% checks. Here is an example:
-%% \begin{lstlisting}
-%% val x = new Array[String](1)
-%% val y: Array[Any] = x
-%% y(0) = new Rational(1, 2)  // this is syntactic sugar for
-%%                            // y.update(0, new Rational(1, 2))
-%% \end{lstlisting}
+\begin{lstlisting}
+val x = new Array[String](1)
+val y: Array[Any] = x
+y(0) = new Rational(1, 2)  // this is syntactic sugar for
+                           // y.update(0, new Rational(1, 2))
+\end{lstlisting}
 %% In the first line, a new array of strings is created. In the second
 %% line, this array is bound to a variable \code{y}, of type
 %% \code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
@@ -3144,14 +3268,14 @@ class Rational(n: Int, d: Int) {
 %% methods in the class, and type arguments to other covariant types. Not
 %% co-variant are types of formal method parameters. Hence, the following
 %% class definition would have been rejected
-%% \begin{lstlisting}
-%% class Array[+A] {
-%%   def apply(index: Int): A
-%%   def update(index: Int, elem: A)
-%%                                ^ $\mbox{\sl covariant type parameter}$ A
-%%                                  $\mbox{\sl appears in contravariant position.}$
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class Array[+A] {
+  def apply(index: Int): A
+  def update(index: Int, elem: A)
+                               ^ $\mbox{\sl covariant type parameter}$ A
+                                 $\mbox{\sl appears in contravariant position.}$
+}
+\end{lstlisting}
 %% So far, so good. Intuitively, the compiler was correct in rejecting
 %% the \code{update} procedure in a co-variant class because \code{update}
 %% potentially changes state, and therefore undermines the soundness of
@@ -3161,12 +3285,12 @@ class Rational(n: Int, d: Int) {
 %% type parameter still appears contra-variantly. An example is
 %% \code{push} in type \code{Stack}. Again the Scala compiler will reject
 %% the definition of this method for co-variant stacks.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%%   def push(x: A): Stack[A] =
-%%               ^ $\mbox{\sl covariant type parameter}$ A
-%%                 $\mbox{\sl appears in contravariant position.}$
-%% \end{lstlisting}
+\begin{lstlisting}
+class Stack[+A] {
+  def push(x: A): Stack[A] =
+              ^ $\mbox{\sl covariant type parameter}$ A
+                $\mbox{\sl appears in contravariant position.}$
+\end{lstlisting}
 %% This is a pity, because, unlike arrays, stacks are purely functional data
 %% structures and therefore should enable co-variant subtyping. However,
 %% there is a a way to solve the problem by using a polymorphic method
@@ -3184,10 +3308,10 @@ class Rational(n: Int, d: Int) {
 
 %% Using lower bounds, we can generalize the \code{push} method in
 %% \code{Stack} as follows.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-%% \end{lstlisting}
+\begin{lstlisting}
+class Stack[+A] {
+  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+\end{lstlisting}
 %% Technically, this solves our variance problem since now the type
 %% parameter \code{A} appears no longer as a parameter type of method
 %% \code{push}. Instead, it appears as lower bound for another type
@@ -3216,9 +3340,9 @@ class Rational(n: Int, d: Int) {
 %% why we originally defined a generic class \code{EmptyStack[A]}, even
 %% though a single value denoting empty stacks of arbitrary type would
 %% do. For co-variant stacks, however, one can use the following idiom:
-%% \begin{lstlisting}
-%% object EmptyStack extends Stack[Nothing] { ... }
-%% \end{lstlisting}
+\begin{lstlisting}
+object EmptyStack extends Stack[Nothing] { ... }
+\end{lstlisting}
 %% The bottom type \code{Nothing} contains no value, so the type
 %% \code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
 %% contains no elements. Furthermore, \code{Nothing} is a subtype of all
@@ -3226,22 +3350,22 @@ class Rational(n: Int, d: Int) {
 %% subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
 %% possible to use a single empty stack object in user code. For
 %% instance:
-%% \begin{lstlisting}
-%% val s = EmptyStack.push("abc").push(new AnyRef())
-%% \end{lstlisting}
-%% Let's analyze the type assignment for this expression in detail.  The
-%% \code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
-%% method
-%% \begin{lstlisting}
-%% push[B >: Nothing](elem: B): Stack[B] .
-%% \end{lstlisting}
+\begin{lstlisting}
+val s = EmptyStack.push("abc").push(new AnyRef())
+\end{lstlisting}
+%%Let's analyze the type assignment for this expression in detail.  The
+%%\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
+%%method
+\begin{lstlisting}
+push[B >: Nothing](elem: B): Stack[B] .
+\end{lstlisting}
 %% Local type inference will determine that the type parameter \code{B}
 %% should be instantiated to \code{String} in the application 
 %% \code{EmptyStack.push("abc")}. The result type of that application is hence
 %% \code{Stack[String]}, which in turn has a method
-%% \begin{lstlisting}
-%% push[B >: String](elem: B): Stack[B] .
-%% \end{lstlisting}
+\begin{lstlisting}
+push[B >: String](elem: B): Stack[B] .
+\end{lstlisting}
 %% The final part of the value definition above is the application of
 %% this method to \code{new AnyRef()}. Local type inference will
 %% determine that the type parameter \code{b} should this time be
@@ -3259,24 +3383,24 @@ class Rational(n: Int, d: Int) {
 %% stacks. Stacks have now co-variant subtyping, the \code{push} method
 %% has been generalized, and the empty stack is represented by a single
 %% object.
-%% \begin{lstlisting}
-%% abstract class Stack[+A] {
-%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-%%   def isEmpty: Boolean
-%%   def top: A
-%%   def pop: Stack[A]
-%% }
-%% object EmptyStack extends Stack[Nothing] {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class Stack[+A] {
+  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+  def isEmpty: Boolean
+  def top: A
+  def pop: Stack[A]
+}
+object EmptyStack extends Stack[Nothing] {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
 %% Many classes in the Scala library are generic. We now present two
 %% commonly used families of generic classes, tuples and functions. The
 %% discussion of another common class, lists, is deferred to the next
@@ -3288,21 +3412,21 @@ class Rational(n: Int, d: Int) {
 %% instance, take the function \code{divmod} which returns the integer quotient
 %% and rest of two given integer arguments.  Of course, one can define a
 %% class to hold the two results of \code{divmod}, as in:
-%% \begin{lstlisting}
-%% case class TwoInts(first: Int, second: Int)
-%% def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
-%% \end{lstlisting}
+\begin{lstlisting}
+case class TwoInts(first: Int, second: Int)
+def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
+\end{lstlisting}
 %% However, having to define a new class for every possible pair of
 %% result types is very tedious. In Scala one can use instead a
 %% generic class \lstinline@Tuple$2$@, which is defined as follows:
-%% \begin{lstlisting}
-%% package scala
-%% case class Tuple2[A, B](_1: A, _2: B)
-%% \end{lstlisting}
-%% With \code{Tuple2}, the \code{divmod} method can be written as follows.
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
-%% \end{lstlisting}
+\begin{lstlisting}
+package scala
+case class Tuple2[A, B](_1: A, _2: B)
+\end{lstlisting}
+%%With \code{Tuple2}, the \code{divmod} method can be written as follows.
+\begin{lstlisting}
+def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
+\end{lstlisting}
 %% As usual, type parameters to constructors can be omitted if they are
 %% deducible from value arguments. There exist also tuple classes for
 %% every other number of elements (the current Scala implementation
@@ -3312,24 +3436,24 @@ class Rational(n: Int, d: Int) {
 %% Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
 %% \code{Triple} for \code{Tuple3}).  With these conventions,
 %% \code{divmod} can equivalently be written as follows.
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
-%% \end{lstlisting}
+\begin{lstlisting}
+def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
+\end{lstlisting}
 %% }
 %% How are elements of tuples accessed? Since tuples are case classes,
 %% there are two possibilities. One can either access a tuple's fields
 %% using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
-%% \begin{lstlisting}
-%% val xy = divmod(x, y)
-%% println("quotient: " + xy._1 + ", rest: " + xy._2)
-%% \end{lstlisting}
+\begin{lstlisting}
+val xy = divmod(x, y)
+println("quotient: " + xy._1 + ", rest: " + xy._2)
+\end{lstlisting}
 %% Or one uses pattern matching on tuples, as in the following example:
-%% \begin{lstlisting}
-%% divmod(x, y) match {
-%%   case Tuple2(n, d) =>
-%%     println("quotient: " + n + ", rest: " + d)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+divmod(x, y) match {
+  case Tuple2(n, d) =>
+    println("quotient: " + n + ", rest: " + d)
+}
+\end{lstlisting}
 %% Note that type parameters are never used in patterns; it would have
 %% been illegal to write case \code{Tuple2[Int, Int](n, d)}.
 
@@ -3339,12 +3463,12 @@ class Rational(n: Int, d: Int) {
 %% \lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
 %% equivalently for types and for patterns. With that tuple syntax, the
 %% \lstinline@divmod@ example is written as follows:
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
-%% divmod(x, y) match {
-%%   case (n, d) => println("quotient: " + n + ", rest: " + d)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
+divmod(x, y) match {
+  case (n, d) => println("quotient: " + n + ", rest: " + d)
+}
+\end{lstlisting}
 %% \section{Functions}\label{sec:functions}
 
 %% Scala is a functional language in that functions are first-class
@@ -3353,12 +3477,12 @@ class Rational(n: Int, d: Int) {
 %% instance, a function from type \code{String} to type \code{Int} is
 %% represented as an instance of the trait \code{Function1[String, Int]}.
 %% The \code{Function1} trait is defined as follows.
-%% \begin{lstlisting}
-%% package scala
-%% trait Function1[-A, +B] {
-%%   def apply(x: A): B
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+package scala
+trait Function1[-A, +B] {
+  def apply(x: A): B
+}
+\end{lstlisting}
 %% Besides \code{Function1}, there are also definitions of for functions
 %% of all other arities (the current implementation implements this only
 %% up to a reasonable limit).  That is, there is one definition for each
@@ -3381,11 +3505,11 @@ class Rational(n: Int, d: Int) {
 
 %% Functions are an example where a contra-variant type parameter
 %% declaration is useful. For example, consider the following code:
-%% \begin{lstlisting}
-%% val f: (AnyRef => Int)  =  x => x.hashCode()
-%% val g: (String => Int)  =  f
-%% g("abc")
-%% \end{lstlisting}
+\begin{lstlisting}
+val f: (AnyRef => Int)  =  x => x.hashCode()
+val g: (String => Int)  =  f
+g("abc")
+\end{lstlisting}
 %% It's sound to bind the value \code{g} of type \code{String => Int} to
 %% \code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
 %% do with function of type \code{String => Int} is pass it a string in
@@ -3397,43 +3521,43 @@ class Rational(n: Int, d: Int) {
 %% $S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
 
 %% \example Consider the Scala code
-%% \begin{lstlisting}
-%% val plus1: (Int => Int)  =  (x: Int) => x + 1
-%% plus1(2)
-%% \end{lstlisting}
-%% This is expanded into the following object code.
-%% \begin{lstlisting}
-%% val plus1: Function1[Int, Int] = new Function1[Int, Int] {
-%%   def apply(x: Int): Int = x + 1
-%% }
-%% plus1.apply(2)
-%% \end{lstlisting}
+\begin{lstlisting}
+val plus1: (Int => Int)  =  (x: Int) => x + 1
+plus1(2)
+\end{lstlisting}
+%%This is expanded into the following object code.
+\begin{lstlisting}
+val plus1: Function1[Int, Int] = new Function1[Int, Int] {
+  def apply(x: Int): Int = x + 1
+}
+plus1.apply(2)
+\end{lstlisting}
 %% Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
 %% represents an instance of an {\em anonymous class}. It combines the
 %% creation of a new \code{Function1} object with an implementation of 
 %% the \code{apply} method (which is abstract in \code{Function1}).
 %% Equivalently, but more verbosely, one could have used a local class:
-%% \begin{lstlisting}
-%% val plus1: Function1[Int, Int] = {
-%%   class Local extends Function1[Int, Int] {
-%%     def apply(x: Int): Int = x + 1
-%%   }
-%%   new Local: Function1[Int, Int]
-%% }
-%% plus1.apply(2)
-%% \end{lstlisting}
+\begin{lstlisting}
+val plus1: Function1[Int, Int] = {
+  class Local extends Function1[Int, Int] {
+    def apply(x: Int): Int = x + 1
+  }
+  new Local: Function1[Int, Int]
+}
+plus1.apply(2)
+\end{lstlisting}
  
 %% \chapter{Lists}
 
 %% Lists are an important data structure in many Scala programs.  
 %% A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
 %% \code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
-%% \begin{lstlisting}
-%% val fruit = List("apples", "oranges", "pears")
-%% val nums  = List(1, 2, 3, 4)
-%% val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-%% val empty = List()
-%% \end{lstlisting}
+\begin{lstlisting}
+val fruit = List("apples", "oranges", "pears")
+val nums  = List(1, 2, 3, 4)
+val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+val empty = List()
+\end{lstlisting}
 %% Lists are similar to arrays in languages such as C or Java, but there
 %% are also three important differences. First, lists are immutable. That
 %% is, elements of a list cannot be changed by assignment. Second, 
@@ -3446,12 +3570,12 @@ class Rational(n: Int, d: Int) {
 %% Like arrays, lists are {\em homogeneous}. That is, the elements of a
 %% list all have the same type.  The type of a list with elements of type
 %% \code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
-%% \begin{lstlisting}
-%% val fruit: List[String]    = List("apples", "oranges", "pears")
-%% val nums : List[Int]       = List(1, 2, 3, 4)
-%% val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-%% val empty: List[Int]       = List()
-%% \end{lstlisting}
+\begin{lstlisting}
+val fruit: List[String]    = List("apples", "oranges", "pears")
+val nums : List[Int]       = List(1, 2, 3, 4)
+val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+val empty: List[Int]       = List()
+\end{lstlisting}
 
 %% \paragraph{List constructors}
 %% All lists are built from two more fundamental constructors, \code{Nil}
@@ -3461,21 +3585,21 @@ class Rational(n: Int, d: Int) {
 %% which is followed by (the elements of) list \code{xs}.  Hence, the
 %% list values above could also have been defined as follows (in fact
 %% their previous definition is simply syntactic sugar for the definitions below).
-%% \begin{lstlisting}
-%% val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
-%% val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
-%% val diag3  = (1 :: (0 :: (0 :: Nil))) ::
-%%              (0 :: (1 :: (0 :: Nil))) ::
-%%              (0 :: (0 :: (1 :: Nil))) :: Nil
-%% val empty  = Nil
-%% \end{lstlisting}
+\begin{lstlisting}
+val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
+val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
+val diag3  = (1 :: (0 :: (0 :: Nil))) ::
+             (0 :: (1 :: (0 :: Nil))) ::
+             (0 :: (0 :: (1 :: Nil))) :: Nil
+val empty  = Nil
+\end{lstlisting}
 %% The `\code{::}' operation associates to the right: \code{A :: B :: C} is
 %% interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
 %% parentheses in the definitions above. For instance, we can write
 %% shorter
-%% \begin{lstlisting}
-%% val nums  =  1 :: 2 :: 3 :: 4 :: Nil
-%% \end{lstlisting}
+\begin{lstlisting}
+val nums  =  1 :: 2 :: 3 :: 4 :: Nil
+\end{lstlisting}
 
 %% \paragraph{Basic operations on lists}
 %% All operations on lists can be expressed in terms of the following three:
@@ -3489,13 +3613,13 @@ class Rational(n: Int, d: Int) {
 
 %% These operations are defined as methods of list objects. So we invoke
 %% them by selecting from the list that's operated on. Examples:
-%% \begin{lstlisting}
-%% empty.isEmpty   = true
-%% fruit.isEmpty   = false
-%% fruit.head      = "apples"
-%% fruit.tail.head = "oranges"
-%% diag3.head      = List(1, 0, 0)
-%% \end{lstlisting}
+\begin{lstlisting}
+empty.isEmpty   = true
+fruit.isEmpty   = false
+fruit.head      = "apples"
+fruit.tail.head = "oranges"
+diag3.head      = List(1, 0, 0)
+\end{lstlisting}
 %% The \code{head} and \code{tail} methods are defined only for non-empty
 %% lists.  When selected from an empty list, they throw an exception.
 
@@ -3506,11 +3630,11 @@ class Rational(n: Int, d: Int) {
 %% the remainder \code{xs} and insert the element \code{x} at the right
 %% position in the result. Sorting an empty list will yield the
 %% empty list. Expressed as Scala code:
-%% \begin{lstlisting}
-%% def isort(xs: List[Int]): List[Int] =
-%%   if (xs.isEmpty) Nil
-%%   else insert(xs.head, isort(xs.tail))
-%% \end{lstlisting}
+\begin{lstlisting}
+def isort(xs: List[Int]): List[Int] =
+  if (xs.isEmpty) Nil
+  else insert(xs.head, isort(xs.tail))
+\end{lstlisting}
 
 %% \begin{exercise} Provide an implementation of the missing function
 %% \code{insert}.
@@ -3521,19 +3645,19 @@ class Rational(n: Int, d: Int) {
 %% lists by pattern matching, using patterns composed from the \code{Nil}
 %% and \code{::} constructors. For instance, \code{isort} can be written
 %% alternatively as follows.
-%% \begin{lstlisting}
-%% def isort(xs: List[Int]): List[Int] = xs match {
-%%   case List() => List()
-%%   case x :: xs1 => insert(x, isort(xs1))
-%% }
-%% \end{lstlisting}
-%% where
-%% \begin{lstlisting}
-%% def insert(x: Int, xs: List[Int]): List[Int] = xs match {
-%%   case List() => List(x)
-%%   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def isort(xs: List[Int]): List[Int] = xs match {
+  case List() => List()
+  case x :: xs1 => insert(x, isort(xs1))
+}
+\end{lstlisting}
+onde
+\begin{lstlisting}
+def insert(x: Int, xs: List[Int]): List[Int] = xs match {
+  case List() => List(x)
+  case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
+}
+\end{lstlisting}
 
 %% \section{Definition of class List I: First Order Methods}
 %% \label{sec:list-first-order}
@@ -3541,10 +3665,10 @@ class Rational(n: Int, d: Int) {
 %% Lists are not built in in Scala; they are defined by an abstract class
 %% \code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
 %% In the following we present a tour through class \code{List}.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class List[+A] {
-%% \end{lstlisting}
+\begin{lstlisting}
+package scala
+abstract class List[+A] {
+\end{lstlisting}
 %% \code{List} is an abstract class, so one cannot define elements by
 %% calling the empty \code{List} constructor (e.g. by
 %% \code{new List}).  The class has a type parameter \code{a}. It is
@@ -3560,62 +3684,62 @@ class Rational(n: Int, d: Int) {
 %% First, there are the three basic methods \code{isEmpty},
 %% \code{head}, \code{tail}. Their implementation in terms of pattern
 %% matching is straightforward:
-%% \begin{lstlisting}
-%% def isEmpty: Boolean = this match {
-%%   case Nil => true
-%%   case x :: xs => false
-%% }
-%% def head: A = this match {
-%%   case Nil => error("Nil.head")
-%%   case x :: xs => x
-%% }
-%% def tail: List[A] = this match {
-%%   case Nil => error("Nil.tail")
-%%   case x :: xs => xs
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def isEmpty: Boolean = this match {
+  case Nil => true
+  case x :: xs => false
+}
+def head: A = this match {
+  case Nil => error("Nil.head")
+  case x :: xs => x
+}
+def tail: List[A] = this match {
+  case Nil => error("Nil.tail")
+  case x :: xs => xs
+}
+\end{lstlisting}
 
-%% The next function computes the length of a list.
-%% \begin{lstlisting}
-%% def length: Int = this match {
-%%   case Nil => 0
-%%   case x :: xs => 1 + xs.length
-%% }
-%% \end{lstlisting}
+%%The next function computes the length of a list.
+\begin{lstlisting}
+def length: Int = this match {
+  case Nil => 0
+  case x :: xs => 1 + xs.length
+}
+\end{lstlisting}
 %% \begin{exercise} Design a tail-recursive version of \code{length}.
 %% \end{exercise}
 
 %% The next two functions are the complements of \code{head} and
 %% \code{tail}.
-%% \begin{lstlisting}
-%% def last: A
-%% def init: List[A]
-%% \end{lstlisting}
+\begin{lstlisting}
+def last: A
+def init: List[A]
+\end{lstlisting}
 %% \code{xs.last} returns the last element of list \code{xs}, whereas
 %% \code{xs.init} returns all elements of \code{xs} except the last.
 %% Both functions have to traverse the entire list, and are thus less
 %% efficient than their \code{head} and \code{tail} analogues.
 %% Here is the implementation of \code{last}.
-%% \begin{lstlisting}
-%% def last: A = this match {
-%%   case Nil      => error("Nil.last")
-%%   case x :: Nil => x
-%%   case x :: xs  => xs.last
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def last: A = this match {
+  case Nil      => error("Nil.last")
+  case x :: Nil => x
+  case x :: xs  => xs.last
+}
+\end{lstlisting}
 %% The implementation of \code{init} is analogous.
 
 %% The next three functions return a prefix of the list, or a suffix, or
 %% both.
-%% \begin{lstlisting}
-%% def take(n: Int): List[A] =
-%%   if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
+\begin{lstlisting}
+def take(n: Int): List[A] =
+  if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
 
-%% def drop(n: Int): List[A] =
-%%   if (n == 0 || isEmpty) this else tail.drop(n-1)
+def drop(n: Int): List[A] =
+  if (n == 0 || isEmpty) this else tail.drop(n-1)
 
-%% def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
-%% \end{lstlisting}
+def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
+\end{lstlisting}
 %% \code{(xs take n)} returns the first \code{n} elements of list
 %% \code{xs}, or the whole list, if its length is smaller than \code{n}.
 %% \code{(xs drop n)} returns all elements of \code{xs} except the
@@ -3625,9 +3749,9 @@ class Rational(n: Int, d: Int) {
 
 %% The next function returns an element at a given index in a list.
 %% It is thus analogous to array subscripting. Indices start at 0.
-%% \begin{lstlisting}
-%% def apply(n: Int): A = drop(n).head
-%% \end{lstlisting}
+\begin{lstlisting}
+def apply(n: Int): A = drop(n).head
+\end{lstlisting}
 %% The \code{apply} method has a special meaning in Scala. An object with
 %% an \code{apply} method can be applied to arguments as if it was a
 %% function. For instance, to pick the 3'rd element of a list \code{xs},
@@ -3638,26 +3762,26 @@ class Rational(n: Int, d: Int) {
 %% of consecutive elements of the original list.  To extract the sublist
 %% $xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
 
-%% \begin{lstlisting}
-%% xs.drop(m).take(n - m)
-%% \end{lstlisting}
+\begin{lstlisting}
+xs.drop(m).take(n - m)
+\end{lstlisting}
 
-%% \paragraph{Zipping lists} The next function combines two lists into a list of pairs.
-%% Given two lists
-%% \begin{lstlisting}
-%% xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
-%% ys = List(y$_1$, ..., y$_n$)   ,
-%% \end{lstlisting}
+%%\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
+%%Given two lists
+\begin{lstlisting}
+xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
+ys = List(y$_1$, ..., y$_n$)   ,
+\end{lstlisting}
 %% \code{xs zip ys} constructs the list
 %% \lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
 %% If the two lists have different lengths, the longer one of the two is
 %% truncated. Here is the definition of \code{zip} -- note that it is a
 %% polymorphic method.
-%% \begin{lstlisting}
-%% def zip[B](that: List[B]): List[(a,b)] =
-%%   if (this.isEmpty || that.isEmpty) Nil
-%%   else (this.head, that.head) :: (this.tail zip that.tail)
-%% \end{lstlisting}
+\begin{lstlisting}
+def zip[B](that: List[B]): List[(a,b)] =
+  if (this.isEmpty || that.isEmpty) Nil
+  else (this.head, that.head) :: (this.tail zip that.tail)
+\end{lstlisting}
 
 %% \paragraph{Consing lists.}
 %% Like any infix operator, \code{::}
@@ -3665,9 +3789,9 @@ class Rational(n: Int, d: Int) {
 %% is the list that is extended. This is possible, because operators
 %% ending with a `\code{:}' character are treated specially in Scala.  
 %% All such operators are treated as methods of their right operand. E.g.,
-%% \begin{lstlisting}
-%%     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
-%% \end{lstlisting}
+\begin{lstlisting}
+    x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
+\end{lstlisting}
 %% Note, however, that operands of a binary operation are in each case
 %% evaluated from left to right.  So, if \code{D} and \code{E} are
 %% expressions with possible side-effects, \code{D :: E} is translated to
@@ -3678,14 +3802,14 @@ class Rational(n: Int, d: Int) {
 %% operators concerns their associativity.  Operators ending in
 %% `\code{:}' are right-associative, whereas other operators are
 %% left-associative.  E.g.,
-%% \begin{lstlisting}
-%%     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
-%% \end{lstlisting}
-%% The definition of \code{::} as a method in
-%% class \code{List} is as follows:
-%% \begin{lstlisting}
-%% def ::[B >: A](x: B): List[B] = new scala.::(x, this)
-%% \end{lstlisting}
+\begin{lstlisting}
+    x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
+\end{lstlisting}
+%%The definition of \code{::} as a method in
+%%class \code{List} is as follows:
+\begin{lstlisting}
+def ::[B >: A](x: B): List[B] = new scala.::(x, this)
+\end{lstlisting}
 %% Note that \code{::} is defined for all elements \code{x} of type
 %% \code{B} and lists of type \code{List[A]} such that the type \code{B}
 %% of \code{x} is a supertype of the list's element type \code{A}. The result
@@ -3699,35 +3823,35 @@ class Rational(n: Int, d: Int) {
 %% all elements of \code{xs}, followed by all elements of \code{ys}.
 %% Because it ends in a colon, \code{:::} is right-associative and is
 %% considered as a method of its right-hand operand. Therefore,
-%% \begin{lstlisting}
-%% xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
-%%                   =   zs.:::(ys).:::(xs)
-%% \end{lstlisting}
-%% Here is the implementation of the \code{:::} method:
-%% \begin{lstlisting}
-%%   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
-%%     case Nil => this
-%%     case p :: ps => this.:::(ps).::(p)
-%%   }
-%% \end{lstlisting}
+\begin{lstlisting}
+xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
+                  =   zs.:::(ys).:::(xs)
+\end{lstlisting}
+%%Here is the implementation of the \code{:::} method:
+\begin{lstlisting}
+  def :::[B >: A](prefix: List[B]): List[B] = prefix match {
+    case Nil => this
+    case p :: ps => this.:::(ps).::(p)
+  }
+\end{lstlisting}
 
 %% \paragraph{Reversing lists} Another useful operation
 %% is list reversal. There is a method \code{reverse} in \code{List} to
 %% that effect. Let's try to give its implementation:
-%% \begin{lstlisting}
-%% def reverse[A](xs: List[A]): List[A] = xs match {
-%%   case Nil => Nil
-%%   case x :: xs => reverse(xs) ::: List(x)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def reverse[A](xs: List[A]): List[A] = xs match {
+  case Nil => Nil
+  case x :: xs => reverse(xs) ::: List(x)
+}
+\end{lstlisting}
 %% This implementation has the advantage of being simple, but it is not
 %% very efficient.  Indeed, one concatenation is executed for every
 %% element in the list. List concatenation takes time proportional to the
 %% length of its first operand. Therefore, the complexity of
 %% \code{reverse(xs)} is
-%% \[
-%% n + (n - 1) + ... + 1 = n(n+1)/2
-%% \]
+\[
+n + (n - 1) + ... + 1 = n(n+1)/2
+\]
 %% where $n$ is the length of \code{xs}. Can \code{reverse} be
 %% implemented more efficiently? We will see later that there exists
 %% another implementation which has only linear complexity.
@@ -3753,18 +3877,18 @@ class Rational(n: Int, d: Int) {
 %% used for the comparison of elements. We obtain a function of maximal
 %% generality by passing these two items as parameters. This leads to the
 %% following implementation.
-%% \begin{lstlisting}
-%% def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
-%%   def merge(xs1: List[A], xs2: List[A]): List[A] =
-%%     if (xs1.isEmpty) xs2
-%%     else if (xs2.isEmpty) xs1
-%%     else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
-%%     else xs2.head :: merge(xs1, xs2.tail)
-%%   val n = xs.length/2
-%%   if (n == 0) xs
-%%   else merge(msort(less)(xs take n), msort(less)(xs drop n))
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
+  def merge(xs1: List[A], xs2: List[A]): List[A] =
+    if (xs1.isEmpty) xs2
+    else if (xs2.isEmpty) xs1
+    else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
+    else xs2.head :: merge(xs1, xs2.tail)
+  val n = xs.length/2
+  if (n == 0) xs
+  else merge(msort(less)(xs take n), msort(less)(xs drop n))
+}
+\end{lstlisting}
 %% The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
 %% length of the input list. To see why, note that splitting a list in
 %% two and merging two sorted lists each take time proportional to the
@@ -3783,16 +3907,16 @@ class Rational(n: Int, d: Int) {
 %% sorting lists.
 
 %% Here is an example how \code{msort} is used.
-%% \begin{lstlisting}
-%% msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
-%% \end{lstlisting}
-%% The definition of \code{msort} is curried, to make it easy to specialize it with particular
-%% comparison functions. For instance,
-%% \begin{lstlisting}
+\begin{lstlisting}
+msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
+\end{lstlisting}
+%%The definition of \code{msort} is curried, to make it easy to specialize it with particular
+%%comparison functions. For instance,
+\begin{lstlisting}
 
-%% val intSort = msort((x: Int, y: Int) => x < y)
-%% val reverseSort = msort((x: Int, y: Int) => x > y)
-%% \end{lstlisting}
+val intSort = msort((x: Int, y: Int) => x < y)
+val reverseSort = msort((x: Int, y: Int) => x > y)
+\end{lstlisting}
 
 %% \section{Definition of class List II: Higher-Order Methods}
 
@@ -3813,89 +3937,90 @@ class Rational(n: Int, d: Int) {
 %% A common operation is to transform each element of a list and then
 %% return the lists of results.  For instance, to scale each element of a
 %% list by a given factor.
-%% \begin{lstlisting}
-%% def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
-%%   case Nil => xs
-%%   case x :: xs1 => x * factor :: scaleList(xs1, factor)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
+  case Nil => xs
+  case x :: xs1 => x * factor :: scaleList(xs1, factor)
+}
+\end{lstlisting}
 %% This pattern can be generalized to the \code{map} method of class \code{List}:
-%% \begin{lstlisting}
-%% abstract class List[A] { ...
-%%   def map[B](f: A => B): List[B] = this match {
-%%     case Nil => this
-%%     case x :: xs => f(x) :: xs.map(f)
-%%   }
-%% \end{lstlisting}
-%% Using \code{map}, \code{scaleList} can be more concisely written as follows.
-%% \begin{lstlisting}
-%% def scaleList(xs: List[Double], factor: Double) =
-%%   xs map (x => x * factor)
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class List[A] { ...
+  def map[B](f: A => B): List[B] = this match {
+    case Nil => this
+    case x :: xs => f(x) :: xs.map(f)
+  }
+\end{lstlisting}
+%%Using \code{map}, \code{scaleList} can be more concisely written as follows.
+\begin{lstlisting}
+def scaleList(xs: List[Double], factor: Double) =
+  xs map (x => x * factor)
+\end{lstlisting}
 
 %% As another example, consider the problem of returning a given column
 %% of a matrix which is represented as a list of rows, where each row is
 %% again a list. This is done by the following function \code{column}.
 
-%% \begin{lstlisting}
-%% def column[A](xs: List[List[A]], index: Int): List[A] =
-%%   xs map (row => row(index))
-%% \end{lstlisting}
+\begin{lstlisting}
+def column[A](xs: List[List[A]], index: Int): List[A] =
+  xs map (row => row(index))
+\end{lstlisting}
 
 %% Closely related to \code{map} is the \code{foreach} method, which
 %% applies a given function to all elements of a list, but does not
 %% construct a list of results. The function is thus applied only for its
 %% side effect. \code{foreach} is defined as follows.
-%% \begin{lstlisting}
-%%   def foreach(f: A => Unit) {
-%%     this match {
-%%       case Nil => ()
-%%       case x :: xs => f(x); xs.foreach(f)
-%%     }
-%%   }
-%% \end{lstlisting}
-%% This function can be used for printing all elements of a list, for instance:
-%% \begin{lstlisting}
-%%   xs foreach (x => println(x))
-%% \end{lstlisting} 
+\begin{lstlisting}
+  def foreach(f: A => Unit) {
+    this match {
+      case Nil => ()
+      case x :: xs => f(x); xs.foreach(f)
+    }
+  }
+\end{lstlisting}
+%%This function can be used for printing all elements of a list, for instance:
+\begin{lstlisting}
+  xs foreach (x => println(x))
+\end{lstlisting} 
 
-%% \begin{exercise} Consider a function which squares all elements of a list and
+ \begin{exercise} 
+%%Consider a function which squares all elements of a list and
 %% returns a list with the results. Complete the following two equivalent
 %% definitions of \code{squareList}.
 
-%% \begin{lstlisting}
-%% def squareList(xs: List[Int]): List[Int] = xs match {
-%%   case List() => ??
-%%   case y :: ys => ??
-%% }
-%% def squareList(xs: List[Int]): List[Int] =
-%%   xs map ??
-%% \end{lstlisting}
-%% \end{exercise}
+\begin{lstlisting}
+def squareList(xs: List[Int]): List[Int] = xs match {
+  case List() => ??
+  case y :: ys => ??
+}
+def squareList(xs: List[Int]): List[Int] =
+  xs map ??
+\end{lstlisting}
+\end{exercise}
 
 %% \paragraph{Filtering Lists}
 %% Another common operation selects from a list all elements fulfilling a
 %% given criterion. For instance, to return a list of all positive
 %% elements in some given lists of integers:
-%% \begin{lstlisting}
-%% def posElems(xs: List[Int]): List[Int] = xs match {
-%%   case Nil => xs
-%%   case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
-%% }
-%% \end{lstlisting}
-%% This pattern is generalized to the \code{filter} method of class \code{List}:
-%% \begin{lstlisting}
-%%   def filter(p: A => Boolean): List[A] = this match {
-%%     case Nil => this
-%%     case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
-%%   }
-%% \end{lstlisting}
-%% Using \code{filter}, \code{posElems} can be more concisely written as
-%% follows.
-%% \begin{lstlisting}
-%% def posElems(xs: List[Int]): List[Int] =
-%%   xs filter (x => x > 0)
-%% \end{lstlisting}
+\begin{lstlisting}
+def posElems(xs: List[Int]): List[Int] = xs match {
+  case Nil => xs
+  case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
+}
+\end{lstlisting}
+%%This pattern is generalized to the \code{filter} method of class \code{List}:
+\begin{lstlisting}
+  def filter(p: A => Boolean): List[A] = this match {
+    case Nil => this
+    case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
+  }
+\end{lstlisting}
+%%Using \code{filter}, \code{posElems} can be more concisely written as
+%%follows.
+\begin{lstlisting}
+def posElems(xs: List[Int]): List[Int] =
+  xs filter (x => x > 0)
+\end{lstlisting}
 
 %% An operation related to filtering is testing whether all elements of a
 %% list satisfy a certain condition. Dually, one might also be interested
@@ -3903,12 +4028,12 @@ class Rational(n: Int, d: Int) {
 %% satisfies a certain condition. These operations are embodied in the
 %% higher-order functions \code{forall} and \code{exists} of class
 %% \code{List}.
-%% \begin{lstlisting}
-%% def forall(p: A => Boolean): Boolean =
-%%   isEmpty || (p(head) && (tail forall p))
-%% def exists(p: A => Boolean): Boolean =
-%%   !isEmpty && (p(head) || (tail exists p))
-%% \end{lstlisting}
+\begin{lstlisting}
+def forall(p: A => Boolean): Boolean =
+  isEmpty || (p(head) && (tail forall p))
+def exists(p: A => Boolean): Boolean =
+  !isEmpty && (p(head) || (tail exists p))
+\end{lstlisting}
 %% To illustrate the use of \code{forall}, consider the question of whether
 %% a number if prime. Remember that a number $n$ is prime of it can be
 %% divided without remainder only by one and itself. The most direct
@@ -3916,19 +4041,19 @@ class Rational(n: Int, d: Int) {
 %% numbers from 2 up to and excluding itself gives a non-zero
 %% remainder. This list of numbers can be generated using a function
 %% \code{List.range} which is defined in object \code{List} as follows.
-%% \begin{lstlisting}
-%% package scala
-%% object List { ...
-%%   def range(from: Int, end: Int): List[Int] =
-%%     if (from >= end) Nil else from :: range(from + 1, end)
-%% \end{lstlisting}
+\begin{lstlisting}
+package scala
+object List { ...
+  def range(from: Int, end: Int): List[Int] =
+    if (from >= end) Nil else from :: range(from + 1, end)
+\end{lstlisting}
 %% For example, \code{List.range(2, n)}
 %% generates the list of all integers from 2 up to and excluding $n$.
 %% The function \code{isPrime} can now simply be defined as follows.
-%% \begin{lstlisting}
-%% def isPrime(n: Int) =
-%%   List.range(2, n) forall (x => n % x != 0)
-%% \end{lstlisting}
+\begin{lstlisting}
+def isPrime(n: Int) =
+  List.range(2, n) forall (x => n % x != 0)
+\end{lstlisting}
 %% We see that the mathematical definition of prime-ness has been
 %% translated directly into Scala code. 
 
@@ -3938,98 +4063,98 @@ class Rational(n: Int, d: Int) {
 %% \paragraph{Folding and Reducing Lists}
 %% Another common operation is to combine the elements of a list with
 %% some operator.  For instance:
-%% \begin{lstlisting}
-%% sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
-%% product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
-%% \end{lstlisting}
+\begin{lstlisting}
+sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
+product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
+\end{lstlisting}
 %% Of course, we can implement both functions with a
 %% recursive scheme:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int]): Int = xs match {
-%%   case Nil => 0
-%%   case y :: ys => y + sum(ys)
-%% }
-%% def product(xs: List[Int]): Int = xs match {
-%%   case Nil => 1
-%%   case y :: ys => y * product(ys)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def sum(xs: List[Int]): Int = xs match {
+  case Nil => 0
+  case y :: ys => y + sum(ys)
+}
+def product(xs: List[Int]): Int = xs match {
+  case Nil => 1
+  case y :: ys => y * product(ys)
+}
+\end{lstlisting}
 %% But we can also use the generalization of this program scheme embodied
 %% in the \code{reduceLeft} method of class \code{List}.  This method
 %% inserts a given binary operator between adjacent elements of a given list.
 %% E.g.\ 
-%% \begin{lstlisting}
-%% List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
-%% \end{lstlisting}
-%% Using \code{reduceLeft}, we can make the common pattern
-%% in \code{sum} and \code{product} apparent:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
-%% def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
-%% \end{lstlisting}
-%% Here is the implementation of \code{reduceLeft}.
-%% \begin{lstlisting}
-%%   def reduceLeft(op: (A, A) => A): A = this match {
-%%     case Nil     => error("Nil.reduceLeft")
-%%     case x :: xs => (xs foldLeft x)(op)
-%%   }
-%%   def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
-%%     case Nil => z
-%%     case x :: xs => (xs foldLeft op(z, x))(op)
-%%   }
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
+\end{lstlisting}
+%%Using \code{reduceLeft}, we can make the common pattern
+%%in \code{sum} and \code{product} apparent:
+\begin{lstlisting}
+def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
+def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
+\end{lstlisting}
+%%Here is the implementation of \code{reduceLeft}.
+\begin{lstlisting}
+  def reduceLeft(op: (A, A) => A): A = this match {
+    case Nil     => error("Nil.reduceLeft")
+    case x :: xs => (xs foldLeft x)(op)
+  }
+  def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
+    case Nil => z
+    case x :: xs => (xs foldLeft op(z, x))(op)
+  }
+}
+\end{lstlisting}
 %% We see that the \code{reduceLeft} method is defined in terms of
 %% another generally useful method, \code{foldLeft}.  The latter takes as
 %% additional parameter an {\em accumulator} \code{z}, which is returned
 %% when \code{foldLeft} is applied on an empty list. That is,
-%% \begin{lstlisting}
-%% (List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
-%% \end{lstlisting}
-%% The \code{sum} and \code{product} methods can be defined alternatively
-%% using \code{foldLeft}:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
-%% def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
-%% \end{lstlisting}
+\begin{lstlisting}
+(List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
+\end{lstlisting}
+%%The \code{sum} and \code{product} methods can be defined alternatively
+%%using \code{foldLeft}:
+\begin{lstlisting}
+def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
+def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
+\end{lstlisting}
 
-%% \paragraph{FoldRight and ReduceRight}
-%% Applications of \code{foldLeft} and \code{reduceLeft} expand to
-%% left-leaning trees. \todo{insert pictures}.  They have duals
-%% \code{foldRight} and \code{reduceRight}, which produce right-leaning
-%% trees.
-%% \begin{lstlisting}
-%% List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
-%% (List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
-%% \end{lstlisting}
-%% These are defined as follows.
-%% \begin{lstlisting}
-%%   def reduceRight(op: (A, A) => A): A = this match {
-%%     case Nil => error("Nil.reduceRight")
-%%     case x :: Nil => x
-%%     case x :: xs => op(x, xs.reduceRight(op))
-%%   }
-%%   def foldRight[B](z: B)(op: (A, B) => B): B = this match {
-%%     case Nil => z
-%%     case x :: xs => op(x, (xs foldRight z)(op))
-%%   }
-%% \end{lstlisting}
+%%\paragraph{FoldRight and ReduceRight}
+%%Applications of \code{foldLeft} and \code{reduceLeft} expand to
+%%left-leaning trees. \todo{insert pictures}.  They have duals
+%%\code{foldRight} and \code{reduceRight}, which produce right-leaning
+%%trees.
+\begin{lstlisting}
+List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
+(List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
+\end{lstlisting}
+%%These are defined as follows.
+\begin{lstlisting}
+  def reduceRight(op: (A, A) => A): A = this match {
+    case Nil => error("Nil.reduceRight")
+    case x :: Nil => x
+    case x :: xs => op(x, xs.reduceRight(op))
+  }
+  def foldRight[B](z: B)(op: (A, B) => B): B = this match {
+    case Nil => z
+    case x :: xs => op(x, (xs foldRight z)(op))
+  }
+\end{lstlisting}
 
-%% Class \code{List} defines also two symbolic abbreviations for
-%% \code{foldLeft} and \code{foldRight}:
-%% \begin{lstlisting}
-%%   def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
-%%   def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
-%% \end{lstlisting}
+%%Class \code{List} defines also two symbolic abbreviations for
+%%\code{foldLeft} and \code{foldRight}:
+\begin{lstlisting}
+  def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
+  def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
+\end{lstlisting}
 %% The method names picture the left/right leaning trees of the fold
 %% operations by forward or backward slashes. The \code{:} points in each
 %% case to the list argument whereas the end of the slash points to the
 %% accumulator (or: zero) argument \code{z}. 
 %% That is, 
-%% \begin{lstlisting}
-%% (z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
-%% (List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
-%% \end{lstlisting}
+\begin{lstlisting}
+(z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
+(List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
+\end{lstlisting}
 %% For associative and commutative operators, \code{/:} and
 %% \code{:\\} are equivalent (even though there may be a difference
 %% in efficiency).  
@@ -4041,15 +4166,15 @@ class Rational(n: Int, d: Int) {
 %% \code{flatten} should be the concatenation of all element lists into a
 %% single list. Here is an implementation of this method in terms of 
 %% \code{:\\}.
-%% \begin{lstlisting}
-%% def flatten[A](xs: List[List[A]]): List[A] =
-%%   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
-%% \end{lstlisting} 
+\begin{lstlisting}
+def flatten[A](xs: List[List[A]]): List[A] =
+  (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
+\end{lstlisting} 
 %% Consider replacing the body of \lstinline@flatten@
 %% by 
-%% \begin{lstlisting}
-%%   ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
-%% \end{lstlisting}
+\begin{lstlisting}
+  ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
+\end{lstlisting}
 %% What would be the difference in asymptotic
 %% complexity between the two versions of \lstinline@flatten@?
 
@@ -4067,49 +4192,49 @@ class Rational(n: Int, d: Int) {
 %% to be reversed. We now develop a new implementation of \code{reverse},
 %% which has linear cost.  The idea is to use a \code{foldLeft}
 %% operation based on the following program scheme.
-%% \begin{lstlisting}
-%% class List[+A] { ...
-%%   def reverse: List[A] = (z? /: this)(op?)
-%% \end{lstlisting}
+\begin{lstlisting}
+class List[+A] { ...
+  def reverse: List[A] = (z? /: this)(op?)
+\end{lstlisting}
 %% It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
 %% try to deduce them from examples.
-%% \begin{lstlisting}
-%%   Nil
-%% = Nil.reverse                 // by specification
-%% = (z /: Nil)(op)              // by the template for reverse
-%% = (Nil foldLeft z)(op)        // by the definition of /:
-%% = z                           // by definition of foldLeft
-%% \end{lstlisting}
+\begin{lstlisting}
+  Nil
+= Nil.reverse                 // by specification
+= (z /: Nil)(op)              // by the template for reverse
+= (Nil foldLeft z)(op)        // by the definition of /:
+= z                           // by definition of foldLeft
+\end{lstlisting}
 %% Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
 %% let's study reversal of a list of length one.
-%% \begin{lstlisting}
-%%   List(x)
-%% = List(x).reverse             // by specification
-%% = (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
-%% = (List(x) foldLeft Nil)(op)  // by the definition of /:
-%% = op(Nil, x)                  // by definition of foldLeft
-%% \end{lstlisting}
+\begin{lstlisting}
+  List(x)
+= List(x).reverse             // by specification
+= (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
+= (List(x) foldLeft Nil)(op)  // by the definition of /:
+= op(Nil, x)                  // by definition of foldLeft
+\end{lstlisting}
 %% Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
 %% as \code{x :: Nil}. This suggests to take as \code{op} the
 %% \code{::} operator with its operands exchanged.  Hence, we arrive at
 %% the following implementation for \code{reverse}, which has linear complexity.
-%% \begin{lstlisting}
-%% def reverse: List[A] =
-%%   ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
-%% \end{lstlisting}
+\begin{lstlisting}
+def reverse: List[A] =
+  ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
+\end{lstlisting}
 %% (Remark: The type annotation of \code{Nil} is necessary 
 %% to make the type inferencer work.)
 
 %% \begin{exercise} Fill in the missing expressions to complete the following
 %% definitions of some basic list-manipulation operations as fold
 %% operations.
-%% \begin{lstlisting}
-%% def mapFun[A, B](xs: List[A], f: A => B): List[B] =
-%%   (xs :\ List[B]()){ ?? }
+\begin{lstlisting}
+def mapFun[A, B](xs: List[A], f: A => B): List[B] =
+  (xs :\ List[B]()){ ?? }
 
-%% def lengthFun[A](xs: List[A]): int =
-%%   (0 /: xs){ ?? }
-%% \end{lstlisting}
+def lengthFun[A](xs: List[A]): int =
+  (0 /: xs){ ?? }
+\end{lstlisting}
 %% \end{exercise}
 
 %% \paragraph{Nested Mappings}
@@ -4122,11 +4247,11 @@ class Rational(n: Int, d: Int) {
 %% integer $n$, find all pairs of positive integers $i$ and $j$, where 
 %% $1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
 %% the pairs are
-%% \bda{c|lllllll}
-%% i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
-%% j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
-%% i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
-%% \eda
+\bda{c|lllllll}
+i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
+j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
+i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
+\eda
 
 %% A natural way to solve this problem consists of two steps. In a first step,
 %% one generates the sequence of all pairs $(i, j)$ of integers such that
@@ -4140,38 +4265,38 @@ class Rational(n: Int, d: Int) {
 %% Second, for each integer $i$ between $1$ and $n$, generate the list of
 %% pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
 %% combination of \code{range} and \code{map}:
-%% \begin{lstlisting}
-%%   List.range(1, i) map (x => (i, x))
-%% \end{lstlisting}
+\begin{lstlisting}
+  List.range(1, i) map (x => (i, x))
+\end{lstlisting}
 %% Finally, combine all sublists using \code{foldRight} with \code{:::}.
 %% Putting everything together gives the following expression:
-%% \begin{lstlisting}
-%% List.range(1, n)
-%%   .map(i => List.range(1, i).map(x => (i, x)))
-%%   .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
-%%   .filter(pair => isPrime(pair._1 + pair._2))
-%% \end{lstlisting}
+\begin{lstlisting}
+List.range(1, n)
+  .map(i => List.range(1, i).map(x => (i, x)))
+  .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
+  .filter(pair => isPrime(pair._1 + pair._2))
+\end{lstlisting}
 
 %% \paragraph{Flattening Maps}
 %% The combination of mapping and then concatenating sublists 
 %% resulting from the map
 %% is so common that we there is a special method 
 %% for it in class \code{List}:
-%% \begin{lstlisting}
-%% abstract class List[+A] { ...
-%%   def flatMap[B](f: A => List[B]): List[B] = this match {
-%%     case Nil => Nil
-%%     case x :: xs => f(x) ::: (xs flatMap f)
-%%   }
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class List[+A] { ...
+  def flatMap[B](f: A => List[B]): List[B] = this match {
+    case Nil => Nil
+    case x :: xs => f(x) ::: (xs flatMap f)
+  }
+}
+\end{lstlisting}
 %% With \code{flatMap}, the pairs-whose-sum-is-prime expression 
 %% could have been written more concisely as follows.
-%% \begin{lstlisting}
-%% List.range(1, n)
-%%   .flatMap(i => List.range(1, i).map(x => (i, x)))
-%%   .filter(pair => isPrime(pair._1 + pair._2))
-%% \end{lstlisting}
+\begin{lstlisting}
+List.range(1, n)
+  .flatMap(i => List.range(1, i).map(x => (i, x)))
+  .filter(pair => isPrime(pair._1 + pair._2))
+\end{lstlisting}
 
 
 
@@ -4196,21 +4321,21 @@ class Rational(n: Int, d: Int) {
 
 %% Recall the concatenation operation for lists:
 
-%% \begin{lstlisting}
-%% class List[+A] {
-%%   ...
-%%   def ::: (that: List[A]): List[A] =
-%%     if (isEmpty) that
-%%     else head :: (tail ::: that)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class List[+A] {
+  ...
+  def ::: (that: List[A]): List[A] =
+    if (isEmpty) that
+    else head :: (tail ::: that)
+}
+\end{lstlisting}
 
 %% We would like to verify that concatenation is associative, with the
 %% empty list \code{List()} as left and right identity:
-%% \bda{lcl}
-%%    (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
-%%    xs ::: List()          &=& xs \gap =\ List() ::: xs
-%% \eda
+\bda{lcl}
+   (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
+   xs ::: List()          &=& xs \gap =\ List() ::: xs
+\eda
 %% \emph{Q}: How can we prove statements like the one above?
 
 %% \emph{A}: By \emph{structural induction} over lists.
@@ -4230,30 +4355,30 @@ class Rational(n: Int, d: Int) {
 %% \ee
 %% %\es\bs
 %% \emph{Example}: Given
-%% \begin{lstlisting}
-%% def factorial(n: Int): Int =
-%%   if (n == 0) 1
-%%   else n * factorial(n-1)
-%% \end{lstlisting}
+\begin{lstlisting}
+def factorial(n: Int): Int =
+  if (n == 0) 1
+  else n * factorial(n-1)
+\end{lstlisting}
 %% show that, for all \code{n >= 4},
-%% \begin{lstlisting}
-%%    factorial(n) >= 2$^n$
-%% \end{lstlisting}
+\begin{lstlisting}
+   factorial(n) >= 2$^n$
+\end{lstlisting}
 %% \es\bs
 %% \Case{\code{4}}
 %% is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
 
 %% \Case{\code{n+1}} 
 %% We have for \code{n >= 4}:
-%% \begin{lstlisting}
-%%     \= factorial(n + 1)
-%%  =     \> $\expl{by the second clause of factorial(*)}$
-%%        \> (n + 1) * factorial(n)
-%%  >=    \> $\expl{by calculation}$
-%%        \> 2 * factorial(n)
-%%  >=    \> $\expl{by the induction hypothesis}$
-%%        \> 2 * 2$^n$.
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= factorial(n + 1)
+ =     \> $\expl{by the second clause of factorial(*)}$
+       \> (n + 1) * factorial(n)
+ >=    \> $\expl{by calculation}$
+       \> 2 * factorial(n)
+ >=    \> $\expl{by the induction hypothesis}$
+       \> 2 * 2$^n$.
+\end{lstlisting}
 %% Note that in our proof we can freely apply reduction steps such as in (*)
 %% anywhere in a term.
 
@@ -4288,17 +4413,17 @@ class Rational(n: Int, d: Int) {
 
 %% \Case{\code{List()}}
 %% For the left-hand side, we have:
-%% \begin{lstlisting}
-%%     \= (List() ::: ys) ::: zs
-%%  =     \> $\expl{by first clause of \prog{:::}}$
-%%        \> ys ::: zs
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= (List() ::: ys) ::: zs
+ =     \> $\expl{by first clause of \prog{:::}}$
+       \> ys ::: zs
+\end{lstlisting}
 %% For the right-hand side, we have:
-%% \begin{lstlisting}
-%%     \= List() ::: (ys ::: zs)
-%%  =     \> $\expl{by first clause of \prog{:::}}$
-%%        \> ys ::: zs
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= List() ::: (ys ::: zs)
+ =     \> $\expl{by first clause of \prog{:::}}$
+       \> ys ::: zs
+\end{lstlisting}
 %% So the case is established.
 
 %% \es
@@ -4306,22 +4431,22 @@ class Rational(n: Int, d: Int) {
 %% \Case{\code{x :: xs}} 
 
 %% For the left-hand side, we have:
-%% \begin{lstlisting}
-%%     \= ((x :: xs) ::: ys) ::: zs
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> (x :: (xs ::: ys)) ::: zs
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> x :: ((xs ::: ys) ::: zs)
-%%  =     \> $\expl{by the induction hypothesis}$
-%%        \> x :: (xs ::: (ys ::: zs))
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= ((x :: xs) ::: ys) ::: zs
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> (x :: (xs ::: ys)) ::: zs
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> x :: ((xs ::: ys) ::: zs)
+ =     \> $\expl{by the induction hypothesis}$
+       \> x :: (xs ::: (ys ::: zs))
+\end{lstlisting}
 
 %% For the right-hand side, we have:
-%% \begin{lstlisting}
-%%     \= (x :: xs) ::: (ys ::: zs)
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> x :: (xs ::: (ys ::: zs))
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= (x :: xs) ::: (ys ::: zs)
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> x :: (xs ::: (ys ::: zs))
+\end{lstlisting}
 %% So the case (and with it the property) is established.
 
 %% \begin{exercise}
@@ -4331,51 +4456,51 @@ class Rational(n: Int, d: Int) {
 %% \end{exercise}
 
 %% As a more difficult example, consider function
-%% \begin{lstlisting}
-%% abstract class List[A] { ...
-%%   def reverse: List[A] = this match {
-%%     case List() => List()
-%%     case x :: xs => xs.reverse ::: List(x)
-%%   }
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class List[A] { ...
+  def reverse: List[A] = this match {
+    case List() => List()
+    case x :: xs => xs.reverse ::: List(x)
+  }
+}
+\end{lstlisting}
 %% We would like to prove the proposition that
-%% \begin{lstlisting}
-%%    xs.reverse.reverse  =  xs  .
-%% \end{lstlisting}
+\begin{lstlisting}
+   xs.reverse.reverse  =  xs  .
+\end{lstlisting}
 %% We proceed by induction over \code{xs}. The base case is easy to establish:
-%% \begin{lstlisting}
-%%     \= List().reverse.reverse
-%%  =     \> $\expl{by first clause of \prog{reverse}}$
-%%        \> List().reverse
-%%  =     \> $\expl{by first clause of \prog{reverse}}$
-%%        \> List()
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= List().reverse.reverse
+ =     \> $\expl{by first clause of \prog{reverse}}$
+       \> List().reverse
+ =     \> $\expl{by first clause of \prog{reverse}}$
+       \> List()
+\end{lstlisting}
 %% \es\bs
 %% For the induction step, we try:
-%% \begin{lstlisting}
-%%     \= (x :: xs).reverse.reverse
-%%  =     \> $\expl{by second clause of \prog{reverse}}$
-%%        \> (xs.reverse ::: List(x)).reverse
-%% \end{lstlisting}
-%% There's nothing more we can do to this expression, so we turn to the right side:
-%% \begin{lstlisting}
-%%     \= x :: xs
-%%  =     \> $\expl{by induction hypothesis}$
-%%        \> x :: xs.reverse.reverse
-%% \end{lstlisting}
-%% The two sides have simplified to different expressions.
+\begin{lstlisting}
+    \= (x :: xs).reverse.reverse
+ =     \> $\expl{by second clause of \prog{reverse}}$
+       \> (xs.reverse ::: List(x)).reverse
+\end{lstlisting}
+%%There's nothing more we can do to this expression, so we turn to the right side:
+\begin{lstlisting}
+    \= x :: xs
+ =     \> $\expl{by induction hypothesis}$
+       \> x :: xs.reverse.reverse
+\end{lstlisting}
+%%The two sides have simplified to different expressions.
 
-%% So we still have to show that
-%% \begin{lstlisting}
-%%   (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
-%% \end{lstlisting}
-%% Trying to prove this directly by induction does not work.
+%%So we still have to show that
+\begin{lstlisting}
+  (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
+\end{lstlisting}
+%%Trying to prove this directly by induction does not work.
 
-%% Instead we have to {\em generalize} the equation to:
-%% \begin{lstlisting}
-%%   (ys ::: List(x)).reverse  =  x :: ys.reverse
-%% \end{lstlisting}
+%%Instead we have to {\em generalize} the equation to:
+\begin{lstlisting}
+  (ys ::: List(x)).reverse  =  x :: ys.reverse
+\end{lstlisting}
 %% \es\bs
 %% This equation can be proved by a second induction argument over \code{ys}.
 %% (See blackboard).
@@ -4403,29 +4528,29 @@ class Rational(n: Int, d: Int) {
 %% \example Recall our definition of \code{IntSet} with 
 %% operations \code{contains} and \code{incl}:
 
-%% \begin{lstlisting}
-%% abstract class IntSet {
-%%   abstract def incl(x: Int): IntSet
-%%   abstract def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
-%% \es\bs
-%% \begin{lstlisting}
-%% case class Empty extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
-%% }
-%% case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: Int): IntSet =
-%%     if (x < elem) NonEmpty(elem, left incl x, right)
-%%     else if (x > elem) NonEmpty(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+abstract class IntSet {
+  abstract def incl(x: Int): IntSet
+  abstract def contains(x: Int): Boolean
+}
+\end{lstlisting}
+\es\bs
+\begin{lstlisting}
+case class Empty extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
+}
+case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: Int): IntSet =
+    if (x < elem) NonEmpty(elem, left incl x, right)
+    else if (x > elem) NonEmpty(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
 %% (With \code{case} added, so that we can use factory methods instead of \code{new}).
 
 %% What does it mean to prove the correctness of this implementation?
@@ -4439,11 +4564,11 @@ class Rational(n: Int, d: Int) {
 
 %% For all sets \code{s}, elements \code{x}, \code{y}:
 
-%% \begin{lstlisting}
-%% Empty contains x          \= =  false
-%% (s incl x) contains x     \> =  true
-%% (s incl x) contains y     \> =  s contains y         if x $\neq$ y
-%% \end{lstlisting}
+\begin{lstlisting}
+Empty contains x          \= =  false
+(s incl x) contains x     \> =  true
+(s incl x) contains y     \> =  s contains y         if x $\neq$ y
+\end{lstlisting}
 
 %% (In fact, one can show that these laws characterize the desired data
 %% type completely).
@@ -4458,34 +4583,34 @@ class Rational(n: Int, d: Int) {
 
 %% \emph{Proof:}
 
-%% \Case{\code{Empty}}
-%% \begin{lstlisting}
-%%     \= (Empty incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
-%%        \> NonEmpty(x, Empty, Empty) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-%%        \> true
-%% \end{lstlisting}
+\Case{\code{Empty}}
+\begin{lstlisting}
+    \= (Empty incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
+       \> NonEmpty(x, Empty, Empty) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+       \> true
+\end{lstlisting}
 
-%% \Case{\code{NonEmpty(x, l, r)}}
-%% \begin{lstlisting}
-%%     \= (NonEmpty(x, l, r) incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-%%        \> NonEmpty(x, l, r) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
-%%        \> true
-%% \end{lstlisting}
-%% \es\bs
-%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-%% \begin{lstlisting}
-%%     \= (NonEmpty(y, l, r) incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-%%        \> NonEmpty(y, l, r incl x) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-%%        \> (r incl x) contains x
-%%  =     \> $\expl{by the induction hypothesis}$
-%%        \> true
-%% \end{lstlisting}
+\Case{\code{NonEmpty(x, l, r)}}
+\begin{lstlisting}
+    \= (NonEmpty(x, l, r) incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+       \> NonEmpty(x, l, r) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
+       \> true
+\end{lstlisting}
+\es\bs
+\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+\begin{lstlisting}
+    \= (NonEmpty(y, l, r) incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+       \> NonEmpty(y, l, r incl x) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+       \> (r incl x) contains x
+ =     \> $\expl{by the induction hypothesis}$
+       \> true
+\end{lstlisting}
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
 
@@ -4500,17 +4625,17 @@ class Rational(n: Int, d: Int) {
 
 %% Say we add a \code{union} function to \code{IntSet}:
 
-%% \begin{lstlisting}
-%% class IntSet { ...
-%%   def union(other: IntSet): IntSet
-%% }
-%% class Expty extends IntSet { ...
-%%   def union(other: IntSet) = other
-%% }
-%% class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
-%%   def union(other: IntSet): IntSet = l union r union other incl x
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class IntSet { ...
+  def union(other: IntSet): IntSet
+}
+class Expty extends IntSet { ...
+  def union(other: IntSet) = other
+}
+class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
+  def union(other: IntSet): IntSet = l union r union other incl x
+}
+\end{lstlisting}
 
 %% The correctness of \code{union} can be subsumed with the following
 %% law:
@@ -4531,39 +4656,39 @@ class Rational(n: Int, d: Int) {
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
 
-%% \begin{lstlisting}
-%%     \= (Empty union ys) contains x 
-%%  =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
-%%         \> ys contains x
-%%  =      \> $\expl{Boolean algebra}$
-%%         \> false || ys contains x
-%%  =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
-%%         \> (Empty contains x) || (ys contains x)
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= (Empty union ys) contains x 
+ =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
+        \> ys contains x
+ =      \> $\expl{Boolean algebra}$
+        \> false || ys contains x
+ =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
+        \> (Empty contains x) || (ys contains x)
+\end{lstlisting}
 
-%% \begin{lstlisting}
-%%     \= (NonEmpty(x, l, r) union ys) contains x
-%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-%%         \> (l union r union ys incl x) contains x
-%%  =      \> $\expl{by Proposition 2}$
-%%         \> true
-%%  =      \> $\expl{Boolean algebra}$
-%%         \> true || (ys contains x)
-%%  =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
-%%         \> (NonEmpty(x, l, r) contains x) || (ys contains x)
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= (NonEmpty(x, l, r) union ys) contains x
+ =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+        \> (l union r union ys incl x) contains x
+ =      \> $\expl{by Proposition 2}$
+        \> true
+ =      \> $\expl{Boolean algebra}$
+        \> true || (ys contains x)
+ =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
+        \> (NonEmpty(x, l, r) contains x) || (ys contains x)
+\end{lstlisting}
 
-%% \begin{lstlisting}
-%%     \= (NonEmpty(y, l, r) union ys) contains x
-%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-%%         \> (l union r union ys incl y) contains x
-%%  =      \> $\expl{by Proposition 3}$
-%%         \> (l union r union ys) contains x
-%%  =      \> $\expl{by the induction hypothesis}$
-%%         \> ((l union r) contains x) || (ys contains x)
-%%  =      \> $\expl{by Proposition 3}$
-%%         \> ((l union r incl y) contains x) || (ys contains x)
-%% \end{lstlisting}
+\begin{lstlisting}
+    \= (NonEmpty(y, l, r) union ys) contains x
+ =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+        \> (l union r union ys incl y) contains x
+ =      \> $\expl{by Proposition 3}$
+        \> (l union r union ys) contains x
+ =      \> $\expl{by the induction hypothesis}$
+        \> ((l union r) contains x) || (ys contains x)
+ =      \> $\expl{by Proposition 3}$
+        \> ((l union r incl y) contains x) || (ys contains x)
+\end{lstlisting}
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
 %%  ... is analogous.
@@ -4588,21 +4713,21 @@ class Rational(n: Int, d: Int) {
 %% As a first example, say we are given a list \code{persons} of persons
 %% with \code{name} and \code{age} fields.  To print the names of all
 %% persons in the sequence which are aged over 20, one can write:
-%% \begin{lstlisting}
-%% for (p <- persons if p.age > 20) yield p.name
-%% \end{lstlisting}
-%% This is equivalent to the following expression , which uses
-%% higher-order functions \code{filter} and \code{map}:
-%% \begin{lstlisting}
-%% persons filter (p => p.age > 20) map (p => p.name)
-%% \end{lstlisting}
+\begin{lstlisting}
+for (p <- persons if p.age > 20) yield p.name
+\end{lstlisting}
+%%This is equivalent to the following expression , which uses
+%%higher-order functions \code{filter} and \code{map}:
+\begin{lstlisting}
+persons filter (p => p.age > 20) map (p => p.name)
+\end{lstlisting}
 %% The for-comprehension looks a bit like a for-loop in imperative languages,
 %% except that it constructs a list of the results of all iterations.
 
 %% Generally, a for-comprehension is of the form
-%% \begin{lstlisting}
-%% for ( $s$ ) yield $e$
-%% \end{lstlisting}
+\begin{lstlisting}
+for ( $s$ ) yield $e$
+\end{lstlisting}
 %% Here, $s$ is a sequence of {\em generators}, {\em definitions} and
 %% {\em filters}.  A {\em generator} is of the form \code{val x <- e},
 %% where \code{e} is a list-valued expression. It binds \code{x} to
@@ -4624,20 +4749,20 @@ class Rational(n: Int, d: Int) {
 %% integer $n$, find all pairs of positive integers $i$ and $j$, where $1
 %% \leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
 %% this problem is solved as follows:
-%% \begin{lstlisting}
-%% for { i <- List.range(1, n)
-%%       j <- List.range(1, i)
-%%       if isPrime(i+j) } yield {i, j}
-%% \end{lstlisting}
+\begin{lstlisting}
+for { i <- List.range(1, n)
+      j <- List.range(1, i)
+      if isPrime(i+j) } yield {i, j}
+\end{lstlisting}
 %% This is arguably much clearer than the solution using \code{map},
 %% \code{flatMap} and \code{filter} that we have developed previously.
 
 %% As a second example, consider computing the scalar product of two
 %% vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
 %% be written as follows.
-%% \begin{lstlisting}
-%%   sum(for ((x, y) <- xs zip ys) yield x * y)
-%% \end{lstlisting}
+\begin{lstlisting}
+  sum(for ((x, y) <- xs zip ys) yield x * y)
+\end{lstlisting}
 
 %% \section{The N-Queens Problem}
 
@@ -4674,21 +4799,21 @@ class Rational(n: Int, d: Int) {
 %% of solution lists, this time of length $k$. We continue the process
 %% until we have reached solutions of the size of the chess-board $n$.
 %% This algorithmic idea is embodied in function \code{placeQueens} below:
-%% \begin{lstlisting}
-%% def queens(n: Int): List[List[Int]] = {
-%%   def placeQueens(k: Int): List[List[Int]] =
-%%     if (k == 0) List(List())
-%%     else for { queens <- placeQueens(k - 1)
-%%                column <- List.range(1, n + 1)
-%%                if isSafe(column, queens, 1) } yield column :: queens
-%%   placeQueens(n)
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+def queens(n: Int): List[List[Int]] = {
+  def placeQueens(k: Int): List[List[Int]] =
+    if (k == 0) List(List())
+    else for { queens <- placeQueens(k - 1)
+               column <- List.range(1, n + 1)
+               if isSafe(column, queens, 1) } yield column :: queens
+  placeQueens(n)
+}
+\end{lstlisting}
 
 %% \begin{exercise} Write the function
-%% \begin{lstlisting}
-%%   def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
-%% \end{lstlisting}
+\begin{lstlisting}
+  def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
+\end{lstlisting}
 %% which tests whether a queen in the given column \verb@col@ is safe with 
 %% respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
 %% placed and the row of the first queen in the list.
@@ -4700,56 +4825,56 @@ class Rational(n: Int, d: Int) {
 %% database query languages.  For instance, say we are given a 
 %% database \code{books}, represented as a list of books, where
 %% \code{Book} is defined as follows.
-%% \begin{lstlisting}
-%% case class Book(title: String, authors: List[String])
-%% \end{lstlisting}
+\begin{lstlisting}
+case class Book(title: String, authors: List[String])
+\end{lstlisting}
 %% Here is a small example database:
-%% \begin{lstlisting}
-%% val books: List[Book] = List(
-%%   Book("Structure and Interpretation of Computer Programs",
-%%        List("Abelson, Harold", "Sussman, Gerald J.")),
-%%   Book("Principles of Compiler Design",
-%%        List("Aho, Alfred", "Ullman, Jeffrey")),
-%%   Book("Programming in Modula-2",
-%%        List("Wirth, Niklaus")),
-%%   Book("Introduction to Functional Programming"),
-%%        List("Bird, Richard")),
-%%   Book("The Java Language Specification",
-%%        List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
-%% \end{lstlisting}
+\begin{lstlisting}
+val books: List[Book] = List(
+  Book("Structure and Interpretation of Computer Programs",
+       List("Abelson, Harold", "Sussman, Gerald J.")),
+  Book("Principles of Compiler Design",
+       List("Aho, Alfred", "Ullman, Jeffrey")),
+  Book("Programming in Modula-2",
+       List("Wirth, Niklaus")),
+  Book("Introduction to Functional Programming"),
+       List("Bird, Richard")),
+  Book("The Java Language Specification",
+       List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
+\end{lstlisting}
 %% Then, to find the titles of all books whose author's last name is ``Ullman'':
-%% \begin{lstlisting}
-%% for (b <- books; a <- b.authors if a startsWith "Ullman")
-%% yield b.title
-%% \end{lstlisting}
+\begin{lstlisting}
+for (b <- books; a <- b.authors if a startsWith "Ullman")
+yield b.title
+\end{lstlisting}
 %% (Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
 %% to find the titles of all books that have the string ``Program'' in
 %% their title:
-%% \begin{lstlisting}
-%% for (b <- books if (b.title indexOf "Program") >= 0)
-%% yield b.title
-%% \end{lstlisting}
+\begin{lstlisting}
+for (b <- books if (b.title indexOf "Program") >= 0)
+yield b.title
+\end{lstlisting}
 %% Or, to find the names of all authors that have written at least two
 %% books in the database.
-%% \begin{lstlisting}
-%% for (b1 <- books; b2 <- books if b1 != b2;
-%%      a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
-%% yield a1
-%% \end{lstlisting}
+\begin{lstlisting}
+for (b1 <- books; b2 <- books if b1 != b2;
+     a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
+yield a1
+\end{lstlisting}
 %% The last solution is not yet perfect, because authors will appear
 %% several times in the list of results.  We still need to remove
 %% duplicate authors from result lists.  This can be achieved with the
 %% following function.
-%% \begin{lstlisting}
-%% def removeDuplicates[A](xs: List[A]): List[A] =
-%%   if (xs.isEmpty) xs
-%%   else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
-%% \end{lstlisting}
+\begin{lstlisting}
+def removeDuplicates[A](xs: List[A]): List[A] =
+  if (xs.isEmpty) xs
+  else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
+\end{lstlisting}
 %% Note that the last expression in method \code{removeDuplicates}
 %% can be equivalently expressed using a for-comprehension.
-%% \begin{lstlisting}
-%% xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
-%% \end{lstlisting}
+\begin{lstlisting}
+xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
+\end{lstlisting}
 
 %% \section{Translation of For-Comprehensions}
 
@@ -4759,69 +4884,69 @@ class Rational(n: Int, d: Int) {
 %% \begin{itemize}
 %% \item
 %% A simple for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e) yield e'
-%% \end{lstlisting}
-%% is translated to
-%% \begin{lstlisting}
-%% e.map(x => e')
-%% \end{lstlisting}
-%% \item
-%% A for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e if f; s) yield e'
-%% \end{lstlisting}
+\begin{lstlisting}
+for (x <- e) yield e'
+\end{lstlisting}
+%%is translated to
+\begin{lstlisting}
+e.map(x => e')
+\end{lstlisting}
+%%\item
+%%A for-comprehension
+\begin{lstlisting}
+for (x <- e if f; s) yield e'
+\end{lstlisting}
 %% where \code{f} is a filter and \code{s} is a (possibly empty)
 %% sequence of generators or filters
 %% is translated to
-%% \begin{lstlisting}
-%% for (x <- e.filter(x => f); s) yield e'
-%% \end{lstlisting}
+\begin{lstlisting}
+for (x <- e.filter(x => f); s) yield e'
+\end{lstlisting}
 %% and then translation continues with the latter expression.
 %% \item
 %% A for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e; y <- e'; s) yield e''
-%% \end{lstlisting}
+\begin{lstlisting}
+for (x <- e; y <- e'; s) yield e''
+\end{lstlisting}
 %% where \code{s} is a (possibly empty)
 %% sequence of generators or filters
 %% is translated to
-%% \begin{lstlisting}
-%% e.flatMap(x => for (y <- e'; s) yield e'')
-%% \end{lstlisting}
+\begin{lstlisting}
+e.flatMap(x => for (y <- e'; s) yield e'')
+\end{lstlisting}
 %% and then translation continues with the latter expression.
 %% \end{itemize}
 %% For instance, taking our "pairs of integers whose sum is prime" example:
-%% \begin{lstlisting}
-%% for { i <- range(1, n)
-%%       j <- range(1, i)
-%%       if isPrime(i+j)
-%% } yield {i, j}
-%% \end{lstlisting}
+\begin{lstlisting}
+for { i <- range(1, n)
+      j <- range(1, i)
+      if isPrime(i+j)
+} yield {i, j}
+\end{lstlisting}
 %% Here is what we get when we translate this expression:
-%% \begin{lstlisting}
-%% range(1, n)
-%%   .flatMap(i =>
-%%     range(1, i)
-%%       .filter(j => isPrime(i+j))
-%%       .map(j => (i, j)))
-%% \end{lstlisting}
+\begin{lstlisting}
+range(1, n)
+  .flatMap(i =>
+    range(1, i)
+      .filter(j => isPrime(i+j))
+      .map(j => (i, j)))
+\end{lstlisting}
 
 %% Conversely, it would also be possible to express functions \code{map},
 %% \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
 %% three functions again, this time implemented using for-comprehensions.
-%% \begin{lstlisting}
-%% object Demo {
-%%   def map[A, B](xs: List[A], f: A => B): List[B] =
-%%     for (x <- xs) yield f(x)
+\begin{lstlisting}
+object Demo {
+  def map[A, B](xs: List[A], f: A => B): List[B] =
+    for (x <- xs) yield f(x)
 
-%%   def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
-%%     for (x <- xs; y <- f(x)) yield y
+  def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
+    for (x <- xs; y <- f(x)) yield y
 
-%%   def filter[A](xs: List[A], p: A => Boolean): List[A] =
-%%     for (x <- xs if p(x)) yield x
-%% }
-%% \end{lstlisting}
+  def filter[A](xs: List[A], p: A => Boolean): List[A] =
+    for (x <- xs if p(x)) yield x
+}
+\end{lstlisting}
 %% Not surprisingly, the translation of the for-comprehension in the body of
 %% \code{Demo.map} will produce a call to \code{map} in class \code{List}.
 %% Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
@@ -4829,18 +4954,18 @@ class Rational(n: Int, d: Int) {
 
 %% \begin{exercise}
 %% Define the following function in terms of \code{for}.
-%% \begin{lstlisting}
-%% def flatten[A](xss: List[List[A]]): List[A] =
-%%   (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
-%% \end{lstlisting}
+\begin{lstlisting}
+def flatten[A](xss: List[List[A]]): List[A] =
+  (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
+\end{lstlisting}
 %% \end{exercise}
 
 %% \begin{exercise}
 %% Translate
-%% \begin{lstlisting}
-%% for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
-%% for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
-%% \end{lstlisting}
+\begin{lstlisting}
+for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
+for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
+\end{lstlisting}
 %% to higher-order functions.
 %% \end{exercise}
 
@@ -4851,9 +4976,9 @@ class Rational(n: Int, d: Int) {
 %% not needed but we would still like the flexibility of generators and
 %% filters in iterations over lists. This is made possible by a variant
 %% of the for-comprehension syntax, which expresses for-loops:
-%% \begin{lstlisting}
-%% for ( $s$ ) $e$
-%% \end{lstlisting}
+\begin{lstlisting}
+for ( $s$ ) $e$
+\end{lstlisting}
 %% This construct is the same as the standard for-comprehension syntax
 %% except that the keyword \code{yield} is missing. The for-loop is
 %% executed by executing the expression $e$ for each element generated
@@ -4861,12 +4986,12 @@ class Rational(n: Int, d: Int) {
 
 %% As an example, the following expression prints out all elements of a
 %% matrix represented as a list of lists:
-%%  \begin{lstlisting}
-%% for (xs <- xss) {
-%%   for (x <- xs) print(x + "\t")
-%%   println()
-%% }
-%% \end{lstlisting}
+ \begin{lstlisting}
+for (xs <- xss) {
+  for (x <- xs) print(x + "\t")
+  println()
+}
+\end{lstlisting}
 %% The translation of for-loops to higher-order methods of class
 %% \code{List} is similar to the translation of for-comprehensions, but
 %% is simpler. Where for-comprehensions translate to \code{map} and
@@ -4900,11 +5025,11 @@ class Rational(n: Int, d: Int) {
 %%  \code{C[A]} for which you want to enable for-comprehensions. Then
 %%  \code{C} should define \code{map}, \code{flatMap} and \code{filter}
 %%  with the following types:
-%% \begin{lstlisting}
-%% def map[B](f: A => B): C[B]
-%% def flatMap[B](f: A => C[B]): C[B]
-%% def filter(p: A => Boolean): C[A]
-%% \end{lstlisting}
+\begin{lstlisting}
+def map[B](f: A => B): C[B]
+def flatMap[B](f: A => C[B]): C[B]
+def filter(p: A => Boolean): C[A]
+\end{lstlisting}
 %% It would be attractive to enforce these types statically in the Scala
 %% compiler, for instance by requiring that any type supporting
 %% for-comprehensions implements a standard trait with these methods

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -511,7 +511,7 @@ caixa de correio que casa com um destes padrões e aplica a ação correspondent
 %----------
 
 
-%----------xpto
+%----------
 %% \item
 %% The last case of \code{receiveWithin} is guarded by a
 %% \code{TIMEOUT} pattern. If no other messages are received in the meantime, this
@@ -520,9 +520,13 @@ caixa de correio que casa com um destes padrões e aplica a ação correspondent
 %% special message, which is triggered by the \code{Actor} implementation itself.
 \item
 O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
+Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrão é disparado
+após o prazo que foi passado como argumento para o método envolvente \code{receiveWithin}.
+\code{TIMEOUT} é uma mensagem especial, que é disparada pela própria implementação do 
+\code{Actor}.    
 %----------
 
-%----------
+%----------xpto
 %% \item
 %% Reply messages are sent using syntax of the form
 %% \code{destination ! SomeMessage}. \code{!} is used here as a

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -389,13 +389,18 @@ para fechar a transação. Apresentamos uma visão superficial de uma
  implementação aqui.
 %----------
 
-%----------xpto
+%----------
 %% As a first step, we define the messages that are exchanged during an
 %% auction. There are two abstract base classes
 %% \code{AuctionMessage} for messages from clients to the auction
 %% service, and \code{AuctionReply} for replies from the service to the
 %% clients.  For both base classes there exists a number of cases, which
 %% are defined in Figure~\ref{fig:simple-auction-msgs}.
+Como primeiro passo, definimos as mensagens que são trocadas durante um
+leilão. Há duas classes base abstratas \code{AuctionMessage} para mensagens 
+de clientes do serviço de leilão, e \code{AuctionReply} para respostas 
+do serviço aos clientes. Para ambas as classes base há um número de casos 
+definidos na Figura~\ref{fig:simple-auction-msgs}.
 %----------
 
 \begin{lstlisting}[style=floating,label=fig:simple-auction,caption=Implementation of an Auction Service]
@@ -434,12 +439,17 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 }
 \end{lstlisting}
 
-%----------
+%----------xpto
 %% For each base class, there are a number of {\em case classes} which
 %% define the format of particular messages in the class. These messages
 %% might well be ultimately mapped to small XML documents. We expect
 %% automatic tools to exist that convert between XML documents and
 %% internal data structures like the ones defined above.
+Para cada classe base, há um número de {\em classes case} que definem
+o formato de mensagens particulares dentro da classe. Estas mensagens
+podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
+que hajam ferramentas automáticas que convertam entre documentos XML e 
+estruturas de dados internas, tais como as definidas acima.
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -171,7 +171,7 @@ para eles.
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
 Em particular, há o método \code{filter} que recebe como argumento uma
-(\em função predicado}. Esta função predicado deve mapear elementos do 
+{\em função predicado}. Esta função predicado deve mapear elementos do 
 vetor para valores boleanos. O resultado de \code{filter} é um vetor
 consistindo de todos os elementos do vetor original para o qual a função
 predicado é verdadeira. O método \code{filter} de um objeto tipo
@@ -525,14 +525,14 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 %----------
 
 %----------
-%% \chapter{\label{chap:simple-funs}Expressions and Simple Functions}
+\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
 
-%% \section{Expressions And Simple Functions}
+\section{Expressions And Simple Functions}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
@@ -609,9 +609,10 @@ unnamed4: Double = 62.83185307179586
 %% The process of stepwise simplification of expressions to values is
 %% called {\em reduction}.
 
-%% \section{Parameters}
+\section{Parameters}
 
 %% Using \code{def}, one can also define functions with parameters. For example:
+Usando \code{def}, pode-se também definir funções com parâmetros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -689,39 +690,39 @@ $\rightarrow$  25
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
-%% \begin{lstlisting}
-%% scala> def loop: Int = loop
-%% loop: Int
+\begin{lstlisting}
+scala> def loop: Int = loop
+loop: Int
 
-%% scala> def first(x: Int, y: Int) = x
-%% first: (Int,Int)Int
-%% \end{lstlisting}
+scala> def first(x: Int, y: Int) = x
+first: (Int,Int)Int
+\end{lstlisting}
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
-%% \begin{lstlisting}
-%% $\,\,\,$   first(1, loop)
-%% $\rightarrow$  first(1, loop)
-%% $\rightarrow$  first(1, loop)
-%% $\rightarrow$  ...
-%% \end{lstlisting}
+\begin{lstlisting}
+$\,\,\,$   first(1, loop)
+$\rightarrow$  first(1, loop)
+$\rightarrow$  first(1, loop)
+$\rightarrow$  ...
+\end{lstlisting}
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
 
-%% \example\ 
+\example\ 
  
-%% \begin{lstlisting}
-%% scala> def constOne(x: Int, y: => Int) = 1
-%% constOne: (Int,=> Int)Int
+\begin{lstlisting}
+scala> def constOne(x: Int, y: => Int) = 1
+constOne: (Int,=> Int)Int
 
-%% scala> constOne(1, loop)
-%% unnamed0: Int = 1
+scala> constOne(1, loop)
+unnamed0: Int = 1
 
-%% scala> constOne(loop, 2)               // gives an infinite loop.
-%% ^C                                     // stops execution with Ctrl-C
-%% \end{lstlisting}
+scala> constOne(loop, 2)               // gives an infinite loop.
+^C                                     // stops execution with Ctrl-C
+\end{lstlisting}
 
-%% \section{Conditional Expressions}
+\section{Conditional Expressions}
 
 %% Scala's \code{if-else} lets one choose between two alternatives.  Its
 %% syntax is like Java's \code{if-else}. But where Java's \code{if-else}
@@ -1486,51 +1487,51 @@ $\rightarrow$  25
 
 %% \subsection*{Definitions:}
 
-%% \begin{lstlisting}
-%% Def          =  FunDef  |  ValDef
-%% FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
-%% ValDef       =  'val' ident [':' Type] '=' Expr
-%% Parameters   =  Parameter {',' Parameter}
-%% Parameter    =  ident ':' ['=>'] Type
-%% \end{lstlisting}
-%% Definitions can be:
-%% \begin{itemize}
-%% \item
-%% function definitions such as \code{def square(x: Int): Int = x * x},
-%% \item
-%% value definitions such as \code{val y = square(2)}.
-%% \end{itemize}
+\begin{lstlisting}
+Def          =  FunDef  |  ValDef
+FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
+ValDef       =  'val' ident [':' Type] '=' Expr
+Parameters   =  Parameter {',' Parameter}
+Parameter    =  ident ':' ['=>'] Type
+\end{lstlisting}
+Definitions can be:
+\begin{itemize}
+\item
+function definitions such as \code{def square(x: Int): Int = x * x},
+\item
+value definitions such as \code{val y = square(2)}.
+\end{itemize}
 
-%% \chapter{Classes and Objects}
-%% \label{chap:classes}
+\chapter{Classes and Objects}
+\label{chap:classes}
 
 %% Scala does not have a built-in type of rational numbers, but it is
 %% easy to define one, using a class. Here's a possible implementation.
 
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) {
-%%   private def gcd(x: Int, y: Int): Int = {
-%%     if (x == 0) y
-%%     else if (x < 0) gcd(-x, y)
-%%     else if (y < 0) -gcd(x, -y)
-%%     else gcd(y % x, x)
-%%   }
-%%   private val g = gcd(n, d)
+\begin{lstlisting}
+class Rational(n: Int, d: Int) {
+  private def gcd(x: Int, y: Int): Int = {
+    if (x == 0) y
+    else if (x < 0) gcd(-x, y)
+    else if (y < 0) -gcd(x, -y)
+    else gcd(y % x, x)
+  }
+  private val g = gcd(n, d)
 
-%%   val numer: Int = n/g
-%%   val denom: Int = d/g
-%%   def +(that: Rational) =
-%%     new Rational(numer * that.denom + that.numer * denom,
-%%                  denom * that.denom)
-%%   def -(that: Rational) =
-%%     new Rational(numer * that.denom - that.numer * denom, 
-%%                  denom * that.denom)
-%%   def *(that: Rational) =
-%%     new Rational(numer * that.numer, denom * that.denom)
-%%   def /(that: Rational) =
-%%     new Rational(numer * that.denom, denom * that.numer)
-%% }
-%% \end{lstlisting}
+  val numer: Int = n/g
+  val denom: Int = d/g
+  def +(that: Rational) =
+    new Rational(numer * that.denom + that.numer * denom,
+                 denom * that.denom)
+  def -(that: Rational) =
+    new Rational(numer * that.denom - that.numer * denom, 
+                 denom * that.denom)
+  def *(that: Rational) =
+    new Rational(numer * that.numer, denom * that.denom)
+  def /(that: Rational) =
+    new Rational(numer * that.denom, denom * that.numer)
+}
+\end{lstlisting}
 %% This defines \code{Rational} as a class which takes two constructor
 %% arguments \code{n} and \code{d}, containing the number's numerator and
 %% denominator parts.  The class provides fields which return these parts
@@ -6507,12 +6508,12 @@ would give the response
 \begin{lstlisting}
 > (a6->List[a6])
 \end{lstlisting}
-%% \comment{
-%% To make the type inferencer more useful, we complete it with a
-%% parser. 
-%% Function \code{main} of module \code{testInfer}
-%% parses and typechecks a Mini-ML expression which is given as the first
-%% command line argument.
+\comment{
+To make the type inferencer more useful, we complete it with a
+parser. 
+Function \code{main} of module \code{testInfer}
+parses and typechecks a Mini-ML expression which is given as the first
+command line argument.
 \begin{lstlisting}
   def main(args: Array[String]) {
     val ps = new ParseString(args(0)) with MiniMLParsers
@@ -6643,20 +6644,20 @@ let id = (\x.x) in (((if (id true)) (id nil)) zero):
  reason: cannot unify Int with List[a14]
 \end{lstlisting}
 
-%% \begin{exercise}\label{exercise:hm-parse} Using the parser library constructed in
-%% Exercise~\ref{exercise:end-marker}, modify the MiniML parser library
-%% so that no marker ``;'' is necessary for indicating the end of input.
-%% \end{exercise}
-%% }
+\begin{exercise}\label{exercise:hm-parse} Using the parser library constructed in
+Exercise~\ref{exercise:end-marker}, modify the MiniML parser library
+so that no marker ``;'' is necessary for indicating the end of input.
+\end{exercise}
+}
 
-%% \begin{exercise}\label{execcise:hm-extend} Extend the Mini-ML \comment{parser and} type
-%% inferencer with a \code{letrec} construct which allows the definition of
-%% recursive functions. Syntax:
-%% \begin{lstlisting}
-%% letrec ident "=" term in term .
-%% \end{lstlisting}
-%% The typing of \code{letrec} is as for \code{let}, 
-%% except that the defined identifier is visible in the defining expression. Using \code{letrec}, the \code{length} function for lists can now be defined as follows.
+\begin{exercise}\label{execcise:hm-extend} Extend the Mini-ML \comment{parser and} type
+inferencer with a \code{letrec} construct which allows the definition of
+recursive functions. Syntax:
+\begin{lstlisting}
+letrec ident "=" term in term .
+\end{lstlisting}
+The typing of \code{letrec} is as for \code{let}, 
+except that the defined identifier is visible in the defining expression. Using \code{letrec}, the \code{length} function for lists can now be defined as follows.
 \begin{lstlisting}
 letrec length = \xs.
   if (isEmpty xs)
@@ -6754,7 +6755,7 @@ def spawn(p: => Unit) {
 }
 \end{lstlisting}
 
-%% \comment{
+\comment{
 %% \section{Logic Variable}
 
 %% A logic variable (or lvar for short) offers operations \code{:=}
@@ -7315,10 +7316,10 @@ abstract class Actor extends Thread with MailBox {
 }
 \end{lstlisting}
 
-%% \comment{
-%% As an extended example of an application that uses actors, we come
-%% back to the auction server example of Section~\ref{sec:ex-auction}.
-%% The following code implements:
+\comment{
+As an extended example of an application that uses actors, we come
+back to the auction server example of Section~\ref{sec:ex-auction}.
+The following code implements:
 
 \begin{figure}[thb]
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4659,7 +4659,6 @@ def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
 def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
 \end{lstlisting}
 
-%--------------xpto
 \paragraph{FoldRight e ReduceRight}
 Aplicações de \code{foldLeft} e \code{reduceLeft} expandem para árvores inclinadas à esquerda. 
 \todo{insert pictures}. Eles têm duals \code{foldRight} e \code{reduceRight} que produzem 
@@ -4709,32 +4708,31 @@ em termos de \code{:\\}.
 def flatten[A](xs: List[List[A]]): List[A] =
   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
 \end{lstlisting} 
-Consider replacing the body of \lstinline@flatten@
-by 
+Considere substituir o corpo de  \lstinline@flatten@ por 
 \begin{lstlisting}
   ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
 \end{lstlisting}
-What would be the difference in asymptotic
-complexity between the two versions of \lstinline@flatten@?
+Qual a diferença na complexidade assintótica entre as duas versões de \lstinline@flatten@? 
 
-In fact \code{flatten} is predefined together with a set of other
-userful function in an object called \code{List} in the standatd Scala
-library. It can be accessed from user program by calling
-\code{List.flatten}. Note that \code{flatten} is not a method of class
-\code{List} -- it would not make sense there, since it applies only
-to lists of lists, not to all lists in general.
+De fato \code{flatten} é predefinido junto com um conjunto de outras funções úteis no objeto 
+chamado \code{List} na biblioteca padrão Scala. Pode ser acessado de um programa usuário 
+chamando \code{List.flatten}. Observe que \code{flatten} não é um método da classe
+\code{List}---não faz sentido, pois aplica-se somente a listas de listas, não a todas as
+listas em geral. 
+
 \end{exercise}
 
-\paragraph{List Reversal Again} We have seen in 
-Section~\ref{sec:list-first-order} an implementation of method
-\code{reverse} whose run-time was quadratic in the length of the list
-to be reversed. We now develop a new implementation of \code{reverse},
-which has linear cost.  The idea is to use a \code{foldLeft}
-operation based on the following program scheme.
+\paragraph{Novamente Inversão de Lista} Vimos na Seção~\ref{sec:list-first-order} uma 
+implementação do método \code{reverse} cujo tempo de execução era quadrático para o 
+tamanho da lista a ser invertida. Agora desenvolveremos uma nova implementação de
+\code{reverse}, cujo custo é linear. A idéia é usar uma operação \code{foldLeft} 
+baseada no seguinte programa scheme.
 \begin{lstlisting}
 class List[+A] { ...
   def reverse: List[A] = (z? /: this)(op?)
 \end{lstlisting}
+
+%-------------xpto
 It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
 try to deduce them from examples.
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4841,12 +4841,10 @@ invés da indexação, listas são geralmente percorridas recursivamente, onde p
 baseados em casamento de padrões sobre a lista percorrida. Há também um rico conjunto de combinadores de
 alta ordem que permitem a instanciação de um conjunto de padrões pré-definidos de computações sobre listas.
 
-%---------------xpto
-
 \comment{
-\bsh{Reasoning About Lists}
+\bsh{Pensando sobre Listas}
 
-Recall the concatenation operation for lists:
+Lembre da operação de concatenação para listas:
 
 \begin{lstlisting}
 class List[+A] {
@@ -4859,123 +4857,121 @@ class List[+A] {
 
 We would like to verify that concatenation is associative, with the
 empty list \code{List()} as left and right identity:
+
+Poderíamos querer verificar que a concatenação é associativa, com a lista vazia \code{List()} como 
+identidade esquerda e direita:
 \bda{lcl}
    (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
    xs ::: List()          &=& xs \gap =\ List() ::: xs
 \eda
-\emph{Q}: How can we prove statements like the one above?
+\emph{Q}: Como podemos provar declarações como a expressa acima?
 
-\emph{A}: By \emph{structural induction} over lists.
+\emph{R}: Através de \emph{indução estrutural} sobre listas.
 \es
-\bsh{Reminder: Natural Induction}
+\bsh{Lembrete: Indução Natural}
 
-Recall the proof principle of \emph{natural induction}:
+Lembrando o princípio da prova por \emph{indução natural}:
 
-To show a property \mathtext{P(n)} for all numbers \mathtext{n \geq b}:
+Para mostrar uma propriedade \mathtext{P(n)} para todos os números \mathtext{n \geq b}:
 \be
-\item Show that \mathtext{P(b)} holds (\emph{base case}).
-\item For arbitrary \mathtext{n \geq b} show:
+\item Mostre que \mathtext{P(b)} vale para o (\emph{caso base}).
+\item Para \mathtext{n \geq b} arbitrários, mostre:
 \begin{quote}
-     if \mathtext{P(n)} holds, then \mathtext{P(n+1)} holds as well
+     se vale \mathtext{P(n)}, então \mathtext{P(n+1)} também vale
 \end{quote}
-(\emph{induction step}).
+(\emph{passo indutivo}).
 \ee
 %\es\bs
-\emph{Example}: Given
+\emph{Examplo}: Dado
 \begin{lstlisting}
 def factorial(n: Int): Int =
   if (n == 0) 1
   else n * factorial(n-1)
 \end{lstlisting}
-show that, for all \code{n >= 4},
+mostre que, para todos \code{n >= 4},
 \begin{lstlisting}
    factorial(n) >= 2$^n$
 \end{lstlisting}
 \es\bs
 \Case{\code{4}}
-is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
-
+é estabelecido pelo simples cálculo de \code{factorial(4) = 24} e \code{2$^4$ = 16}.
 \Case{\code{n+1}} 
-We have for \code{n >= 4}:
+Temos para \code{n >= 4}:
 \begin{lstlisting}
     \= factorial(n + 1)
- =     \> $\expl{by the second clause of factorial(*)}$
+ =     \> $\expl{pela segundo cláusula de factorial(*)}$
        \> (n + 1) * factorial(n)
- >=    \> $\expl{by calculation}$
+ >=    \> $\expl{pelo cálculo}$
        \> 2 * factorial(n)
- >=    \> $\expl{by the induction hypothesis}$
+ >=    \> $\expl{pela hipótese de indução}$
        \> 2 * 2$^n$.
 \end{lstlisting}
-Note that in our proof we can freely apply reduction steps such as in (*)
-anywhere in a term.
+Observe que em nossa prova podemos aplicar livremente passos de redução tais como em (*) qualquer lugar do termo.
 
+Isto funciona porque programas puramente funcionais não têm efeitos colaterais; logo um termo é equivalente 
+ao termo a que se reduz.
+O princípio é chamado  {\em\emph{transparência referencial}}.
 
-This works because purely functional programs do not have side
-effects; so a term is equivalent to the term it reduces to.
-
-The principle is called {\em\emph{referential transparency}}.
 \es
-\bsh{Structural Induction}
+\bsh{Indução Estrutural}
 
-The principle of structural induction is analogous to natural induction:
+O princípio da indução estrutural é análogo à indução natural:
 
-In the case of lists, it is as follows:
+No caso de listas, funciona como segue:
 
-To prove a property \mathtext{P(xs)} for all lists \mathtext{xs},
+Para provar uma propriedade \mathtext{P(xs)} para todas as listas  \mathtext{xs},
+
 \be
-\item Show that \code{P(List())} holds (\emph{base case}).
-\item For arbitrary lists \mathtext{xs} and elements \mathtext{x} 
-      show:
+\item Mostre que \code{P(List())} vale no (\emph{caso base}).
+\item Para listas arbitrárias \mathtext{xs} e elementos \mathtext{x}, mostre: 
 \begin{quote}
-     if \mathtext{P(xs)} holds, then \mathtext{P(x :: xs)} holds as well
+     se \mathtext{P(xs)} vale, então \mathtext{P(x :: xs)} também vale.
 \end{quote}
-(\emph{induction step}).
+(\emph{passo indutivo}).
 \ee
 
 \es
-\bsh{Example}
+\bsh{Exemplo}
 
-We show \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} by structural induction
-on \code{xs}.
+Mostramos \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} através de indução estrutural sobre \code{xs}.
 
 \Case{\code{List()}}
-For the left-hand side, we have:
+Para a parte esquerda, temos:
 \begin{lstlisting}
     \= (List() ::: ys) ::: zs
- =     \> $\expl{by first clause of \prog{:::}}$
+ =     \> $\expl{pela primeira cláusula de \prog{:::}}$
        \> ys ::: zs
 \end{lstlisting}
-For the right-hand side, we have:
+Para a parte direita, temos:
 \begin{lstlisting}
     \= List() ::: (ys ::: zs)
- =     \> $\expl{by first clause of \prog{:::}}$
+ =     \> $\expl{pela primeira cláusula de \prog{:::}}$
        \> ys ::: zs
 \end{lstlisting}
-So the case is established.
+Então, o case é estabelecido.
 
 \es
 \bs
 \Case{\code{x :: xs}} 
 
-For the left-hand side, we have:
+Para a parte esquerda, temos:
 \begin{lstlisting}
     \= ((x :: xs) ::: ys) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
+ =     \> $\expl{pela segunda cláusula de \prog{:::}}$
        \> (x :: (xs ::: ys)) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
+ =     \> $\expl{pela segunda cláusula de \prog{:::}}$
        \> x :: ((xs ::: ys) ::: zs)
- =     \> $\expl{by the induction hypothesis}$
+ =     \> $\expl{pela hipótese de indução}$
        \> x :: (xs ::: (ys ::: zs))
 \end{lstlisting}
 
-For the right-hand side, we have:
+Para a parte direita, temos:
 \begin{lstlisting}
     \= (x :: xs) ::: (ys ::: zs)
- =     \> $\expl{by second clause of \prog{:::}}$
+ =     \> $\expl{pela segunda cláusula de \prog{:::}}$
        \> x :: (xs ::: (ys ::: zs))
 \end{lstlisting}
-So the case (and with it the property) is established.
-
+Então, o case (e com ele a propriedade) é estabelecido.
 \begin{exercise}
 %% Show by induction on \code{xs} that \code{xs ::: List()  =  xs}.
 Mostre por indu\c{c}\~{a}o que dado \code{xs} temos \code{xs ::: List() = xs}. 
@@ -4992,66 +4988,66 @@ abstract class List[A] { ...
   }
 }
 \end{lstlisting}
-We would like to prove the proposition that
+Gostaríamos de provar a proposição 
 \begin{lstlisting}
    xs.reverse.reverse  =  xs  .
 \end{lstlisting}
-We proceed by induction over \code{xs}. The base case is easy to establish:
+Procedemos por indução sobre \code{xs}. O caso base é fácil de se estabelecer:
 \begin{lstlisting}
     \= List().reverse.reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
+ =     \> $\expl{pela primeira cláusula de \prog{reverse}}$
        \> List().reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
+ =     \> $\expl{pela primeira cláusula de \prog{reverse}}$
        \> List()
 \end{lstlisting}
 \es\bs
-For the induction step, we try:
+Para o passo indutivo, tentamos:
 \begin{lstlisting}
     \= (x :: xs).reverse.reverse
- =     \> $\expl{by second clause of \prog{reverse}}$
+ =     \> $\expl{pela segunda cláusula de \prog{reverse}}$
        \> (xs.reverse ::: List(x)).reverse
 \end{lstlisting}
-There's nothing more we can do to this expression, so we turn to the right side:
+Não há nada mais o que se fazer com esta expressão, logo nos voltamos para a parte direita:
 \begin{lstlisting}
     \= x :: xs
- =     \> $\expl{by induction hypothesis}$
+ =     \> $\expl{pela hipótese indutiva}$
        \> x :: xs.reverse.reverse
 \end{lstlisting}
-The two sides have simplified to different expressions.
-
-So we still have to show that
+Os dois lados foram simplificados para expressões diferentes.
+Portanto, ainda temos que mostrar que 
 \begin{lstlisting}
   (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
 \end{lstlisting}
-Trying to prove this directly by induction does not work.
+Tentar provar isto diretamente através de indução não funciona.
 
-Instead we have to {\em generalize} the equation to:
+Ao invés, temos que {\em generalizar} a equação para:
 \begin{lstlisting}
   (ys ::: List(x)).reverse  =  x :: ys.reverse
 \end{lstlisting}
 \es\bs
-This equation can be proved by a second induction argument over \code{ys}.
-(See blackboard).
+Esta equação pode ser provada por um segundo argumento indutivo sobre \code{ys}.
+(Veja o blackboard).
 
 \begin{exercise}
-Is it the case that \code{(xs drop m) at n  =  xs at (m + n)} for all 
-natural numbers \code{m}, \code{n} and all lists \code{xs}?
+No caso em que \code{(xs drop m) at n  =  xs at (m + n)} para todos os números naturais \code{m}, 
+\code{n} e todas as listas \code{xs}?
 \end{exercise}
 
 \es
-\bsh{Structural Induction on Trees}
+\bsh{Indução Estrutural sobre Árvores}
 
-Structural induction is not restricted to lists; it works for arbitrary
-trees.
+Indução estrutural não se restringe à listas; funciona para árvores arbitrárias.
 
-The general induction principle is as follows.
+O princípio geral de indução é como segue.
 
-To show that property \code{P(t)} holds for all trees of a certain type,
+Para mostrar que a propriedade \code{P(t)} vale para todas as árvores de um certo tipo,
 \begin{itemize}
-\item Show \code{P(l)} for all leaf trees \code{$l$}.
-\item For every interior node \code{t} with subtrees \code{s$_1$, ..., s$_n$}, 
-      show that \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}.
+\item Mostre \code{P(l)} para todas as folhas das árvores \code{$l$}.
+\item Para cada nó interno \code{t} com subárvores \code{s$_1$, ..., s$_n$},
+      mostre que  \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}. 
 \end{itemize} 
+
+%------------xpto
 
 \example Recall our definition of \code{IntSet} with 
 operations \code{contains} and \code{incl}:

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -9,7 +9,7 @@
 
 \chapter{\label{chap:example-one}Um primeiro exemplo}
 
-Para começar, apresentamos um primeiro exemplo, a implementação de Quicksort em Scala.
+Para come\c{c}ar, apresentamos um primeiro exemplo, a implementa\c{c}\~{a}o de Quicksort em Scala.
 
 \begin{lstlisting}
 def sort(xs: Array[Int]) {
@@ -35,20 +35,20 @@ def sort(xs: Array[Int]) {
 }
 \end{lstlisting}
 
-A implementação se parece muito com a que você faria em Java
-ou C. Nós usamos os mesmos operadores e estruturas de controle.
-Existem também algumas pequenas diferenças sintáticas, particularmente:
+A implementa\c{c}\~{a}o se parece muito com a que voc\^{e} faria em Java
+ou C. N\'{o}s usamos os mesmos operadores e estruturas de controle.
+Existem tamb\'{e}m algumas pequenas diferen\c{c}as sint\'{a}ticas, particularmente:
 \begin{itemize}
 \item
-As declarações começam usando palavras reservadas. Particularmente, declarações de funções são iniciadas
-com a palavra \code{def}, declarações de variáveis são iniciadas com a palavra \code{var} e
-declaração de constantes (chamadas de valores) são iniciadas com a palavra \code{val}.
+As declara\c{c}\~{o}es come\c{c}am usando palavras reservadas. Particularmente, declara\c{c}\~{o}es de fun\c{c}\~{o}es s\~{a}o iniciadas
+com a palavra \code{def}, declara\c{c}\~{o}es de vari\'{a}veis s\~{a}o iniciadas com a palavra \code{var} e
+declara\c{c}\~{a}o de constantes (chamadas de valores) s\~{a}o iniciadas com a palavra \code{val}.
 \item
-O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
+O tipo de um par\^{a}metro em uma fun\c{c}\~{a}o \'{e} declarado ap\'{o}s o nome do par\^{a}metro seguido de dois pontos(:).
 O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
-A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
-O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
+A  declara\c{c}\~{a}o de vetores do tipo \code{T} \'{e} feita usando a express\~{a}o \code{Array[T]} ao inv\'{e}s de \code{T[]}. 
+O i-\'{e}simo elemento de um vetor \code{a} \'{e} acessado usando \code{a(i)} ao inv\'{e}s de \code{a[i]}.
 %----------
 %\item
 %Functions can be nested inside other functions. Nested functions can
@@ -57,10 +57,10 @@ O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invé
 %\code{swap} and \code{sort1}, and therefore need not be passed as a
 %parameter to them.
 \item
-Funções podem ser aninhadas umas dentro das outras. Funções aninhadas podem
-acessar parâmetros e variáveis locais de suas funções externas. Por
-exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e 
-\code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
+Fun\c{c}\~{o}es podem ser aninhadas umas dentro das outras. Fun\c{c}\~{o}es aninhadas podem
+acessar par\^{a}metros e vari\'{a}veis locais de suas fun\c{c}\~{o}es externas. Por
+exemplo, o nome do vetor \code{xs} \'{e} vis\'{i}vel nas fun\c{c}\~{o}es \code{swap} e 
+\code{sort1}, e portanto n\~{a}o precisam ser passadas como um par\^{a}metro para elas.
 %----------
 \end{itemize}
 
@@ -76,13 +76,13 @@ exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e
 %completely different. Here is Quicksort again, this time written in
 %functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
-com algumas peculiaridades sintáticas. De fato é possível escrever
-programas em estilo imperativo ou orientado a objetos. Isto é 
-importante, porque é uma das coisas que facilitam combinar componentes
+com algumas peculiaridades sint\'{a}ticas. De fato \'{e} poss\'{i}vel escrever
+programas em estilo imperativo ou orientado a objetos. Isto \'{e} 
+importante, porque \'{e} uma das coisas que facilitam combinar componentes
 Scala com componentes escritos em linguagens convencionais, tais como Java,
 C\# ou Visual Basic.
-Entretanto, também é possível escrever programas num estilo completamente
-diferente. Aqui está o Quicksort novamente, desta vez escrito em 
+Entretanto, tamb\'{e}m \'{e} poss\'{i}vel escrever programas num estilo completamente
+diferente. Aqui est\'{a} o Quicksort novamente, desta vez escrito em 
 estilo funcional.
 %----------
 \begin{lstlisting}
@@ -114,19 +114,19 @@ def sort(xs: Array[Int]): Array[Int] = {
 %% less than or greater or equal to pivot.}
 %% \item The result is obtained by appending the three sub-arrays together.
 %% \end{itemize}
-O programa funcional captura a essência do algoritmo quicksort de modo conciso:
+O programa funcional captura a ess\^{e}ncia do algoritmo quicksort de modo conciso:
 \begin{itemize}
-\item Se o vetor está vazio ou consiste de um único elemento, já está ordenado,
-      então retorne imediatamente.
-\item Se o vetor não está vazio, escolha um elemento do meio do vetor como pivô.
+\item Se o vetor est\'{a} vazio ou consiste de um \'{u}nico elemento, j\'{a} est\'{a} ordenado,
+      ent\~{a}o retorne imediatamente.
+\item Se o vetor n\~{a}o est\'{a} vazio, escolha um elemento do meio do vetor como piv\^{o}.
 \item Particione o vetor em dois subvetores contendo, respectivamente os elementos
- que são menores que o elemento pivô, maiores que, e um terceiro vetor que contém
- elementos iguais ao pivô.
-\item Ordene os dois primeiros subvetores por uma chamada recursiva da função de 
-ordenação.\footnote{Isso não é exatamente o que o algoritmo imperativo faz; este 
-último particiona o vetor em dois subvetores contendo elementos menores que ou 
-maiores ou iguais ao pivô.}
-\item O resultado é obtido pela concatenação dos três subvetores.
+ que s\~{a}o menores que o elemento piv\^{o}, maiores que, e um terceiro vetor que cont\'{e}m
+ elementos iguais ao piv\^{o}.
+\item Ordene os dois primeiros subvetores por uma chamada recursiva da fun\c{c}\~{a}o de 
+ordena\c{c}\~{a}o.\footnote{Isso n\~{a}o \'{e} exatamente o que o algoritmo imperativo faz; este 
+\'{u}ltimo particiona o vetor em dois subvetores contendo elementos menores que ou 
+maiores ou iguais ao piv\^{o}.}
+\item O resultado \'{e} obtido pela concatena\c{c}\~{a}o dos tr\^{e}s subvetores.
 \end{itemize}
 %----------
 
@@ -138,12 +138,12 @@ maiores ou iguais ao pivô.}
 %% implementation returns a new sorted array and leaves the argument
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
-Tanto a implementação imperativa quanto a funcional tem mesma complexidade
-assintótica -- $O(N;log(N))$ no caso médio e $O(Nˆ2)$ no pior caso. Mas onde
-a implementação imperativa opera localmente, modificando o vetor original,
-a implementação funcional retorna um novo vetor ordenado e deixa o vetor
-original inalterado. A implementação funcional, portanto, requer mais
-memória transiente que a imperativa.
+Tanto a implementa\c{c}\~{a}o imperativa quanto a funcional tem mesma complexidade
+assint\'{o}tica -- $O(N;log(N))$ no caso m\'{e}dio e $O(N FIXME)$ no pior caso. Mas onde
+a implementa\c{c}\~{a}o imperativa opera localmente, modificando o vetor original,
+a implementa\c{c}\~{a}o funcional retorna um novo vetor ordenado e deixa o vetor
+original inalterado. A implementa\c{c}\~{a}o funcional, portanto, requer mais
+mem\'{o}ria transiente que a imperativa.
 %----------
 
 %----------
@@ -154,12 +154,12 @@ memória transiente que a imperativa.
 %% standard Scala library, and which itself is implemented in
 %% Scala. Because arrays are instances of \verb@Seq@ all sequence
 %% methods are available for them.
-A implementação funcional faz parecer que Scala é uma linguagem
-especializada para operações funcionais sobre vetores. De fato, não é;
-todas as operações usadas no exemplo são simples métodos de biblioteca
-de uma classe {\em sequência} \code{Seq[T]} que é parte da biblioteca
-padrão Scala, e onde ela mesma é implementada em Scala. Como vetores são 
-instâncias de \verb@Seq@, todos os métodos de sequência estão disponíveis
+A implementa\c{c}\~{a}o funcional faz parecer que Scala \'{e} uma linguagem
+especializada para opera\c{c}\~{o}es funcionais sobre vetores. De fato, n\~{a}o \'{e};
+todas as opera\c{c}\~{o}es usadas no exemplo s\~{a}o simples m\'{e}todos de biblioteca
+de uma classe {\em sequ\^{e}ncia} \code{Seq[T]} que \'{e} parte da biblioteca
+padr\~{a}o Scala, e onde ela mesma \'{e} implementada em Scala. Como vetores s\~{a}o 
+inst\^{a}ncias de \verb@Seq@, todos os m\'{e}todos de sequ\^{e}ncia est\~{a}o dispon\'{i}veis
 para eles.
 %----------
 
@@ -170,11 +170,11 @@ para eles.
 %% array consisting of all the elements of the original array for which the
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
-Em particular, há o método \code{filter} que recebe como argumento uma
-{\em função predicado}. Esta função predicado deve mapear elementos do 
-vetor para valores boleanos. O resultado de \code{filter} é um vetor
-consistindo de todos os elementos do vetor original para o qual a função
-predicado é verdadeira. O método \code{filter} de um objeto tipo
+Em particular, h\'{a} o m\'{e}todo \code{filter} que recebe como argumento uma
+{\em fun\c{c}\~{a}o predicado}. Esta fun\c{c}\~{a}o predicado deve mapear elementos do 
+vetor para valores boleanos. O resultado de \code{filter} \'{e} um vetor
+consistindo de todos os elementos do vetor original para o qual a fun\c{c}\~{a}o
+predicado \'{e} verdadeira. O m\'{e}todo \code{filter} de um objeto tipo
 \code{Array[T]} portanto tem a assinatura. 
 %----------
 
@@ -188,11 +188,11 @@ def filter(p: T => Boolean): Array[T]
 %% of type \code{t} and return a \code{Boolean}.  Functions like
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
-Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
+Aqui, \code{T=>Boolean} \'{e} o tipo das fun\c{c}\~{o}es que recebem um elemento 
 do tipo \code{T} e retornam um valor booleano do tipo \code{Boolean}. 
-Funções como \code{filter} 
-que recebem uma outra função como argumento ou retornam uma função como
-resultado são chamadas {\em funções de alta ordem.}     
+Fun\c{c}\~{o}es como \code{filter} 
+que recebem uma outra fun\c{c}\~{a}o como argumento ou retornam uma fun\c{c}\~{a}o como
+resultado s\~{a}o chamadas {\em fun\c{c}\~{o}es de alta ordem.}     
 %----------
 
 %----------
@@ -205,15 +205,15 @@ resultado são chamadas {\em funções de alta ordem.}
 %% for binary infix operators which start with a letter. Hence, the
 %% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
 %% method call ~\lstinline@xs.filter(pivot >)@.
-Scala não faz distinção entre nomes de identificadores e nomes de operadores.
-um identificador pode ser ou uma sequência de letras ou digitos que começam
-com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
+Scala n\~{a}o faz distin\c{c}\~{a}o entre nomes de identificadores e nomes de operadores.
+um identificador pode ser ou uma sequ\^{e}ncia de letras ou digitos que come\c{c}am
+com uma letra, ou podem ser uma sequ\^{e}ncia de caracteres especiais, tais como 
 ``\code{+}'', ``\code{*}'', ou ``\code{:}''.  Qualquer identificador pode
-ser usado como operador infixo em Scala. A operação binária $E;op;E'$ é sempre
-interpretado como a chamada de método $E.op(E')$. Isso vale também para 
-operadores binários infixos que iniciam com uma letra. Consequentemente,
-a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
-método ~\lstinline@xs.filter(pivot >)@.
+ser usado como operador infixo em Scala. A opera\c{c}\~{a}o bin\'{a}ria $E;op;E'$ \'{e} sempre
+interpretado como a chamada de m\'{e}todo $E.op(E')$. Isso vale tamb\'{e}m para 
+operadores bin\'{a}rios infixos que iniciam com uma letra. Consequentemente,
+a express\~{a}o  ~\lstinline@xs filter (pivot >)@~ \'{e} equivalente à chamada de
+m\'{e}todo ~\lstinline@xs.filter(pivot >)@.
 %----------
 
 
@@ -231,25 +231,25 @@ método ~\lstinline@xs.filter(pivot >)@.
 %% summarize, \code{xs.filter(pivot >)} returns a list consisting
 %% of all elements of the list \code{xs} that are smaller than
 %% \code{pivot}.
-No programa quicksort, \code{filter} é aplicado três vezes a um argumento 
-de função anônima. O primeiro argumento, \code{pivot >}, representa uma 
-função que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
-Este é um exemplo de uma {\em função parcialmente aplicada}. Um outro modo, 
-equivalente de se escrever esta função, que torna o argumento oculto explicito
-é ~\lstinline@x => pivot > x@. A função é anônima, ou seja, não é definida
-com um nome. O tipo do parâmetro  \code{x} é omitido porque um compilador Scala 
-pode inferí-lo automáticamente a partir do contexto onde a função é usada.
+No programa quicksort, \code{filter} \'{e} aplicado tr\^{e}s vezes a um argumento 
+de fun\c{c}\~{a}o an\^{o}nima. O primeiro argumento, \code{pivot >}, representa uma 
+fun\c{c}\~{a}o que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
+Este \'{e} um exemplo de uma {\em fun\c{c}\~{a}o parcialmente aplicada}. Um outro modo, 
+equivalente de se escrever esta fun\c{c}\~{a}o, que torna o argumento oculto explicito
+\'{e} ~\lstinline@x => pivot > x@. A fun\c{c}\~{a}o \'{e} an\^{o}nima, ou seja, n\~{a}o \'{e} definida
+com um nome. O tipo do par\^{a}metro  \code{x} \'{e} omitido porque um compilador Scala 
+pode infer\'{i}-lo autom\'{a}ticamente a partir do contexto onde a fun\c{c}\~{a}o \'{e} usada.
 Resumindo, \code{xs.filter(pivot >)} retorna uma lista consistindo de todos os 
-elementos da lista \code{xs} que são menores que \code{pivot}.  
+elementos da lista \code{xs} que s\~{a}o menores que \code{pivot}.  
 %----------
 
 %----------
 %% Looking again in detail at the first, imperative implementation of
 %% Quicksort, we find that many of the language constructs used in the
 %% second solution are also present, albeit in a disguised form.
-Olhando novamente em detalhes para a primeira, implementação imperativa
+Olhando novamente em detalhes para a primeira, implementa\c{c}\~{a}o imperativa
 do Quicksort, percebemos que muitos dos construtores da linguagem 
-usados na segunda solução estão presentes, embora de modo distinto.
+usados na segunda solu\c{c}\~{a}o est\~{a}o presentes, embora de modo distinto.
 %----------
 
 
@@ -263,23 +263,23 @@ usados na segunda solução estão presentes, embora de modo distinto.
 %% Of course, a compiler is free (if it is moderately smart, even expected)
 %% to recognize the special case of calling the \code{+} method over
 %% integer arguments and to generate efficient inline code for it.
-Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
-ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
-são métodos de seus operandos esquerdos. Consequentemente, a expressão 
-\code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
-do valor inteiro de \code{i}. De fato, um compilador é livre (se 
+Por exemplo, operadores bin\'{a}rios padr\~{a}o, tais como \code{+}, \code{-},
+ou \code{<} n\~{a}o s\~{a}o tratados de modo especial. Assim como \code{append}, 
+s\~{a}o m\'{e}todos de seus operandos esquerdos. Consequentemente, a express\~{a}o 
+\code{i+1} \'{e} vista como a invoca\c{c}\~{a}o de \code{i.+(1)} do m\'{e}todo \code{+}      
+do valor inteiro de \code{i}. De fato, um compilador \'{e} livre (se 
 moderadamente esperto, ainda que  esperado) para reconhecer o caso 
-especial da chamada de método \code{+} sobre argumentos inteiros e 
-para gerar código inline eficiente para isso.  
+especial da chamada de m\'{e}todo \code{+} sobre argumentos inteiros e 
+para gerar c\'{o}digo inline eficiente para isso.  
 %----------
 
 %----------
 %% For efficiency and better error diagnostics the \code{while} loop is a
 %% primitive construct in Scala. But in principle, it could have just as
 %% well been a predefined function. Here is a possible implementation of it:
-Por eficiência e melhor detecção de erros o laço \code{while} é um construtor 
-primitivo em Scala. Mas em princípio, poderia do mesmo modo ser uma função 
-predefinida. Aqui está uma possível implementação para ele: 
+Por efici\^{e}ncia e melhor detec\c{c}\~{a}o de erros o la\c{c}o \code{while} \'{e} um construtor 
+primitivo em Scala. Mas em princ\'{i}pio, poderia do mesmo modo ser uma fun\c{c}\~{a}o 
+predefinida. Aqui est\'{a} uma poss\'{i}vel implementa\c{c}\~{a}o para ele: 
 %----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
@@ -293,11 +293,11 @@ def While (p: => Boolean) (s: => Unit) {
 %% parameter it takes a command function which also takes no parameters
 %% and yields a result of type \lstinline@Unit@. \code{While} invokes the
 %% command function as long as the test function yields true.
-A função \code{While} recebe como primeiro parâmetro uma função teste,
-que não recebe parâmetros e produz um valor boleano. Como segundo parâmetro 
-recebe uma função comando que também não recebe parâmetros e produz como 
-resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
-enquanto a função teste produzir verdadeiro.
+A fun\c{c}\~{a}o \code{While} recebe como primeiro par\^{a}metro uma fun\c{c}\~{a}o teste,
+que n\~{a}o recebe par\^{a}metros e produz um valor boleano. Como segundo par\^{a}metro 
+recebe uma fun\c{c}\~{a}o comando que tamb\'{e}m n\~{a}o recebe par\^{a}metros e produz como 
+resultado o tipo  \lstinline@Unit@. \code{While} invoca a fun\c{c}\~{a}o comando
+enquanto a fun\c{c}\~{a}o teste produzir verdadeiro.
 %----------
 
 %----------
@@ -312,13 +312,13 @@ enquanto a função teste produzir verdadeiro.
 %% ``expression-oriented'' formulation of the \lstinline@swap@ function
 %% in the first implementation of quicksort, which makes this explicit:
 O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
-no Java; é usado sempre que uma função não retornar um resultado interessante.
-De fato, porque Scala é uma linguagem orientada a expressões, cada função 
-retorna algum resultado. Se nenhuma expressão de retorno é  explicitamente
-fornecida, o valor \lstinline@()@, que é pronunciado ``unit'', é assumido.
-Este valor é do tipo \lstinline@Unit@. Funções que retornam ``unit'' são 
-também chamadas {\em procedimentos}. Aqui está uma formulação mais 
-``orientada a expressão'' da função \lstinline@swap@ na primeira implementação
+no Java; \'{e} usado sempre que uma fun\c{c}\~{a}o n\~{a}o retornar um resultado interessante.
+De fato, porque Scala \'{e} uma linguagem orientada a express\~{o}es, cada fun\c{c}\~{a}o 
+retorna algum resultado. Se nenhuma express\~{a}o de retorno \'{e}  explicitamente
+fornecida, o valor \lstinline@()@, que \'{e} pronunciado ``unit'', \'{e} assumido.
+Este valor \'{e} do tipo \lstinline@Unit@. Fun\c{c}\~{o}es que retornam ``unit'' s\~{a}o 
+tamb\'{e}m chamadas {\em procedimentos}. Aqui est\'{a} uma formula\c{c}\~{a}o mais 
+``orientada a express\~{a}o'' da fun\c{c}\~{a}o \lstinline@swap@ na primeira implementa\c{c}\~{a}o
 do quicksort, que explicita isto:
 %----------
 
@@ -334,10 +334,10 @@ def swap(i: Int, j: Int) {
 %% \lstinline@return@ keyword is not necessary. Note that functions
 %% returning an explicit value always need an ``='' before their
 %% body or defining expression.  
-O valor resultante desta função é simplesmente sua última expressão---uma
-palavra chave \lstinline@return@ não é necessária. Observe que funções 
-que retornam um valor explícito sempre precisam de um ``='' antes de
-seus corpos ou expressões de definição.
+O valor resultante desta fun\c{c}\~{a}o \'{e} simplesmente sua \'{u}ltima express\~{a}o---uma
+palavra chave \lstinline@return@ n\~{a}o \'{e} necess\'{a}ria. Observe que fun\c{c}\~{o}es 
+que retornam um valor expl\'{i}cito sempre precisam de um ``='' antes de
+seus corpos ou express\~{o}es de defini\c{c}\~{a}o.
 %----------
 
 \chapter{Programando com Atores e Mensagens}
@@ -351,14 +351,14 @@ seus corpos ou expressões de definição.
 %% its incoming messages which is represented as a queue. It can work
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
-Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
-é particularmente indicada. Considere a tarefa de implementar um serviço
-de leilão eletrônico. Podemos usar um modelo de processo no estilo 
-actor do Erlang para implementar os participantes do leilão. Actors são 
-objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
-para suas mensagens de entrada que é representada para uma fila. Pode
+Aqui est\'{a} um exemplo que mostra uma \'{a}rea de aplica\c{c}\~{a}o para a qual Scala 
+\'{e} particularmente indicada. Considere a tarefa de implementar um servi\c{c}o
+de leil\~{a}o eletr\^{o}nico. Podemos usar um modelo de processo no estilo 
+actor do Erlang para implementar os participantes do leil\~{a}o. Actors s\~{a}o 
+objetos para os quais as mensagens s\~{a}o enviadas. Cada actor tem uma caixa de correio 
+para suas mensagens de entrada que \'{e} representada para uma fila. Pode
 trabalhar sequencialmente nas mensagens da sua caixa de correio, ou buscar 
-por mensagens que casam com algum padrão. 
+por mensagens que casam com algum padr\~{a}o. 
 %----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
@@ -383,11 +383,11 @@ case object AuctionOver                      extends AuctionReply
 %% and that communicates with the seller and winning bidder to close the
 %% transaction. We present an overview of a simple implementation
 %% here.
-Para cada item negociado há um actor leiloeiro que publica a 
-informação sobre o item negociado, que aceita ofertas de clientes
-e que se comunica com o vendedor e com o vencedor do leilão 
-para fechar a transação. Apresentamos uma visão superficial de uma
- implementação aqui.
+Para cada item negociado h\'{a} um actor leiloeiro que publica a 
+informa\c{c}\~{a}o sobre o item negociado, que aceita ofertas de clientes
+e que se comunica com o vendedor e com o vencedor do leil\~{a}o 
+para fechar a transa\c{c}\~{a}o. Apresentamos uma vis\~{a}o superficial de uma
+ implementa\c{c}\~{a}o aqui.
 %----------
 
 %----------
@@ -397,10 +397,10 @@ para fechar a transação. Apresentamos uma visão superficial de uma
 %% service, and \code{AuctionReply} for replies from the service to the
 %% clients.  For both base classes there exists a number of cases, which
 %% are defined in Figure~\ref{fig:simple-auction-msgs}.
-Como primeiro passo, definimos as mensagens que são trocadas durante um
-leilão. Há duas classes base abstratas \code{AuctionMessage} para mensagens 
-de clientes do serviço de leilão, e \code{AuctionReply} para respostas 
-do serviço aos clientes. Para ambas as classes base há um número de casos 
+Como primeiro passo, definimos as mensagens que s\~{a}o trocadas durante um
+leil\~{a}o. H\'{a} duas classes base abstratas \code{AuctionMessage} para mensagens 
+de clientes do servi\c{c}o de leil\~{a}o, e \code{AuctionReply} para respostas 
+do servi\c{c}o aos clientes. Para ambas as classes base h\'{a} um n\'{u}mero de casos 
 definidos na Figura~\ref{fig:simple-auction-msgs}.
 %----------
 
@@ -446,11 +446,16 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 %% might well be ultimately mapped to small XML documents. We expect
 %% automatic tools to exist that convert between XML documents and
 %% internal data structures like the ones defined above.
-Para cada classe base, há um número de {\em classes case} que definem
+Para cada classe base, h\'{a} um n\'{u}mero de {\em classes case} que definem
 o formato de mensagens particulares dentro da classe. Estas mensagens
-podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
-que hajam ferramentas automáticas que convertam entre documentos XML e 
+podem em \'{u}ltimo caso ser mapeadas a pequenos documentos XML. Esperamos
+que hajam ferramentas autom\'{a}ticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
+% Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
+%
+% Resp: por que trata-se de um modelo de concorr\^{e}ncia (o nome do modelo) 
+% usado por Scala que foi inspirado no modelo do Erlang:
+%      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
 
 %----------
@@ -468,19 +473,19 @@ estruturas de dados internas, tais como as definidas acima.
 %% message. Before finally stopping, it stays active for another period
 %% determined by the \code{timeToShutdown} constant and replies to
 %% further offers that the auction is closed.
-A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
-\code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
-para esta classe são criados com as informações:
+A Figura~\ref{fig:simple-auction} apresenta uma implementa\c{c}\~{a}o Scala para a classe
+\code{Auction} para actors do leil\~{a}o que coordenam os lances sobre um item. Objetos
+para esta classe s\~{a}o criados pela indica\c{c}\~{a}o
 \begin{itemize}
-\item Um actor vendedor que precisa ser notificado quando o leilão terminou,
-\item o lance mínimo,
-\item a data de quando o leilão foi fechado.
+\item Um actor vendedor que precisa ser notificado quando o leil\~{a}o terminou,
+\item o lance m\'{i}nimo,
+\item a data de quando o leil\~{a}o foi fechado.
 \end{itemize}  
-O comportamento do actor é definido por seu método \code{act}. Este método seleciona
-repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, até que o 
-leilão seja fechado, o que é sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
-finalmente parar, permanece ativo para um outro período determinado pela constante 
-\code{timeToShutdown} e replica para ofertas posteriores que o leilão está fechado.    
+O comportamento do actor \'{e} definido por seu m\'{e}todo \code{act}. Este m\'{e}todo seleciona
+repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, at\'{e} que o 
+leil\~{a}o seja fechado, o que \'{e} sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
+finalmente parar, permanece ativo para um outro per\'{i}odo determinado pela constante 
+\code{timeToShutdown} e replica para ofertas posteriores que o leil\~{a}o est\'{a} fechado.    
 %----------
 
 %----------
@@ -495,14 +500,14 @@ finalmente parar, permanece ativo para um outro período determinado pela consta
 %% messages matching the pattern. The \code{receiveWithin} method selects
 %% the first message in the mailbox which matches one of these patterns
 %% and applies the corresponding action to it.
-Aqui estão algumas explicações extras sobre os construtores usados neste programa:
+Aqui est\~{a}o algumas explica\c{c}\~{o}es extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
-O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um prazo dado
-em milisegundos e uma função que processa mensagens na caixa de correio. A função é dada
-por uma sequência de cases que especificam um padrão e uma ação para mensagens que 
-casam com o padrão. O método \code{receiveWithin} seleciona a primeira mensagem da 
-caixa de correio que casa com um destes padrões e aplica a ação correspondente a ele. 
+O m\'{e}todo \code{receiveWithin} da classe \code{Actor} recebe como par\^{a}metro um prazo dado
+em milisegundos e uma fun\c{c}\~{a}o que processa mensagens na caixa de correio. A fun\c{c}\~{a}o \'{e} dada
+por uma sequ\^{e}ncia de cases que especificam um padr\~{a}o e uma a\c{c}\~{a}o para mensagens que 
+casam com o padr\~{a}o. O m\'{e}todo \code{receiveWithin} seleciona a primeira mensagem da 
+caixa de correio que casa com um destes padr\~{o}es e aplica a a\c{c}\~{a}o correspondente a ele. 
 %----------
 
 
@@ -514,10 +519,10 @@ caixa de correio que casa com um destes padrões e aplica a ação correspondent
 %% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
 %% special message, which is triggered by the \code{Actor} implementation itself.
 \item
-O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
-Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrão é disparado
-após o prazo que foi passado como argumento para o método envolvente \code{receiveWithin}.
-\code{TIMEOUT} é uma mensagem especial, que é disparada pela própria implementação do 
+O \'{u}ltimo case de \code{receiveWithin} \'{e} guardado por um padr\~{a}o \code{TIMEOUT}.  
+Se nenhuma outra mensagem foi recebida nesse meio tempo, este padr\~{a}o \'{e} disparado
+ap\'{o}s o prazo que foi passado como argumento para o m\'{e}todo envolvente \code{receiveWithin}.
+\code{TIMEOUT} \'{e} uma mensagem especial, que \'{e} disparada pela pr\'{o}pria implementa\c{c}\~{a}o do 
 \code{Actor}.    
 %----------
 
@@ -532,10 +537,10 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 %% parameter.
 %% \end{itemize}
 \item
-Mensagens de resposta são enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
-\code{!} é usado aqui como um operador binário com um actor e uma mensagem como argumentos.
-Isto é equivalente em Scala ao chamado de método \code{destino.!(AlgumaMensagem)}, ou seja, 
-a invocação do método \code{!} do actor destino com a mensagem dada como parâmetro.
+Mensagens de resposta s\~{a}o enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
+\code{!} \'{e} usado aqui como um operador bin\'{a}rio com um actor e uma mensagem como argumentos.
+Isto \'{e} equivalente em Scala ao chamado de m\'{e}todo \code{destino.!(AlgumaMensagem)}, ou seja, 
+a invoca\c{c}\~{a}o do m\'{e}todo \code{!} do actor destino com a mensagem dada como par\^{a}metro.
 \end{itemize}    
 %----------
 
@@ -549,14 +554,14 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par�
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussão precedente deu uma idéia de programação distribuída em Scala.Pode parecer 
-que Scala tenha um rico conjunto de construtores que suportam
-processos actor, envio e recebimento de mensagens, programação com timeouts etc.
-De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
-oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
+A discuss\~{a}o precedente deu uma id\'{e}ia de programa\c{c}\~{a}o distribu\'{i}da em Scala. Isso
+d\'{a} a sensa\c{c}\~{a}o que Scala tem um rico conjunto de construtores que suportam
+processos actor, envio e recebimento de mensagens, programa\c{c}\~{a}o com timeouts etc.
+De fato, o oposto \'{e} verdadeiro. Todos os construtores discutidos acima s\~{a}o 
+oferecidos como m\'{e}todos na classe biblioteca \code{Actor}. Aquela classe \'{e}
 ele mesma implementada em Scala, baseado no modelo thread subjacente à linguagem 
-hospedeira (Java ou .NET). A implementação de todas as características da 
-classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
+hospedeira (Java ou .NET). A implementa\c{c}\~{a}o de todas as caracter\'{i}sticas da 
+classe \code{Actor} usada aqui \'{e} dada na Se\c{c}\~{a}o~\ref{sec:actors}.     
 %----------
 
 %----------
@@ -574,37 +579,38 @@ classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
-As vantagens da abordagem baseada em biblioteca são a relativa simplicidade
-da linguagem núcleo e a flexibilidade para os criadores de biblioteca. Como 
-a linguagem núcleo não precisa especificar detalhes da comunicação dos 
-processos de alto nível, pode ser mantida mais simples e geral. Como
-um modelo particular de mensagens numa caixa de correio é um módulo biblioteca, 
-pode ser modificado livremente se um diferente modelo for necessário em algumas 
-aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
-o suficiente para prover as abstrações linguísticas necessárias de um modo 
+As vantagens da abordagem baseada em biblioteca s\~{a}o a relativa simplicidade
+da linguagem n\'{u}cleo e a flexibilidade para os criadores de biblioteca. Como 
+a linguagem n\'{u}cleo n\~{a}o precisa especificar detalhes da comunica\c{c}\~{a}o dos 
+processos de alto n\'{i}vel, pode ser mantida mais simples e geral. Como
+um modelo particular de mensagens numa caixa de correio \'{e} um m\'{o}dulo biblioteca, 
+pode ser modificado livremente se um diferente modelo for necess\'{a}rio em algumas 
+aplica\c{c}\~{o}es. A abordagem requer, entretanto, que a linguagem n\'{u}cleo seja expressiva
+o suficiente para prover as abstra\c{c}\~{o}es lingu\'{i}sticas necess\'{a}rias de um modo 
 conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
-projeto foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
-hospedeira para linguagens de domínios específicos (DSL) implementados por módulos de 
-biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
-pode ser vista como um dessas linguagens de domínios específicos, que conceitualmente
-estendem o núcleo Scala.  
+design foi deix\'{a}-la flex\'{i}vel o suficiente para atuar como uma conveniente linguagem
+hospedeira para dom\'{i}nios de linguagens espec\'{i}ficos implementados por m\'{o}dulos de 
+biblioteca. Por exemplo, a constru\c{c}\~{a}o de comunica\c{c}\~{a}o actor apresentada acima
+pode ser vista como um desses dom\'{i}nios espec\'{i}ficos de linguagem, que conceitualmente
+estendem o n\'{u}cleo Scala.  
 %----------
 
 %----------
+% Vinicius - comecei traducao aqui.
 %%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
-\chapter{\label{chap:simple-funs}Expressões e Funções Simples}
+\chapter{\label{chap:simple-funs}Express\~{o}es e Fun\c{c}\~{o}es Simples}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
 Os exemplos anteriores deram uma ideia do que pode ser feito com Scala. Agora,
-introduzimos as suas construções de linguagem uma a uma de uma maneira mais sistemática.
-Vamos começar com os menores elementos: expressões e funções.
+introduzimos as suas constru\c{c}\~{o}es de linguagem uma a uma de uma maneira mais sistem\'{a}tica.
+Vamos come\c{c}ar com os menores elementos: express\~{o}es e fun\c{c}\~{o}es.
 
 
 %%\section{Expressions And Simple Functions}
-\section{Expressões e Funções Simples}
+\section{Express\~{o}es e Fun\c{c}\~{o}es Simples}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
@@ -612,8 +618,8 @@ Vamos começar com os menores elementos: expressões e funções.
 %% types. For example:
 %----------
 Scala vem com um interpretador que pode ser visto como uma calculadora sofisticada.
-O usuário interage com a calculadora digitando expressões. A calculadora retorna o
-resultado do cálculo e o seu tipo de dado. Por exemplo: 
+O usu\'{a}rio interage com a calculadora digitando express\~{o}es. A calculadora retorna o
+resultado do c\'{a}lculo e o seu tipo de dado. Por exemplo: 
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -627,8 +633,8 @@ unnamed2: java.lang.String = hello world!
 \end{lstlisting}
 %It is also possible to name a sub-expression and use the name instead
 %of the expression afterwards:
-Também é possível dar nome a uma sub-expressão e usar o nome, ao invés da expressão, 
-nas expressões seguintes:
+Tamb\'{e}m \'{e} poss\'{i}vel dar nome a uma sub-express\~{a}o e usar o nome, ao inv\'{e}s da express\~{a}o, 
+nas express\~{o}es seguintes:
 \begin{lstlisting}
 scala> def scale = 5
 scale: Int
@@ -652,9 +658,12 @@ unnamed4: Double = 62.83185307179586
 %% Definitions start with the reserved word \code{def}; they introduce a
 %% name which stands for the expression following the \code{=} sign.  The
 %% interpreter will answer with the introduced name and its type.
-Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
-que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
+Defini\c{c}\~{o}es come\c{c}am com a palavra reservada \code{def}. Elas introduzem um nome
+que representa a express\~{a}o que vem depois do s\'{i}mbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
+% Vinicius - parei traducao aqui.
+
+
 
 %----------
 %% Executing a definition such as \code{def x = e} will not evaluate the
@@ -664,11 +673,11 @@ responde com o nome introduzido e o seu tipo de dado.
 %% evaluation of the definition. If \code{x} is then used subsequently,
 %% it is immediately replaced by the pre-computed value of
 %% \code{e}, so that the expression need not be evaluated again.
-Executando uma definição tal como \code{def x = e} não avaliará a expressão \code{e}. 
-Ao invés \code{e} é avaliado sempre que \code{x} for usado. Alternativamente, Scala 
-oferece um valor definição \code{val x = e}, o qual avalia o lado direito de \code{e}
-como parte da avaliação da definição. Se \code{x} é então usado subsequentemente, é 
-imediatamente substituído pelo valor pré-computado de \code{e}, logo a expressão não 
+Executando uma defini\c{c}\~{a}o tal como \code{def x = e} n\~{a}o avaliar\'{a} a express\~{a}o \code{e}. 
+Ao inv\'{e}s \code{e} \'{e} avaliado sempre que \code{x} for usado. Alternativamente, Scala 
+oferece um valor defini\c{c}\~{a}o \code{val x = e}, o qual avalia o lado direito de \code{e}
+como parte da avalia\c{c}\~{a}o da defini\c{c}\~{a}o. Se \code{x} \'{e} ent\~{a}o usado subsequentemente, \'{e} 
+imediatamente substitu\'{i}do pelo valor pr\'{e}-computado de \code{e}, logo a express\~{a}o n\~{a}o 
 precisa ser avaliada novamente.
 %----------
 
@@ -687,17 +696,17 @@ precisa ser avaliada novamente.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
-Como as expressões são avaliadas? Uma expressão consistindo de operadores e 
-operandos é avaliada pela repetida aplicação dos seguintes passos de simplificação:
+Como as express\~{o}es s\~{a}o avaliadas? Uma express\~{a}o consistindo de operadores e 
+operandos \'{e} avaliada pela repetida aplica\c{c}\~{a}o dos seguintes passos de simplifica\c{c}\~{a}o:
 \begin{itemize}
-\item escolha a operação mais a esquerda.
+\item escolha a opera\c{c}\~{a}o mais a esquerda.
 \item avalie seu operando
 \item aplique o operador aos valores do operando.
 \end{itemize}
-Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
-direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
-nome pelo valor da definição do lado direito. O processo de avaliação para assim que 
-encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
+Um nome definido por \code{def} \'{e} avaliado substituindo o nome pela defini\c{c}\~{a}o do lado
+direito (n\~{a}o avaliada). Um nome definido por \code{val} \'{e} avaliado pela substitui\c{c}\~{a}o do 
+nome pelo valor da defini\c{c}\~{a}o do lado direito. O processo de avalia\c{c}\~{a}o p\'{a}ra assim que 
+encontrarmos um valor. Um valor \'{e} algum dado, tal como uma cadeia de caracteres, um n\'{u}mero, 
 um vetor, ou uma lista.
 %----------
 
@@ -716,7 +725,7 @@ um vetor, ou uma lista.
 %% called {\em reduction}.
 
 \example
-Aqui está uma avaliação de uma expressão aritmética.
+Aqui est\'{a} uma avalia\c{c}\~{a}o de uma express\~{a}o aritm\'{e}tica.
 
 \begin{lstlisting}
 $\,\,\,$   (2 * pi) * radius
@@ -725,15 +734,15 @@ $\rightarrow$  6.283185307179586 * radius
 $\rightarrow$  6.283185307179586 * 10
 $\rightarrow$  62.83185307179586
 \end{lstlisting}
-O processo de simplificar gradualmente expressões para valores é 
-chamado {\em redução}.
+O processo de simplificar gradualmente express\~{o}es para valores \'{e} 
+chamado {\em redu\c{c}\~{a}o}.
 %----------
 
 
 \section{Parameters}
 
 %% Using \code{def}, one can also define functions with parameters. For example:
-Usando \code{def}, pode-se também definir funções com parâmetros. Por exemplo:
+Usando \code{def}, pode-se tamb\'{e}m definir fun\c{c}\~{o}es com par\^{a}metros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -754,8 +763,7 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
-% Vinicius - parei revisao  aqui. - Antes daqui, tudo OK!
-%----------xpto
+%----------
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
 %% following the parameter name and a colon.  At the present time, we
@@ -764,11 +772,13 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
-
-
-Parâmetros de funções seguem o nome da função e sempre são envolvidos por
-parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
-e dois pontos. Até aqui, só precisamos de tipos numéricos   
+Par\^{a}metros de fun\c{c}\~{o}es seguem o nome da fun\c{c}\~{a}o e sempre s\~{a}o envolvidos por
+par\^{e}nteses. Cada par\^{a}metro vem com um tipo que segue o nome do par\^{a}metro
+e dois pontos. At\'{e} aqui, s\'{o} precisamos de tipos num\'{e}ricos, tal como o tipo
+\code{scala.Double} dos n\'{u}meros de precis\~{a}o dupla. Scala define {\em tipos
+aliases} para alguns tipos b\'{a}sicos, logo podemos escrever tipos num\'{e}ricos 
+como em Java. Por exemplo, \code{double} \'{e} um tipo alias de \code{scala.Double}
+e \code{int} \'{e} um tipo alias para \code{scala.Int}.       
 %----------
 
 %----------
@@ -778,6 +788,11 @@ e dois pontos. Até aqui, só precisamos de tipos numéricos
 %% the function's right hand side, and at the same time all formal
 %% parameters of the function are replaced by their corresponding actual
 %% arguments.
+Fun\c{c}\~{o}es com par\^{a}metros s\~{a}o avaliadas analogamente a operadores em express\~{o}es.
+Primeiro, os argumentos da fun\c{c}\~{a}o s\~{a}o avaliados (da esquerda para direita). 
+Ent\~{a}o, a aplica\c{c}\~{a}o da fun\c{c}\~{a}o \'{e} substitu\'{i}do pelo lado direito da fun\c{c}\~{a}o, e
+ao mesmo tempo todos os par\^{a}metros formais s\~{a}o substitu\'{i}dos pelos seus 
+argumentos atuais. 
 %----------
 
 \example\ 
@@ -798,6 +813,10 @@ $\rightarrow$  25
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
 %% have yielded the following reduction sequence:
+O exemplo mostra que o interpretador reduz argumentos de fun\c{c}\~{o}es a valores 
+antes de reescrever a aplica\c{c}\~{a}o da fun\c{c}\~{a}o. Pode-se ao inv\'{e}s escolher aplicar
+a fun\c{c}\~{a}o a argumentos n\~{a}o reduzidos. Isto levar\'{a} a seguinte sequ\^{e}ncia de 
+redu\c{c}\~{a}o: 
 %----------
 
 \begin{lstlisting}
@@ -817,6 +836,10 @@ $\rightarrow$  25
 %% expressions that use only pure functions and that therefore can be
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
+A segunda ordem de avalia\c{c}\~{a}o \'{e} conhecida como \emph{chamada por nome},
+e a primeira por \emph{chamada por valor}. Para express\~{o}es que se utilizam
+apenas de fun\c{c}\~{o}es e que portanto podem ser reduzidas com o modelo de 
+substitui\c{c}\~{a}o, ambos os esquemas levam ao mesmo valor final.
 %----------
 
 %----------
@@ -826,8 +849,13 @@ $\rightarrow$  25
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
+Chamada por valor tem a vantagem de evitar avalia\c{c}\~{o}es repetidas de argumentos.
+Chamada por nome tem a vantagem de evitar avalia\c{c}\~{o}es de argumentos quando o 
+par\^{a}metro n\~{a}o \'{e} usado pela fun\c{c}\~{a}o. Chamada por valor \'{e} geralmente mais 
+eficiente que chamada por nome, mas uma avalia\c{c}\~{a}o de chamada por valor
+pode entrar em la\c{c}o infinito, enquanto uma avalia\c{c}\~{a}o de chamada por nome 
+termina. Considere: 
 %----------
-
 \begin{lstlisting}
 scala> def loop: Int = loop
 loop: Int
@@ -839,6 +867,9 @@ first: (Int,Int)Int
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
+Ent\~{a}o \code{first(1, loop)} \'{e} reduzido com uma chamada por nome a \code{1},
+enquanto o mesmo termo, atrav\'{e}s de uma chamada por valor reduz a si mesmo 
+repetidamente, logo a avalia\c{c}\~{a}o n\~{a}o termina.  
 %----------
 \begin{lstlisting}
 $\,\,\,$   first(1, loop)
@@ -849,7 +880,8 @@ $\rightarrow$  ...
 %----------
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
-
+Scala usa chamada por valor por default, mas muda para avalia\c{c}\~{a}o de chamada por nome 
+se o tipo do par\^{a}metro for precedido por \code{=>}. 
 \example\ 
  
 \begin{lstlisting}
@@ -859,8 +891,8 @@ constOne: (Int,=> Int)Int
 scala> constOne(1, loop)
 unnamed0: Int = 1
 
-scala> constOne(loop, 2)               // gives an infinite loop.
-^C                                     // stops execution with Ctrl-C
+scala> constOne(loop, 2)               // leva a la\c{c}o infinito
+^C                                     // para a execu\c{c}\~{a}o com Ctrl-C
 \end{lstlisting}
 %----------
 
@@ -874,6 +906,13 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% same syntax to choose between two expressions. That's why Scala's
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
+\section{Express\~{o}es Condicionais}
+O \code{if-else} do Scala leva a uma escolha entre duas alternativas. Sua
+sintaxe \'{e} a mesma do \code{if-else} do Java. Mas onde o \code{if-else} do 
+Java pode ser usado somente como uma alternativa entre comandos, Scala 
+permite a mesma sintaxe para escolher entre duas express\~{o}es. Isso porque o
+\code{if-else} do Scala serve tamb\'{e}m como um substituto para a express\~{a}o 
+condicional do Java \code{... ? ... : ...}.      
 %----------
 
 %----------
@@ -888,6 +927,16 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \code{true} and
 %% \code{false}, comparison operators, boolean negation \code{!} and the
 %% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
+\example\
+\begin{lstlisting}
+scala> def abs(x: Double) = if (x >= 0) x else -x
+abs: (Double)Double
+\end{lstlisting}
+Express\~{o}es boleanas em Scala s\~{a}o similares as em Java; s\~{a}o formadas
+a partir de constantes.  
+\code{true} e
+\code{false}, operadores de compara\c{c}\~{a}o, nega\c{c}\~{a}o boleana \code{!} e os 
+operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}. 
 %----------
 
 %----------
@@ -900,6 +949,14 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% def sqrt(x: Double): Double = ...
 %% \end{lstlisting}
 %% which computes the square root of \code{x}.
+
+\section{\label{sec:sqrt}Example: Raiz Quadrada pelo M\'{e}todo de Newton}
+Agora ilustraremos elementos da linguagem intruduzidos at\'{e} aqui na
+constru\c{c}\~{a}o de um programa mais interessante. A tarefa \'{e} escrever um fun\c{c}\~{a}o  
+ \begin{lstlisting}
+ def sqrt(x: Double): Double = ...
+ \end{lstlisting}
+que computa a raiz quadrada de \code{x}. 
 %----------
 
 %----------
@@ -910,14 +967,21 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% example, the next three columns indicate the guess \code{y}, the
 %% quotient \code{x/y}, and their average for the first approximations of
 %% $\sqrt 2$.
-%% \begin{lstlisting}
-%% 1            2/1 = 2               1.5
-%% 1.5          2/1.5 = 1.3333        1.4167
-%% 1.4167       2/1.4167 = 1.4118     1.4142
-%% 1.4142       ...                   ...
+Um modo comum de se computar raizes quadradas \'{e} pelo m\'{e}todo das aproxima\c{c}\~{o}es
+sucessivas de Newton. Inicia-se com um palpite inicial \code{y} (digamos:
+\code{y = 1}). Ent\~{a}o melhora-se repetidamente o atual palpite \code{y} 
+tomando-se a m\'{e}dia de \code{y} e \code{x/y}. Como um exemplo, as pr\'{o}ximas
+tr\^{e}s colunas indicam o palpite \code{y}, o quociente \code{x/y}, e suas
+m\'{e}dias para as primeiras aproxima\c{c}\~{o}es para $\sqrt 2$.       
 
-%% $y$            $x/y$                   $(y + x/y)/2$
-%% \end{lstlisting}
+\begin{lstlisting}
+1            2/1 = 2               1.5
+1.5          2/1.5 = 1.3333        1.4167
+1.4167       2/1.4167 = 1.4118     1.4142
+1.4142       ...                   ...
+
+$y$            $x/y$                   $(y + x/y)/2$
+\end{lstlisting}
 %----------
 
 %----------
@@ -925,14 +989,28 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% which each represent one of the elements of the algorithm.  
 
 %% We first define a function for iterating from a guess to the result:
-%% \begin{lstlisting}
-%% def sqrtIter(guess: Double, x: Double): Double =
-%%   if (isGoodEnough(guess, x)) guess
-%%   else sqrtIter(improve(guess, x), x)
-%% \end{lstlisting}
+
+Este algoritmo pode ser implementado em Scala por um conjunto de pequenas fun\c{c}\~{o}es,
+onde cada uma representa um dos elementos do algoritmo.
+
+Primeiro definimos uma fun\c{c}\~{a}o para iterar do palpite para o resultado:
+%-----------
+
+
+\begin{lstlisting}
+def sqrtIter(guess: Double, x: Double): Double =
+  if (isGoodEnough(guess, x)) guess
+  else sqrtIter(improve(guess, x), x)
+\end{lstlisting}
+
+%-----------
 %% Note that \code{sqrtIter} calls itself recursively.  Loops in
 %% imperative programs can always be modeled by recursion in functional
-%% programs. 
+%% programs.
+ 
+Observe que \code{sqrtIter} chama a si mesmo recursivamente. La\c{c}os em 
+programas imperativos podem sempre ser modelados por recurs\~{a}o em 
+programas funcionais. 
 %----------
 
 %----------
@@ -943,27 +1021,38 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% compute it from the type of the function's right-hand side. However,
 %% even for non-recursive functions it is often a good idea to include a
 %% return type for better documentation.
+Observe tamb\'{e}m que a defini\c{c}\~{a}o de \code{sqrtIter} cont\'{e}m um tipo retorno,
+que segue o se\c{c}\~{a}o de par\^{a}metros. Tais tipos de retorno s\~{a}o mandat\'{o}rios para 
+fun\c{c}\~{o}es recursivas. Para uma fun\c{c}\~{a}o n\~{a}o recursiva, o tipo de retorno \'{e} opcional;
+se estiver faltando o verificador de tipos o computar\'{a} a partir do tipo do lado
+direito da fun\c{c}\~{a}o. Entretanto, mesmo para fun\c{c}\~{o}es n\~{a}o recursivas \'{e} sempre boa id\'{e}ia 
+incluir um tipo de retorno para melhor documenta\c{c}\~{a}o.  
 %----------
 
 %----------
 %% As a second step, we define the two functions called by
 %% \code{sqrtIter}: a function to \code{improve} the guess and a
 %% termination test \code{isGoodEnough}. Here is their definition.
-%% \begin{lstlisting}
-%% def improve(guess: Double, x: Double) =
-%%   (guess + x / guess) / 2
-%----------
 
-%----------
-%% def isGoodEnough(guess: Double, x: Double) =
-%%   abs(square(guess) - x) < 0.001
-%% \end{lstlisting}
+Como segundo passo, definimos as duas fun\c{c}\~{o}es chamadas por:
+\code{sqrtIter}: uma fun\c{c}\~{a}o para melhorar (\code{improve}) o palpite e um
+teste de termina\c{c}\~{a}o \code{isGoodEnough}. Aqui est\~{a}o suas defini\c{c}\~{o}es.
+\begin{lstlisting}
+def improve(guess: Double, x: Double) =
+  (guess + x / guess) / 2    
+
+def isGoodEnough(guess: Double, x: Double) =
+  abs(square(guess) - x) < 0.001
+\end{lstlisting}
 
 %% Finally, the \code{sqrt} function itself is defined by an application
 %% of \code{sqrtIter}.
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = sqrtIter(1.0, x)
-%% \end{lstlisting}
+Finalmente, a pr\'{o}pria fun\c{c}\~{a}o \code{sqrt} \'{e} definida como uma aplica\c{c}\~{a}o de
+\code{sqrtIter}.
+  
+\begin{lstlisting}
+def sqrt(x: Double) = sqrtIter(1.0, x)
+\end{lstlisting}
 %----------
 
 %----------
@@ -975,6 +1064,13 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 
 %% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
 %% \end{exercise}
+\begin{exercise} O teste \code{isGoodEnough} n\~{a}o \'{e} muito preciso para pequenos 
+n\'{u}meros e podem levar a n\~{a}o termina\c{c}\~{a}o para n\'{u}meros muito grandes (por que?).
+Crie uma vers\~{a}o diferente para \code{isGoodEnough} que n\~{a}o tenham esses problemas.
+\end{exercise}
+
+\begin{exercise} Simule a execu\c{c}\~{a}o da express\~{a}o \code{sqrt(4)}.
+\end{exercise}
 %----------
 
 %----------
@@ -986,23 +1082,33 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \code{improve} and \code{isGoodEnough}. The names of these functions
 %% are relevant only for the implementation of \code{sqrt}. We normally
 %% do not want users of \code{sqrt} to access these functions directly.
+\section{Aninhamento de Fun\c{c}\~{o}es}
+
+A programa\c{c}\~{a}o funcional encoraja a constru\c{c}\~{a}o de muitas pequenas fun\c{c}\~{o}es
+auxiliares. Nos \'{u}ltimos exemplos, a implementa\c{c}\~{a}o de \code{sqrt} faz uso da
+fun\c{c}\~{o}es auxiliares \code{sqrtIter}, \code{improve} e \code{isGoodEnough}.
+Os nomes destas fun\c{c}\~{o}es s\~{a}o relevantes somente para a implementa\c{c}\~{a}o de 
+\code{sqrt}. Normalmente n\~{a}o queremos que os usu\'{a}rios de \code{sqrt} acessem
+estas fun\c{c}\~{o}es diretamente.  
 %----------
 
 %----------
 %% We can enforce this (and avoid name-space pollution) by including
 %% the helper functions within the calling function itself:
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = {
-%%   def sqrtIter(guess: Double, x: Double): Double =
-%%     if (isGoodEnough(guess, x)) guess
-%%     else sqrtIter(improve(guess, x), x)
-%%   def improve(guess: Double, x: Double) =
-%%     (guess + x / guess) / 2
-%%   def isGoodEnough(guess: Double, x: Double) =
-%%     abs(square(guess) - x) < 0.001
-%%   sqrtIter(1.0, x)
-%% }
-%% \end{lstlisting}
+N\'{o}s podemos refor\c{c}ar isto (e evitar polui\c{c}\~{a}o de nomes) incluindo
+fun\c{c}\~{o}es auxiliares dentro das pr\'{o}prias fun\c{c}\~{o}es: 
+\begin{lstlisting}
+def sqrt(x: Double) = {
+  def sqrtIter(guess: Double, x: Double): Double =
+    if (isGoodEnough(guess, x)) guess
+    else sqrtIter(improve(guess, x), x)
+  def improve(guess: Double, x: Double) =
+    (guess + x / guess) / 2
+  def isGoodEnough(guess: Double, x: Double) =
+    abs(square(guess) - x) < 0.001
+  sqrtIter(1.0, x)
+}
+\end{lstlisting}
 %----------
 
 %----------
@@ -1011,6 +1117,11 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% result expression which defines its value.  The result expression may
 %% be preceded by auxiliary definitions, which are visible only in the
 %% block itself.
+Neste programa, as chaves \code{\{ ... \}} envolvem um {\em bloco}. 
+Blocos em Scala s\~{a}o eles mesmos express\~{o}es. Cada bloco termina com um
+express\~{a}o resultado o qual define seu valor. A express\~{a}o  resultado pode 
+ser precedida por defini\c{c}\~{o}es auxiliares, as quais s\~{a}o vis\'{i}veis somente no
+pr\'{o}prio bloco. 
 %----------
 
 %----------
@@ -1019,6 +1130,10 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% expression. However, a semicolon is inserted implicitly at the end of
 %% each line, unless one of the following conditions is
 %% true.
+Cada defini\c{c}\~{a}o no bloco pode ser seguida para um ponto e v\'{i}rgula, o qual 
+separa esta defini\c{c}\~{a}o das defini\c{c}\~{o}es subsequentes ou a express\~{a}o  resultado.
+Entretanto, um ponto e v\'{i}rgula \'{e} inserido implicitamente ao final de cada linha,
+a n\~{a}o ser que uma das condi\c{c}\~{o}es a seguir seja verdadeira.
 %----------
 
 %----------
@@ -1032,30 +1147,42 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
 %% because these cannot contain multiple statements anyway.
 %% \end{enumerate}
+\begin{enumerate}
+\item 
+Ou a linha em quest\~{a}o termina com uma palavra tal que um ponto ou um 
+operador infixo n\~{a}o s\~{a}o legais ao final da express\~{a}o.
+\item 
+Ou a pr\'{o}xima linha inicia com uma palavra que n\~{a}o pode iniciar uma express\~{a}o.
+\item
+Ou estamos dentro de par\^{e}nteses \prog{$($...$)$} ou chaves \prog{}, porque 
+estes n\~{a}o podem conter multiplos comandos de qualquer modo.
+\end{enumerate}
 %----------
 
 %----------
 %% Therefore, the following are all legal:
-%% \begin{lstlisting}
-%% def f(x: Int) = x + 1;
-%% f(1) + f(2)
+Entretanto, os seguintes s\~{a}o legais:
 
-%% def g1(x: Int) = x + 1
-%% g(1) + g(2)
+\begin{lstlisting}
+def f(x: Int) = x + 1;
+f(1) + f(2)
 
-%% def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
+def g1(x: Int) = x + 1
+g(1) + g(2)
 
-%% def h1(x) = 
-%%   x + 
-%%   y
-%% h1(1) * h1(2)
+def g2(x: Int) = {x + 1};  /* `;' mandat\'{o}rio */ g2(1) + g2(2)
 
-%% def h2(x: Int) = (
-%%   x     // parentheses mandatory, otherwise a semicolon
-%%   + y   // would be inserted after the `x'.
-%% )
-%% h2(1) / h2(2)
-%% \end{lstlisting}
+def h1(x) = 
+  x + 
+  y
+h1(1) * h1(2)
+
+def h2(x: Int) = (
+  x     // par\^{e}nteses mandat\'{o}rio, sen\~{a}o um ponto e v\'{i}rgula
+  + y   // ser\'{a} inserido ap\'{o}s o `x'.
+)
+h2(1) / h2(2)
+\end{lstlisting}
 %----------
 
 %----------
@@ -1065,76 +1192,100 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \code{sqrt} example. We need not pass \code{x} around as an additional parameter of
 %% the nested functions, since it is always visible in them as a
 %% parameter of the outer function \code{sqrt}. Here is the simplified code:
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = {
-%%   def sqrtIter(guess: Double): Double =
-%%     if (isGoodEnough(guess)) guess
-%%     else sqrtIter(improve(guess))
-%%   def improve(guess: Double) =
-%%     (guess + x / guess) / 2
-%%   def isGoodEnough(guess: Double) =
-%%     abs(square(guess) - x) < 0.001
-%%   sqrtIter(1.0)
-%% }
-%% \end{lstlisting}
+Scala usa as regras usuais de escopo de bloco estruturado. Um nome definido em
+algum outro bloco \'{e} tamb\'{e}m vis\'{i}vel em algum bloco interno, desde que n\~{a}o tenha
+sido redefinido l\'{a}. Esta regra nos permite simplificar nosso exemplo \code{sqrt}.
+N\~{a}o precisamos passar \code{x} como par\^{a}metro adicional de fun\c{c}\~{o}es aninhadas, dado
+que est\'{a} sempre vis\'{i}vel nelas como um par\^{a}metro da fun\c{c}\~{a}o externa \code{sqrt}.
+Aqui est\'{a} o c\'{o}digo simplificado:
+   
+\begin{lstlisting}
+def sqrt(x: Double) = {
+  def sqrtIter(guess: Double): Double =
+    if (isGoodEnough(guess)) guess
+    else sqrtIter(improve(guess))
+  def improve(guess: Double) =
+    (guess + x / guess) / 2
+  def isGoodEnough(guess: Double) =
+    abs(square(guess) - x) < 0.001
+  sqrtIter(1.0)
+}
+\end{lstlisting}
 %----------
 
 
-%% \section{Tail Recursion}
+\section{Tail Recursion}
 
-%% Consider the following function to compute the greatest common divisor
-%% of two given numbers.
+%%Consider the following function to compute the greatest common divisor
+%%of two given numbers.
+Considere a seguinte fun\c{c}\~{a}o para calcular o maior divisor comum entre
+dois n\'{u}meros dados.
 
-%% \begin{lstlisting}
-%% def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
-%% \end{lstlisting}
+\begin{lstlisting}
+def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+\end{lstlisting}
 
-%% Using our substitution model of function evaluation, 
-%% \code{gcd(14, 21)} evaluates as follows:
+%%Using our substitution model of function evaluation, 
+Usando nosso modelo de substitui\c{c}\~{a}o da fun\c{c}\~{a}o de avalia\c{c}\~{a}o,
+\code{gcd(14, 21)} evaluates as follows:
 
-%% \begin{lstlisting}
-%% $\,\,$      gcd(14, 21)  
-%% $\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
-%% $\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
-%% $\rightarrow\!$     gcd(21, 14 % 21)
-%% $\rightarrow\!$     gcd(21, 14)
-%% $\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
-%% $\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
-%% $\rightarrow\!$     gcd(14, 7)
-%% $\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
-%% $\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
-%% $\rightarrow\!$     gcd(7, 0)
-%% $\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
-%% $\rightarrow$ $\rightarrow$  7
-%% \end{lstlisting}
+\begin{lstlisting}
+$\,\,$      gcd(14, 21)  
+$\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
+$\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
+$\rightarrow\!$     gcd(21, 14 % 21)
+$\rightarrow\!$     gcd(21, 14)
+$\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
+$\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
+$\rightarrow\!$     gcd(14, 7)
+$\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
+$\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
+$\rightarrow\!$     gcd(7, 0)
+$\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
+$\rightarrow$ $\rightarrow$  7
+\end{lstlisting}
 
-%% Contrast this with the evaluation of another recursive function, 
-%% \code{factorial}:
+%%Contrast this with the evaluation of another recursive function, 
+Contraste isto com a avalia\c{c}\~{a}o de uma outra fun\c{c}\~{a}o recursiva,
+\code{factorial}:
 
-%% \begin{lstlisting}
-%% def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
-%% \end{lstlisting}
+\begin{lstlisting}
+def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
+\end{lstlisting}
 
-%% The application \code{factorial(5)} rewrites as follows:
-%% \begin{lstlisting}
-%% $\,\,\,$       factorial(5)
-%% $\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
-%% $\rightarrow$      5 * factorial(5 - 1)
-%% $\rightarrow$      5 * factorial(4)
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
-%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
-%% $\rightarrow\ldots\rightarrow$  120
-%% \end{lstlisting}
+%%The application \code{factorial(5)} rewrites as follows:
+A aplica\c{c}\~{a}o de \code{factorial(5)} \'{e} reescrita como segue: 
+
+\begin{lstlisting}
+$\,\,\,$       factorial(5)
+$\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
+$\rightarrow$      5 * factorial(5 - 1)
+$\rightarrow$      5 * factorial(4)
+$\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
+$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
+$\rightarrow\ldots\rightarrow$  120
+\end{lstlisting}
+
+%----------
 %% There is an important difference between the two rewrite sequences:
 %% The terms in the rewrite sequence of \code{gcd} have again and again
 %% the same form. As evaluation proceeds, their size is bounded by a
 %% constant. By contrast, in the evaluation of factorial we get longer
 %% and longer chains of operands which are then multiplied in the last
 %% part of the evaluation sequence.
+H\'{a} uma importante diferen\c{c}a entre as duas senten\c{c}as reescritas:
+Os termos na sequ\^{e}ncia reescrita de \code{gcd} tem repetidamente a
+mesma forma. Conforme a avalia\c{c}\~{a}o prossegue, seu tamanho \'{e} limitado por
+uma constante. Diferentemente, na avalia\c{c}\~{a}o do fatorial obtemos cadeias
+cada vez mais longas de operandos que s\~{a}o ent\~{a}o multiplicados na \'{u}ltima
+parte da sequ\^{e}ncia de avalia\c{c}\~{a}o. 
+%----------
 
+
+%----------
 %% Even though actual implementations of Scala do not work by rewriting
 %% terms, they nevertheless should have the same space behavior as in the
 %% rewrite sequences. In the implementation of \code{gcd}, one notes that
@@ -1146,14 +1297,34 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% instantiation of \code{gcd}, so that no new stack space is needed.
 %% Hence, tail recursive functions are iterative processes, which can be
 %% executed in constant space.
+Ainda que as atuais implementa\c{c}\~{o}es de Scala n\~{a}o trabalhem reescrevendo
+termos, elas contudo devem ter o mesmo comportamento de espa\c{c}o que nas
+sequ\^{e}ncias reescritas. Na implementa\c{c}\~{a}o de \code{gcd}, nota-se que  a 
+chamada recursiva para \code{gcd} \'{e} a \'{u}ltima a\c{c}\~{a}o realizada na avalia\c{c}\~{a}o 
+do seu corpo. Pode-se tamb\'{e}m dizer que \code{gcd} \'{e} uma recurs\~{a}o de cauda
+(tail-recursive). A \'{u}ltima chamada numa fun\c{c}\~{a}o recursiva de cauda pode ser
+implementada por um salto ao in\'{i}cio da fun\c{c}\~{a}o. Os argumentos dessa chamada 
+pode sobrescrever os par\^{a}metros da atual instancia\c{c}\~{a}o de \code{gcd}, portanto 
+nenhum espa\c{c}o na pilha \'{e} necess\'{a}rio. Consequentemente, fun\c{c}\~{o}es recursivas de 
+cauda s\~{a}o processos iterativos, que podem ser executados em espa\c{c}o constante.     
+%----------
 
+%----------
 %% By contrast, the recursive call in \code{factorial} is followed by a
 %% multiplication.  Hence, a new stack frame is allocated for the
 %% recursive instance of factorial, and is deallocated after that
 %% instance has finished. The given formulation of the factorial function
 %% is not tail-recursive; it needs space proportional to its input
 %% parameter for its execution.
+Em contraste, a chamada recursiva em \code{factorial} \'{e} seguida por uma 
+multiplica\c{c}\~{a}o. consequentemente, um novo espa\c{c}o na pilha \'{e} alocado para a 
+inst\^{a}ncia recursiva de fatorial, e \'{e} desalocada ap\'{o}s o t\'{e}rmino daquela 
+inst\^{a}ncia. A formula\c{c}\~{a}o dada para a fun\c{c}\~{a}o fatorial n\~{a}o \'{e} recursiva de cauda;
+ precisa de espa\c{c}o proporcional aos seus par\^{a}metros de entrada para sua
+execu\c{c}\~{a}o. 
+%----------
 
+%----------
 %% More generally, if the last action of a function is a call to another
 %% (possibly the same) function, only a single stack frame is needed for
 %% both functions. Such calls are called ``tail calls''. In principle,
@@ -1164,14 +1335,26 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% re-use the stack frame of a directly tail-recursive function whose
 %% last action is a call to itself.  Other tail calls might be optimized
 %% also, but one should not rely on this across implementations.
+Genericamente, se a \'{u}ltima a\c{c}\~{a}o da fun\c{c}\~{a}o \'{e} uma chamada a outra fun\c{c}\~{a}o
+(possivelmente a mesma), apenas um \'{u}nico espa\c{c}o na pilha \'{e} requerido para 
+ambas fun\c{c}\~{o}es. Tais chamadas s\~{a}o denominadas ``tail call''. Em 
+princ\'{i}pio, tail calls sempre podem reutilizar o espa\c{c}o da pilha da fun\c{c}\~{a}o 
+de chamada. Entretanto, alguns ambientes de execu\c{c}\~{a}o (tais como Java VM) 
+carecem das primitivas para fazer um espa\c{c}o de pilha reutiliz\'{a}vel para 
+tail calls eficientes. A produ\c{c}\~{a}o de uma implementa\c{c}\~{a}o Scala de qualidade \'{e},
+portanto, requerida somente para reutilizar o espa\c{c}o de pilha de uma fun\c{c}\~{a}o 
+recursiva de cauda cuja \'{u}ltima a\c{c}\~{a}o \'{e} chamar a si mesma. Outras chamadas de 
+cauda podem ser otimizadas tamb\'{e}m, mas n\~{a}o deve-se confiar nisso ao longo das
+implementa\c{c}\~{o}es. 
+%----------
 
-%% \begin{exercise} Design a tail-recursive version of
-%% \code{factorial}.
-%% \end{exercise}
+\begin{exercise} Escreva uma implementa\c{c}\~{a}o recursiva de cauda de 
+\code{factorial}.
+\end{exercise}
 
+
+%----------
 %% \chapter{\label{chap:first-class-funs}First-Class Functions}
-\chapter{\label{chap:first-class-funs}Funções na Primeira Classe}
-
 
 %% A function in Scala is a ``first-class value''. Like any other value,
 %% it may be passed as a parameter or returned as a result.  Functions
@@ -1180,93 +1363,142 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
 
-Uma função em Scala é um valor ``valor de primeira classe''. Como qualquer
-outro valor, ele pode ser passado por parâmetro ou retornado como um resultado.
-Funções que recebem outras funções como parâmetros ou os retornem como resultados
-são chamadas funções de ordem-alta e mostram como podem ser um mecanismo flexível para
-a composição de um programa.
-% Vinicius parei aqui
+ \chapter{\label{chap:first-class-funs}Fun\c{c}\~{o}es de Primeira Classe}
+Uma fun\c{c}\~{a}o em Scala \'{e} um valor de primeira classe. Como qualquer outro valor, 
+pode ser passado como um par\^{a}metro ou retornado como um resultado. Fun\c{c}\~{o}es que 
+recebem outras fun\c{c}\~{o}es como par\^{a}metros ou as retornam como resultados s\~{a}o 
+denominadas fun\c{c}\~{o}es de {\em alta ordem}. Este cap\'{i}tulo introduz fun\c{c}\~{o}es de alta ordem 
+e mostra como elas fornecem um mecanismo flex\'{i}vel para a composi\c{c}\~{a}o de programas.
+%----------
 
-
+%----------
 %% As a motivating example, consider the following three related tasks:
-%% \begin{enumerate}
-%% \item
-%% Write a function to sum all integers between two given numbers \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int =
-%%   if (a > b) 0 else a + sumInts(a + 1, b)
-%% \end{lstlisting}
-%% \item 
+Como um exemplo de motiva\c{c}\~{a}o, considere as tr\^{e}s tarefas relacionadas a seguir:
+\begin{enumerate}
+\item
+%%Write a function to sum all integers between two given numbers \code{a} and \code{b}:
+Escreva uma fun\c{c}\~{a}o que some todos os inteiros entre dois dados n\'{u}meros, \code{a} e \code{b}:  
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int =
+  if (a > b) 0 else a + sumInts(a + 1, b)
+\end{lstlisting}
+%----------
+
+%----------
+ \item 
 %% Write a function to sum the squares of all integers between two given numbers 
 %% \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def square(x: Int): Int = x * x
-%% def sumSquares(a: Int, b: Int): Int =
-%%   if (a > b) 0 else square(a) + sumSquares(a + 1, b)
-%% \end{lstlisting}
-%% \item
+Escreva uma fun\c{c}\~{a}o para somar os quadrados de todos os inteiros entre dois dados n\'{u}meros, 
+ \code{a} e \code{b}:
+
+\begin{lstlisting}
+def square(x: Int): Int = x * x
+def sumSquares(a: Int, b: Int): Int =
+  if (a > b) 0 else square(a) + sumSquares(a + 1, b)
+\end{lstlisting}
+\item
 %% Write a function to sum the powers $2^n$ of all integers $n$ between
 %% two given numbers \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-%% def sumPowersOfTwo(a: Int, b: Int): Int =
-%%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
-%% \end{lstlisting}
-%% \end{enumerate}
+Escreva uma fun\c{c}\~{a}o para somar as pot\^{e}ncias $2^n$ de todos os $n$ inteiros entre
+dois dados n\'{u}meros \code{a} e \code{b}:  
+
+\begin{lstlisting}
+def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+def sumPowersOfTwo(a: Int, b: Int): Int =
+  if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
+\end{lstlisting}
+\end{enumerate}
+%----------
+
+%----------
 %% These functions are all instances of
 %% \(\sum^b_a f(n)\) for different values of $f$. 
 %% We can factor out the common pattern by defining a function \code{sum}:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int, a: Int, b: Int): Int =
-%%   if (a > b) 0 else f(a) + sum(f, a + 1, b)
-%% \end{lstlisting}
+Estas fun\c{c}\~{o}es s\~{a}o todas inst\^{a}ncias de \(\sum^b_a f(n)\) para diferentes valores de $x$.
+Podemos obter o padr\~{a}o comum definindo uma fun\c{c}\~{a}o \code{sum}: 
+\begin{lstlisting}
+def sum(f: Int => Int, a: Int, b: Int): Int =
+  if (a > b) 0 else f(a) + sum(f, a + 1, b)
+\end{lstlisting}
 %% The type \code{Int => Int} is the type of functions that
 %% take arguments of type \code{Int} and return results of type
 %% \code{Int}. So \code{sum} is a function which takes another function as
 %% a parameter. In other words, \code{sum} is a {\em higher-order}
 %% function.
+O tipo \code{Int => Int} \'{e} o tipo de fun\c{c}\~{o}es que recebem argumentos do tipo
+\code{Int} e retornam resultados do tipo \code{Int}. Ent\~{a}o \code{sum} \'{e} uma 
+fun\c{c}\~{a}o que recebe uma outra fun\c{c}\~{a}o como par\^{a}metro. Em outras palavras, \code{sum}
+\'{e} uma fun\c{c}\~{a}o de {\em alta ordem}.     
+%----------
 
+%----------
 %% Using \code{sum}, we can formulate the three summing functions as
 %% follows.
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum(id, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
-%% def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
-%% \end{lstlisting}
-%% where
-%% \begin{lstlisting}
-%% def id(x: Int): Int = x
-%% def square(x: Int): Int = x * x
-%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-%% \end{lstlisting}
+Usando \code{sum}, podemos formular as tr\^{e}s fun\c{c}\~{o}es de soma como segue: 
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum(id, a, b)
+def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
+def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
+\end{lstlisting}
+%%where
+onde 
+\begin{lstlisting}
+def id(x: Int): Int = x
+def square(x: Int): Int = x * x
+def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+\end{lstlisting}
+%----------
 
+%----------
 %% \section{Anonymous Functions}
 
 %% Parameterization by functions tends to create many small functions. In
 %% the previous example, we defined \code{id}, \code{square} and
 %% \code{power} as separate functions, so that they could be 
 %% passed as arguments to \code{sum}.
+\section{Fun\c{c}\~{o}es An\^{o}nimas}
+Parametriza\c{c}\~{a}o por fun\c{c}\~{o}es tende a criar v\'{a}rias pequenas fun\c{c}\~{o}es. No exemplo 
+anterior, definimos \code{id}, \code{square} e \code{power} como fun\c{c}\~{o}es 
+separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}.    
+%----------
 
+%----------
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a
 %% function; the function is defined without giving it a name. As an
 %% example consider the anonymous square function:
-%% \begin{lstlisting}
-%%   (x: Int) => x * x
-%% \end{lstlisting}
+
+Ao inv\'{e}s de usarmos defini\c{c}\~{o}es de fun\c{c}\~{o}es nomeadas para estas pequenas fun\c{c}\~{o}es 
+argumentos, podemos formul\'{a}-las de um modo abreviado como {\em fun\c{c}\~{o}es an\^{o}nimas}.
+Uma fun\c{c}\~{a}o an\^{o}nima \'{e} uma express\~{a}o que \'{e} avaliada para uma fun\c{c}\~{a}o; a fun\c{c}\~{a}o \'{e} 
+definida sem receber um nome. Como exemplo considere a fun\c{c}\~{a}o an\^{o}nima quadrado:
+\begin{lstlisting}
+  (x: Int) => x * x
+\end{lstlisting}
+%----------
+  
+%----------
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.
-%% \begin{lstlisting}
-%%   (x: Int, y: Int) => x * y
-%% \end{lstlisting}
+A parte anterior a flecha `\code{=>}' s\~{a}o os par\^{a}metros da fun\c{c}\~{a}o, ao passo que a parte
+seguinte a `\code{=>}' \'{e} o seu corpo.
+Por exemplo, aqui est\'{a} uma fun\c{c}\~{a}o an\^{o}nima que multiplica seus dois argumentos.
+\begin{lstlisting}
+  (x: Int, y: Int) => x * y
+\end{lstlisting}
 %% Using anonymous functions, we can reformulate the first two summation
 %% functions without named auxiliary functions:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
-%% \end{lstlisting}
+Usando fun\c{c}\~{o}es an\^{o}nimas, podemos reformular as duas fun\c{c}\~{o}es soma sem
+fun\c{c}\~{o}es auxiliares nomeadas:
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
+def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
+\end{lstlisting}
+%----------
+
+%----------
 %% Often, the Scala compiler can deduce the parameter type(s) from the
 %% context of the anonymous function in which case they can be omitted.
 %% For instance, in the case of \code{sumInts} or \code{sumSquares}, one
@@ -1274,11 +1506,20 @@ a composição de um programa.
 %% function of type \code{Int => Int}.  Hence, the parameter type
 %% \code{Int} is redundant and may be omitted. If there is a single
 %% parameter without a type, we may also omit the parentheses around it:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
-%% \end{lstlisting}
+Frequentemente, o compilador Scala pode deduzir o tipo do par\^{a}metro a partir
+do contexto da fun\c{c}\~{a}o an\^{o}nima nos casos em que foram omitidos.
+Por exemplo, no caso de \code{sumInts} ou \code{sumSquares}, sabe-se a partir do 
+tipo de \code{sum} que o primeiro par\^{a}metro deve ser uma fun\c{c}\~{a}o de tipo \code{Int => Int}.
+Consequentemente, o tipo do par\^{a}metro \code{Int} \'{e} redundante e pode ser omitido. Se
+houver um \'{u}nico par\^{a}metro sem um tipo, tamb\'{e}m podemos omitir os par\^{a}metros a sua volta. 
+   
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
+def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
+\end{lstlisting}
+%----------
 
+%----------
 %% Generally, the Scala term
 %% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
 %% defines a function which maps its parameters
@@ -1287,17 +1528,30 @@ a composição de um programa.
 %% functions are not essential language elements of Scala, as they can
 %% always be expressed in terms of named functions. Indeed, the 
 %% anonymous function
-%% \begin{lstlisting}
-%% (x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
-%% \end{lstlisting}
+Em geral, o termo em Scala 
+ \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
+define uma fun\c{c}\~{a}o que mapeia seus par\^{a}metros \code{x}$_1$\code{, ..., x}$_n$
+ao resultado da express\~{a}o \code{E} (onde \code{E} pode referir-se a   
+\code{x}$_1$\code{, ..., x}$_n$). Fun\c{c}\~{o}es an\^{o}nimas n\~{a}o s\~{a}o elementos essenciais
+da linguagem Scala, dado que sempre podem ser expressos em termos de fun\c{c}\~{o}es
+nomeadas. De fato, a fun\c{c}\~{a}o an\^{o}nima 
+
+\begin{lstlisting}
+(x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
+\end{lstlisting}
 %% is equivalent to the block
-%% \begin{lstlisting}
-%% { def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
-%% \end{lstlisting}
+\'{e} equivalente ao bloco
+\begin{lstlisting}
+{ def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
+\end{lstlisting}
 %% where \code{f} is fresh name which is used nowhere else in the program.
 %% We also say, anonymous functions are ``syntactic sugar''.
+onde \code{f} \'{e} um novo nome que n\~{a}o \'{e} utilizado em qualquer outro lugar do programa.
+Tamb\'{e}m dizemos que fun\c{c}\~{o}es an\^{o}nimas s\~{a}o ``syntactic sugar''. 
+%----------
 
-%% \section{Currying}
+%----------
+ \section{Currying}
 
 %% The latest formulation of the summing functions is already quite
 %% compact. But we can do even better. Note that
@@ -1307,46 +1561,73 @@ a composição de um programa.
 
 %% Let's try to rewrite \code{sum} so that it does not take the bounds
 %% \code{a} and \code{b} as parameters:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int): (Int, Int) => Int = {
-%%   def sumF(a: Int, b: Int): Int =
-%%     if (a > b) 0 else f(a) + sumF(a + 1, b)
-%%   sumF
-%% }
-%% \end{lstlisting}
+
+A \'{u}ltima formula\c{c}\~{a}o das fun\c{c}\~{o}es de soma j\'{a} s\~{a}o bem compactas. Mas 
+podemos fazer ainda melhor. Observe que \code{a} e \code{b} aparecem como 
+par\^{a}metros e argumentos de cada fun\c{c}\~{a}o, mas n\~{a}o parecem tomar parte de 
+combina\c{c}\~{o}es interessantes. H\'{a} algum modo de nos livrarmos delas?
+
+Vamos tentar reescrever \code{sum} de tal modo que n\~{a}o receba os limites
+\code{a} e \code{b} como par\^{a}metros:     
+
+\begin{lstlisting}
+def sum(f: Int => Int): (Int, Int) => Int = {
+  def sumF(a: Int, b: Int): Int =
+    if (a > b) 0 else f(a) + sumF(a + 1, b)
+  sumF
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% In this formulation, \code{sum} is a function which returns another
 %% function, namely the specialized summing function \code{sumF}. This
 %% latter function does all the work; it takes the bounds \code{a} and
 %% \code{b} as parameters, applies \code{sum}'s function parameter \code{f} to all
 %% integers between them, and sums up the results. 
-
+Nessa formula\c{c}\~{a}o, \code{sum} \'{e} uma fun\c{c}\~{a}o que retorna uma outra fun\c{c}\~{a}o, especificamente
+a fun\c{c}\~{a}o especializada soma \code{sumF}. Esta \'{u}ltima fun\c{c}\~{a}o realiza todo o trabalho; 
+recebe os limites \code{a} e \code{b} como par\^{a}metros, aplica a fun\c{c}\~{a}o \code{f}, par\^{a}metro
+de \code{sum}, a todos os inteiros entre eles, e soma os resultados.
+      
 %% Using this new formulation of \code{sum}, we can now define:
-%% \begin{lstlisting}
-%% def sumInts  =  sum(x => x)
-%% def sumSquares  =  sum(x => x * x)
-%% def sumPowersOfTwo  =  sum(powerOfTwo)
-%% \end{lstlisting}
+Usando esta nova formula\c{c}\~{a}o de \code{sum}, podemos agora definir:
+\begin{lstlisting}
+def sumInts  =  sum(x => x)
+def sumSquares  =  sum(x => x * x)
+def sumPowersOfTwo  =  sum(powerOfTwo)
+\end{lstlisting}
 %% Or, equivalently, with value definitions:
-%% \begin{lstlisting}
-%% val sumInts  =  sum(x => x)
-%% val sumSquares  =  sum(x => x * x)
-%% val sumPowersOfTwo  =  sum(powerOfTwo)
-%% \end{lstlisting}
+Ou, equivalentemente, com defini\c{c}\~{o}es de valores:
+\begin{lstlisting}
+val sumInts  =  sum(x => x)
+val sumSquares  =  sum(x => x * x)
+val sumPowersOfTwo  =  sum(powerOfTwo)
+\end{lstlisting}
+%----------
 
+%----------
 %% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
 %% applied like any other function. For instance,
-%% \begin{lstlisting}
-%% scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
-%% unnamed0: Int = 2096513
-%% \end{lstlisting}
+ \code{sumInts}, \code{sumSquares}, e \code{sumPowersOfTwo} podem ser
+aplicados como qualquer outra fun\c{c}\~{a}o. Por exemplo,
+\begin{lstlisting}
+scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
+unnamed0: Int = 2096513
+\end{lstlisting}
 %% How are function-returning functions applied? As an example, in the expression
-%% \begin{lstlisting}
-%% sum(x => x * x)(1, 10) ,
-%% \end{lstlisting}
+Como fun\c{c}\~{o}es que retornam fun\c{c}\~{o}es s\~{a}o aplicadas? Como exemplo, na express\~{a}o 
+\begin{lstlisting}
+sum(x => x * x)(1, 10) ,
+\end{lstlisting}
 %% the function \code{sum} is applied to the squaring function 
 %% \code{(x => x * x)}. The resulting function is then 
 %% applied to the second argument list, \code{(1, 10)}.
+a fun\c{c}\~{a}o \code{sum} \'{e} aplicada a fun\c{c}\~{a}o quadrada \code{(x => x * x)}. 
+O fun\c{c}\~{a}o resultante \'{e} ent\~{a}o aplicada ao segunda lista de argumentos, \code{(1, 10)}.   
+%----------
 
+%----------
 %% This notation is possible because function application associates to the left.
 %% That is, if $\mbox{args}_1$ and $\mbox{args}_2$ are argument lists, then 
 %% \bda{lcl}
@@ -1355,182 +1636,263 @@ a composição de um programa.
 %% In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
 %% following expression:
 %% \code{(sum(x => x * x))(1, 10)}.
+Essa nota\c{c}\~{a}o \'{e} poss\'{i}vel porque aplica\c{c}\~{o}es de fun\c{c}\~{o}es s\~{a}o associativas à esquerda.
+Ou seja, se $\mbox{args}_1$ e $\mbox{args}_2$ s\~{a}o listas de argumentos, ent\~{a}o 
+\bda{lcl}
+f(\mbox{args}_1)(\mbox{args}_2) & \ \ \mbox{\'{e} equivalente a}\ \ & (f(\mbox{args}_1))(\mbox{args}_2)
+\eda
+Em nosso exemplo, \code{sum(x => x * x)(1, 10)} \'{e} equivalente a seguinte express\~{a}o:
+\code{(sum(x => x * x))(1, 10)}.
+%----------
 
+%----------
 %% The style of function-returning functions is so useful that Scala has
 %% special syntax for it. For instance, the next definition of \code{sum}
 %% is equivalent to the previous one, but is shorter:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int)(a: Int, b: Int): Int =
-%%   if (a > b) 0 else f(a) + sum(f)(a + 1, b)
-%% \end{lstlisting}
+O estilo ``fun\c{c}\~{o}es que retornam fun\c{c}\~{o}es'' \'{e} t\~{a}o \'{u}til que Scala tem sintaxe
+especial para ele. Por exemplo, a pr\'{o}xima defini\c{c}\~{a}o de \code{sum} \'{e} equivalente
+a anterior, por\'{e}m mais curta: 
+\begin{lstlisting}
+def sum(f: Int => Int)(a: Int, b: Int): Int =
+  if (a > b) 0 else f(a) + sum(f)(a + 1, b)
+\end{lstlisting}
 %% Generally, a curried function definition 
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_n$) = E
-%% \end{lstlisting}
-%% where $n > 1$ expands to
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
-%% \end{lstlisting}
-%% where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
-%% \end{lstlisting}
-%% Performing this step $n$ times yields that
-%% \begin{lstlisting}
-%% def f (args$_1$) ... (args$_n$) = E
-%% \end{lstlisting}
-%% is equivalent to
-%% \begin{lstlisting}
-%% def f = (args$_1$) => ... => (args$_n$) => E .
-%% \end{lstlisting}
-%% Or, equivalently, using a value definition:
-%% \begin{lstlisting}
-%% val f = (args$_1$) => ... => (args$_n$) => E .
-%% \end{lstlisting}
+Genericamente, uma defini\c{c}\~{a}o de fun\c{c}\~{a}o currificada
+\begin{lstlisting}
+def f (args$_1$) ... (args$_n$) = E
+\end{lstlisting}
+%%where $n > 1$ expands to
+onde $n > 1$ expande para 
+\begin{lstlisting}
+def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
+\end{lstlisting}
+%%where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
+onde \code{g} \'{e} um novo identificador. Ou, menor, usando uma fun\c{c}\~{a}o an\^{o}nima: 
+\begin{lstlisting}
+def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
+\end{lstlisting}
+%%Performing this step $n$ times yields that
+Realizando este passo $n$ vezes d\'{a} aquela 
+\begin{lstlisting}
+def f (args$_1$) ... (args$_n$) = E
+\end{lstlisting}
+%%is equivalent to
+\'{e} equivalente a 
+\begin{lstlisting}
+def f = (args$_1$) => ... => (args$_n$) => E .
+\end{lstlisting}
+%%Or, equivalently, using a value definition:
+Ou, equivalentemente, usando uma defini\c{c}\~{a}o valor:
+\begin{lstlisting}
+val f = (args$_1$) => ... => (args$_n$) => E .
+\end{lstlisting}
 %% This style of function definition and application is called {\em
 %% currying} after its promoter, Haskell B.\ Curry, a logician of the
 %% 20th century, even though the idea goes back further to Moses
 %% Sch\"onfinkel and Gottlob Frege.
+Este estilo de defini\c{c}\~{a}o de fun\c{c}\~{a}o e aplica\c{c}\~{a}o \'{e} chamado {\em currificado}
+depois que seu divulgador, Haskell B.\ Curry, um l\'{o}gico do s\'{e}culo $20$, mesmo 
+que a id\'{e}ia nos leve de volta a Moses Sch\"onfinkel e Gottlob Frege.
+%----------
 
+%----------
 %% The type of a function-returning function is expressed analogously to
 %% its parameter list. Taking the last formulation of \code{sum} as an example,
 %% the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
 %% This is possible because function types associate to the right. I.e.
-%% \begin{lstlisting}
-%% T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
-%% \end{lstlisting}
+O tipo de uma fun\c{c}\~{a}o que retorna fun\c{c}\~{a}o \'{e} expresso de modo an\'{a}logo a sua lista
+de par\^{a}metros. Tomando a \'{u}ltima formula\c{c}\~{a}o de \code{sum} como exemplo, o tipo 
+para \code{sum} \'{e} \code{(Int => Int) => (Int, Int) => Int}.
+Isso \'{e} poss\'{i}vel porque tipos de fun\c{c}\~{o}es s\~{a}o associativos à direita. Ou seja, 
+\begin{lstlisting}
+T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
+\end{lstlisting}
+%----------
 
-
-%% \begin{exercise}
+%----------
+\begin{exercise}
 %% 1. The \code{sum} function uses a linear recursion. Can you write a
 %% tail-recursive one by filling in the ??'s?
+1. A fun\c{c}\~{a}o \code{sum} usa uma recursiva linear. Voc\^{e} poderia alter\'{a}-la
+para uma fun\c{c}\~{a}o recursiva de cauda, preenchendo as ?? abaixo?  
+\begin{lstlisting}
+def sum(f: Int => Int)(a: Int, b: Int): Int = {
+  def iter(a: Int, result: Int): Int = {
+    if (??) ??
+    else iter(??, ??)
+  }
+  iter(??, ??)
+}
+\end{lstlisting}
+\end{exercise}
+%----------
 
-%% \begin{lstlisting}
-%% def sum(f: Int => Int)(a: Int, b: Int): Int = {
-%%   def iter(a: Int, result: Int): Int = {
-%%     if (??) ??
-%%     else iter(??, ??)
-%%   }
-%%   iter(??, ??)
-%% }
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% \begin{exercise}
+%----------
+\begin{exercise}
 %% Write a function \code{product} that computes the product of the
 %% values of functions at points over a given range.
-%% \end{exercise}
+Escreva uma fun\c{c}\~{a}o \code{produto} que computa o produto de valores de
+fun\c{c}\~{o}es em pontos sobre um dado intervalo.  
+\end{exercise}
 
-%% \begin{exercise}
+\begin{exercise}
 %% Write \code{factorial} in terms of \code{product}.
-%% \end{exercise}
+Escreva \code{fatorial} em termos de \code{produto}.  
+\end{exercise}
 
-%% \begin{exercise}
+\begin{exercise}
 %% Can you write an even more general function which generalizes both
 %% \code{sum} and \code{product}?
-%% \end{exercise}
+Escreva uma fun\c{c}\~{a}o ainda mais gen\'{e}rica que generaliza ambos \code{sum} e \code{produto}.  
+\end{exercise}
+%----------
 
+%----------
 %% \section{Example: Finding Fixed Points of Functions}
 
 %% A number \code{x} is called a {\em fixed point} of a function \code{f} if
-%% \begin{lstlisting}
-%% f(x) = x .
-%% \end{lstlisting}
+\section{Exemplo: Encontrando Pontos Fixos de Fun\c{c}\~{o}es}
+
+Um n\'{u}mero \code{x} \'{e} chamado um {\em ponto fixo} de uma fun\c{c}\~{a}o \code{f} se  
+\begin{lstlisting}
+f(x) = x .
+\end{lstlisting}
 %% For some functions \code{f} we can locate the fixed point by beginning
 %% with an initial guess and then applying \code{f} repeatedly, until the
 %% value does not change anymore (or the change is within a small
 %% tolerance). This is possible if the sequence
-%% \begin{lstlisting}
-%% x, f(x), f(f(x)), f(f(f(x))), ...
-%% \end{lstlisting}
-%% converges to fixed point of $f$. This idea is captured in
-%% the following ``fixed-point finding function'':
-%% \begin{lstlisting}
-%% val tolerance = 0.0001
-%% def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
-%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-%%   def iterate(guess: Double): Double = {
-%%     val next = f(guess)
-%%     if (isCloseEnough(guess, next)) next
-%%     else iterate(next)
-%%   }
-%%   iterate(firstGuess)
-%% }
-%% \end{lstlisting}
+Para algumas fun\c{c}\~{o}es \code{f} podemos encontrar os pontos fixos iniciando
+com um palpite inicial e ent\~{a}o aplicando \code{f} repetidamente, at\'{e} que o valor 
+n\~{a}o mude mais (ou a mudan\c{c}a seja toler\'{a}vel). Isso \'{e} poss\'{i}vel na sequ\^{e}ncia  
+\begin{lstlisting}
+x, f(x), f(f(x)), f(f(f(x))), ...
+\end{lstlisting}
+%%converges to fixed point of $f$. This idea is captured in
+%%the following ``fixed-point finding function'':
+converge para pontos fixos de $f$. Essa id\'{e}ia \'{e} captada na ``fun\c{c}\~{a}o achadora 
+de pontos fixos'' a seguir:
+\begin{lstlisting}
+val tolerance = 0.0001
+def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
+def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+  def iterate(guess: Double): Double = {
+    val next = f(guess)
+    if (isCloseEnough(guess, next)) next
+    else iterate(next)
+  }
+  iterate(firstGuess)
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% We now apply this idea in a reformulation of the square root function.
 %% Let's start with a specification of \code{sqrt}:
-%% \begin{lstlisting}
-%% sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
-%%          =  $\mbox{the {\sl y} such that}$  y = x / y
-%% \end{lstlisting}
+Agora aplicaremos esta id\'{e}ia na reformula\c{c}\~{a}o da fun\c{c}\~{a}o raiz quadrada.
+Vamos come\c{c}ar pela especifica\c{c}\~{a}o de \code{sqrt}:  
+\begin{lstlisting}
+sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
+         =  $\mbox{the {\sl y} such that}$  y = x / y
+\end{lstlisting}
+
 %% Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
 %% This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
-%% \begin{lstlisting}
-%% def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
-%% \end{lstlisting}
+Consequentemente, \code{sqrt(x)} \'{e} um ponto fixo da fun\c{c}\~{a}o \code{y => x / y}.
+Isso sugere que \code{sqrt(x)} pode ser computado por uma itera\c{c}\~{a}o de ponto fixo: 
+\begin{lstlisting}
+def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
+\end{lstlisting}
 %% But if we try this, we find that the computation does not
 %% converge. Let's instrument the fixed point function with a print
 %% statement which keeps track of the current \code{guess} value:
-%% \begin{lstlisting}
-%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-%%   def iterate(guess: Double): Double = {
-%%     val next = f(guess)
-%%     println(next)
-%%     if (isCloseEnough(guess, next)) next
-%%     else iterate(next)
-%%   }
-%%   iterate(firstGuess)
-%% }
-%% \end{lstlisting}
+Mas se tentarmos isso, percebemos que aquela computa\c{c}\~{a}o n\~{a}o converge. 
+Vamos agregar à fun\c{c}\~{a}o de ponto fixo um comando print que mostra o 
+valor corrente de \code{guess}: 
+\begin{lstlisting}
+def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+  def iterate(guess: Double): Double = {
+    val next = f(guess)
+    println(next)
+    if (isCloseEnough(guess, next)) next
+    else iterate(next)
+  }
+  iterate(firstGuess)
+}
+\end{lstlisting}
 %% Then, \code{sqrt(2)} yields:
-%% \begin{lstlisting}
-%%   2.0
-%%   1.0
-%%   2.0
-%%   1.0
-%%   2.0
-%%   ...
-%% \end{lstlisting}
+Ent\~{a}o, \code{sqrt(2)} d\'{a}: 
+\begin{lstlisting}
+  2.0
+  1.0
+  2.0
+  1.0
+  2.0
+  ...
+\end{lstlisting}
+%----------
+
+%----------
 %% One way to control such oscillations is to prevent the guess from changing too much. 
 %% This can be achieved by {\em averaging} successive values of the original sequence:
-%% \begin{lstlisting}
-%% scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
-%% sqrt: (Double)Double
+Um modo de controlar tais oscila\c{c}\~{o}es \'{e} prevenir guess de mudar muito.
+Isso pode ser obtido pela m\'{e}dia (fun\c{c}\~{a}o {\em averaging}) de sucessivos valores da sequ\^{e}ncia 
+original:
+\begin{lstlisting}
+scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
+sqrt: (Double)Double
 
-%% scala> sqrt(2.0)
-%%   1.5
-%%   1.4166666666666665
-%%   1.4142156862745097
-%%   1.4142135623746899
-%%   1.4142135623746899
-%% \end{lstlisting}
+scala> sqrt(2.0)
+  1.5
+  1.4166666666666665
+  1.4142156862745097
+  1.4142135623746899
+  1.4142135623746899
+\end{lstlisting}
 %% In fact, expanding the \code{fixedPoint} function yields exactly our 
 %% previous definition of fixed point from Section~\ref{sec:sqrt}.
-
+De fato, expandindo a fun\c{c}\~{a}o \code{fixedPoint} d\'{a} exatamente nossa pr\'{e}via
+defini\c{c}\~{a}o de ponto fixo da Se\c{c}\~{a}o~\ref{sec:sqrt}.
 %% The previous examples showed that the expressive power of a language
 %% is considerably enhanced if functions can be passed as arguments.  The
 %% next example shows that functions which return functions can also be
 %% very useful.
+Os exemplos anteriores mostraram que o poder de expressividade de uma linguagem 
+\'{e} consideravelmente aumentado se fun\c{c}\~{o}es puderem ser passadas como argumentos.
+O pr\'{o}ximo exemplo mostra que fun\c{c}\~{o}es que retornam fun\c{c}\~{o}es tamb\'{e}m podem ser
+muito \'{u}teis.
+%----------
 
+%----------
 %% Consider again fixed point iterations. We started with the observation
 %% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
 %% Then we made the iteration converge by averaging successive values.
 %% This technique of {\em average damping} is so general that it
 %% can be wrapped in another function.
-%% \begin{lstlisting}
-%% def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
-%% \end{lstlisting}
+Considere novamente itera\c{c}\~{o}es de ponto fixo. Come\c{c}amos observando que 
+$\sqrt(x)$ \'{e} um ponto fixo da fun\c{c}\~{a}o \code{y => x / y}. Ent\~{a}o fazemos
+a itera\c{c}\~{a}o convergir tirando a m\'{e}dia de sucessivos valores. Essa t\'{e}cnica
+de {\em amortecimento da m\'{e}dia} \'{e} t\~{a}o gen\'{e}rica que pode ser denotada
+em outra fun\c{c}\~{a}o.
+\begin{lstlisting}
+def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
+\end{lstlisting}
 %% Using \code{averageDamp}, we can reformulate the square root function
 %% as follows.
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
-%% \end{lstlisting}
+Usando \code{averageDamp}, podemos reformular a fun\c{c}\~{a}o da raiz quadrada
+como segue. 
+\begin{lstlisting}
+def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
+\end{lstlisting}
 %% This expresses the elements of the algorithm as clearly as possible.
-
-%% \begin{exercise} Write a function for cube roots using \code{fixedPoint} and 
+Isto expressa os elementos do algoritmo t\~{a}o claramente quanto poss\'{i}vel.
+\begin{exercise} 
+%%Write a function for cube roots using \code{fixedPoint} and 
 %% \code{averageDamp}.
-%% \end{exercise}
+Escreva uma fun\c{c}\~{a}o para a raiz c\'{u}bica usando \code{fixedPoint} e \code{averageDamp}.  
+\end{exercise}
+%----------
 
+%----------
 %% \section{Summary}
 
 %% We have seen in the previous chapter that functions are essential
@@ -1542,9 +1904,19 @@ a composição de um programa.
 %% reuse. The highest possible level of abstraction is not always the
 %% best, but it is important to know abstraction techniques, so that one
 %% can use abstractions where appropriate.
+Vimos no cap\'{i}tulo anterior que fun\c{c}\~{o}es s\~{a}o abstra\c{c}\~{o}es essenciais porque 
+nos permitem introduzir m\'{e}todos gen\'{e}ricos de computa\c{c}\~{a}o como expl\'{i}citos,
+elementos nomeados em nossa linguagem de programa\c{c}\~{a}o. O presente cap\'{i}tulo
+mostrou que tais abstra\c{c}\~{o}es podem ser combinados por fun\c{c}\~{o}es de alta ordem
+para criar mais abstra\c{c}\~{o}es. Como programadores, devemos procurar por oportunidades 
+de reuso e abstra\c{c}\~{a}o. O mais alto n\'{i}vel poss\'{i}vel de abstra\c{c}\~{a}o nem sempre \'{e} 
+o melhor, mas \'{e} importante saber t\'{e}cnicas de abstra\c{c}\~{a}o, de modo que possamos
+us\'{a}-las quando apropriado. 
+%----------
 
+%----------
 %% \section{Language Elements Seen So Far}
-
+\section{Elementos da Linguagem Vistos At\'{e} Aqui}
 %% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
 %% covered Scala's language elements to express expressions and types
 %% comprising of primitive data and functions.  The context-free syntax
@@ -1552,44 +1924,59 @@ a composição de um programa.
 %% form, where `\code{|}' denotes alternatives, \code{[...]} denotes
 %% option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
 %% (0 or more occurrences).
-
+ Os cap\'{i}tulos ~\ref{chap:simple-funs} e \ref{chap:first-class-funs} trataram
+elementos da linguagem Scala para expressar tipos e express\~{o}es relacionados a
+tipos primitivos e fun\c{c}\~{o}es. A sintaxe livre de contexto desses elementos da
+linguagem s\~{a}o dados abaixo em formato Backus-Naur estendido, onde `\code{|}'
+denotam alternativas, \code{[...]} denotam op\c{c}\~{a}o  (0 ou 1 ocorr\^{e}ncia), e  
+\lstinline@{...}@ denotam (0 ou mais ocorr\^{e}ncias). 
 %% \subsection*{Characters}
-
+\subsection*{Caracteres}
 %% Scala programs are sequences of (Unicode) characters. We distinguish the
 %% following character sets:
-%% \begin{itemize}
-%% \item
+Programas em Scala s\~{a}o sequ\^{e}ncia de caracteres (Unicode). Distinguimos os
+seguintes conjuntos de caracteres.
+ \begin{itemize}
+ \item
 %% whitespace, such as `\code{ }', tabulator, or newline characters,
-%% \item
+espa\c{c}o em branco, tal como `\code{ }', tabula\c{c}\~{a}o, ou caracter de mudan\c{c}a de linha (newline), 
+ \item
 %% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
-%% \item
+letras `\code{a}' a `\code{z}', `\code{A}' a `\code{Z}',    
+ \item
 %% digits \code{`0'} to `\code{9}',
-%% \item
+digitos `\code{0}' a `\code{9}',   
+ \item
 %% the delimiter characters
-
-%% \begin{lstlisting}
-%% .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
-%% \end{lstlisting}
-
-%% \item
+caracteres delimitadores
+ \begin{lstlisting}
+ .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
+ \end{lstlisting}
+ \item
 %% operator characters, such as `\code{#}' `\code{+}',
 %% `\code{:}'. Essentially, these are printable characters which are
 %% in none of the character sets above.
-%% \end{itemize}
+caracteres operadores, tal como `\code{#}', `\code{+}' e `\code{:}'.
+Essencialmente, h\'{a} caracteres imprim\'{i}veis que n\~{a}o est\~{a}o em nenhum dos 
+conjuntos de caracteres acima.   
+ \end{itemize}
 
 %% \subsection*{Lexemes:}
+\subsection*{Lexemas:}
 
-%% \begin{lstlisting}
-%% ident    =  letter {letter | digit}
-%%          |  operator { operator }
-%%          |  ident '_' ident
-%% literal  =  $\mbox{``as in Java''}$
-%% \end{lstlisting}
+\begin{lstlisting}
+ident    =  letter {letter | digit}
+         |  operator { operator }
+         |  ident '_' ident
+literal  =  $\mbox{``como em Java''}$
+\end{lstlisting}
 
 %% Literals are as in Java. They define numbers, characters, strings, or
 %% boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
 %% \code{"he said \"hi!\""}, or \code{true}.
-
+Literais s\~{a}o como em Java. Eles definem n\'{u}meros, caracteres, cadeias de caracteres, ou 
+valores boleanos. Exemplos de literais tais como \code{0}, \code{1.0e10}, \code{'x'},
+\code{"ele disse \"oi!\""}, ou \code{true}.
 %% Identifiers can be of two forms. They either start with a letter,
 %% which is followed by a (possibly empty) sequence of letters or
 %% symbols, or they start with an operator character, which is followed
@@ -1597,87 +1984,120 @@ a composição de um programa.
 %% identifiers may contain underscore characters `\code{_}'. Furthermore,
 %% an underscore character may be followed by either sort of
 %% identifier. Hence, the following are all legal identifiers:
-%% \begin{lstlisting}
-%% x     Room10a     +     --     foldl_:     +_vector
-%% \end{lstlisting}
+Identificadores podem ter duas formas. Eles ou iniciam por uma letra, que \'{e} 
+seguida por uma sequ\^{e}ncia (possivelmente vazia) de letras ou s\'{i}mbolos, ou podem 
+iniciar com um caracter operador, seguido por uma sequ\^{e}ncia (possivelmente vazia) de
+caracteres operadores. Ambas as formas podem conter caracteres ``underscore'' `\code{_}'.
+Al\'{e}m disso, um caracter underscore pode ser seguido por quaisquer identificadores.
+Consequentemente, todos a seguir s\~{a}o identificadores legais:  
+ \begin{lstlisting}
+ x     Room10a     +     --     foldl_:     +_vector
+ \end{lstlisting}
 %% It follows from this rule that subsequent operator-identifiers need to
 %% be separated by whitespace. For instance, the input
 %% \code{x+-y} is parsed as the three token sequence \code{x}, \code{+-},
 %% \code{y}. If we want to express the sum of \code{x} with the
 %% negated value of \code{y}, we need to add at least one space,
 %% e.g. \code{x+ -y}.
+Segue desta regra que identificadores operadores subsequentes precisam ser
+separados por espa\c{c}o em branco. Por exemplo, a entrada \code{x+-y} \'{e} entendida 
+como a sequ\^{e}ncia de tr\^{e}s ``tokens'' \code{x}, \code{+-} e \code{y}. Se
+desejamos expressar a soma de \code{x} com o valor negativo de \code{y}, 
+precisamos acrescentar no m\'{i}nimo um espa\c{c}o, ou seja, \code{x+ -y}.      
+%----------
 
+%----------
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
+O caracter \verb@$@ \'{e} reservado para identificadores gerados
+pelo compilador; n\~{a}o devem ser usados em programas fontes. %$ 
 
 %% The following are reserved words, they may not be used as identifiers:
-%% \begin{lstlisting}
-%% abstract    case        catch       class       def    
-%% do          else        extends     false       final    
-%% finally     for         if          implicit    import      
-%% match       new         null        object      override    
-%% package     private     protected   requires    return      
-%% sealed      super       this        throw       trait
-%% try         true        type        val         var         
-%% while       with        yield
-%% _    :    =    =>    <-    <:    <%     >:    #    @
-%% \end{lstlisting}
+Os seguintes s\~{a}o palavras reservadas, e n\~{a}o devem ser usadas como identificadores:
+\begin{lstlisting}
+abstract    case        catch       class       def    
+do          else        extends     false       final    
+finally     for         if          implicit    import      
+match       new         null        object      override    
+package     private     protected   requires    return      
+sealed      super       this        throw       trait
+try         true        type        val         var         
+while       with        yield
+_    :    =    =>    <-    <:    <%     >:    #    @
+\end{lstlisting}
+%----------
 
+%----------
 %% \subsection*{Types:}
+\subsection*{Types:}
 
-%% \begin{lstlisting}
-%% Type          =  SimpleType | FunctionType
-%% FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
-%% SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
-%%                  Boolean | Unit | String
-%% Types         =  Type {`,' Type}
-%% \end{lstlisting}
+\begin{lstlisting}
+Type          =  SimpleType | FunctionType
+FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
+SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
+                 Boolean | Unit | String
+Types         =  Type {`,' Type}
+\end{lstlisting}
 
 %% Types can be:
-%% \begin{itemize}
-%% \item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
-%% \item the type \code{Boolean} with values \code{true} and \code{false},
-%% \item the type \code{Unit} with the only value \lstinline@()@,
-%% \item the type \code{String},
-%% \item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
-%% \end{itemize}
+Tipos podem ser:
+ \begin{itemize}
+ \item tipos num\'{e}ricos \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (com em Java),
+ \item o tipo \code{Boolean} com valores  \code{true} e \code{false},
+ \item o tipo \code{Unit} com o \'{u}nico valor  \lstinline@()@,
+ \item o tipo \code{String},
+ \item tipos fun\c{c}\~{a}o, tal como  \code{(Int, Int) => Int} ou \code{String => Int => String}.
+ \end{itemize}
+%----------
 
+%----------
 %% \subsection*{Expressions:}
-
-%% \begin{lstlisting}
-%% Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
-%% InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
-%% Operator     = ident
-%% PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
-%% SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
-%% FunctionExpr = (Bindings | Id) '=>' Expr
-%% Bindings     = `(' Binding {`,' Binding} `)'
-%% Binding      = ident [':' Type]
-%% Block        = '{' {Def ';'} Expr '}'
-%% \end{lstlisting}
+ \subsection*{Express\~{o}es:}
+\begin{lstlisting}
+Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
+InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
+Operator     = ident
+PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
+SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
+FunctionExpr = (Bindings | Id) '=>' Expr
+Bindings     = `(' Binding {`,' Binding} `)'
+Binding      = ident [':' Type]
+Block        = '{' {Def ';'} Expr '}'
+\end{lstlisting}
 
 %% Expressions can be:
-%% \begin{itemize}
-%% \item
+Express\~{o}es podem ser:
+ \begin{itemize}
+ \item
 %% identifiers such as \code{x}, \code{isGoodEnough}, \code{*}, or \code{+-},
-%% \item
+identificadores tais como \code{x}, \code{isGoodEnough}, \code{*}, ou \code{+-},
+ \item
 %% literals, such as \code{0}, \code{1.0}, or \code{"abc"},
-%% \item
+literais, tais como \code{0}, \code{1.0}, ou \code{"abc"},
+ \item
 %% field and method selections, such as \code{System.out.println},
-%% \item
-%% function applications, such as \code{sqrt(x)}, 
-%% \item
+Sele\c{c}\~{o}es de campo e m\'{e}todo, tal como \code{System.out.println},
+ \item
+%% function applications, such as \code{sqrt(x)},
+aplica\c{c}\~{o}es de fun\c{c}\~{a}o, tal como \code{sqrt(x)},
+ \item
 %% operator applications, such as \code{-x} or \code{y + x},
-%% \item
+aplica\c{c}\~{o}es de operador, tais como \code{-x} ou \code{y + x},
+ \item
 %% conditionals, such as \code{if (x < 0) -x else x},
-%% \item
+condicionais, tal como \code{if (x < 0) -x else x},
+ \item
 %% blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
-%% \item
+blocos, tal como \lstinline@{ val x = abs(y) ; x * 2 }@,
+ \item
 %% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
-%% \end{itemize}
+fun\c{c}\~{o}es an\^{o}nimas, tais como \code{x => x + 1} ou \code{(x: Int, y: Int) => x + y}.
+ \end{itemize}
+%----------
 
-%% \subsection*{Definitions:}
-
+%----------
+%% \subsection*{Definitions}:
+\subsection*{Defini\c{c}\~{o}es:}
 \begin{lstlisting}
 Def          =  FunDef  |  ValDef
 FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
@@ -1685,19 +2105,26 @@ ValDef       =  'val' ident [':' Type] '=' Expr
 Parameters   =  Parameter {',' Parameter}
 Parameter    =  ident ':' ['=>'] Type
 \end{lstlisting}
-Definitions can be:
+%%Definitions can be:
+Defini\c{c}\~{o}es podem ser:
 \begin{itemize}
 \item
-function definitions such as \code{def square(x: Int): Int = x * x},
+%%function definitions such as \code{def square(x: Int): Int = x * x},
+defini\c{c}\~{o}es de fun\c{c}\~{a}o tal como \code{def square(x: Int): Int = x * x},
 \item
-value definitions such as \code{val y = square(2)}.
+%%value definitions such as \code{val y = square(2)}.
+defini\c{c}\~{o}es de valor tal como \code{val y = square(2)}.
 \end{itemize}
+%----------
 
+%----------
 \chapter{Classes and Objects}
 \label{chap:classes}
 
 %% Scala does not have a built-in type of rational numbers, but it is
 %% easy to define one, using a class. Here's a possible implementation.
+Scala n\~{a}o tem um tipo primitivo para n\'{u}meros racionais, mas \'{e} f\'{a}cil 
+definir um, usando uma classe. Aqui est\'{a} uma poss\'{i}vel implementa\c{c}\~{a}o.
 
 \begin{lstlisting}
 class Rational(n: Int, d: Int) {
@@ -1731,6 +2158,15 @@ class Rational(n: Int, d: Int) {
 %% operation. The left operand of the operation is always the rational
 %% number of which the method is a member.
 
+Isso define \code{Rational} como uma classe que recebe dois argumentos 
+construtores \code{n} e \code{d}, contendo as partes num\'{e}ricas do numerador
+e denominador. A classe prov\^{e} campos que retornam estas partes, bem como
+m\'{e}todos para a aritm\'{e}tica sobre n\'{u}meros racionais. Cada m\'{e}todo aritm\'{e}tico 
+recebe como par\^{a}metro o operando direito da opera\c{c}\~{a}o. O operando esquerdo
+da opera\c{c}\~{a}o sempre \'{e} o n\'{u}mero racional do m\'{e}todo cujo \'{e} membro.   
+%----------
+
+%----------
 %% \paragraph{Private members}
 %% The implementation of rational numbers defines a private method
 %% \code{gcd} which computes the greatest common denominator of two
@@ -1740,23 +2176,41 @@ class Rational(n: Int, d: Int) {
 %% the class to eliminate common factors in the constructor arguments in
 %% order to ensure that numerator and denominator are always in
 %% normalized form.
+\paragraph{Membros Privados}
+A implementa\c{c}\~{a}o dos n\'{u}meros racionais define um m\'{e}todo privado \code{gcd} que 
+computa o maior denominador comum de dois inteiros, bem como um campo
+privado \code{g} que cont\'{e}m o \code{gcd} dos argumentos construtores. Esses
+membros s\~{a}o inacess\'{i}veis de fora da classe \code{Rational}. S\~{a}o usados na 
+implementa\c{c}\~{a}o da classe para eliminar fatores comuns nos argumentos construtores
+para garantir que o numerador e o denominador estejam sempre em forma normalizada.    
+%----------
 
+%----------
 %% \paragraph{Creating and Accessing Objects}
 %% As an example of how rational numbers can be used, here's a program
 %% that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
-%% \begin{lstlisting}
-%% var i = 1
-%% var x = new Rational(0, 1)
-%% while (i <= 10) {
-%%   x += new Rational(1, i)
-%%   i += 1
-%% }
-%% println("" + x.numer + "/" + x.denom)
-%% \end{lstlisting}
+\paragraph{Criando e Acessando Objetos}
+Como um exemplo de como os n\'{u}meros racionais podem ser usados, aqui est\'{a} um programa 
+que imprime a soma de todos os n\'{u}meros $1/i$ onde $i$ est\'{a} no intervalo de 1 a 10. 
+\begin{lstlisting}
+var i = 1
+var x = new Rational(0, 1)
+while (i <= 10) {
+  x += new Rational(1, i)
+  i += 1
+}
+println("" + x.numer + "/" + x.denom)
+\end{lstlisting}
 %% The \code{+} takes as left operand a string and as right operand a
 %% value of arbitrary type. It returns the result of converting its right
 %% operand to a string and appending it to its left operand. 
-  
+O \code{+} recebe como operando esquerdo uma cadeia de caracteres e como 
+operando direito um valor de tipo arbitr\'{a}rio. Retorna o resultado de 
+converter seu operando direito em uma cadeia de caracteres e concaten\'{a}-la 
+a seu operando esquerdo.   
+%----------
+
+%----------
 %% \paragraph{Inheritance and Overriding}
 %% Every class in Scala has a superclass which it extends.  
 %% \comment{Excepted is
@@ -1767,63 +2221,104 @@ class Rational(n: Int, d: Int) {
 %% \code{scala.AnyRef} is implicitly assumed (for Java implementations,
 %% this type is an alias for \code{java.lang.Object}. For instance, class
 %% \code{Rational} could equivalently be defined as
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%% }
-%% \end{lstlisting}
+\paragraph{Heran\c{c}a e Sobrecarga}
+Cada classe em Scala tem uma superclasse que ela estende.
+\comment{A exce\c{c}\~{a}o \'{e} a classe \code{Object}, que n\~{a}o possui superclasse, e
+que \'{e} indiretamente estendida para cada outra classe.}
+Se uma classe n\~{a}o menciona sua superclasse em sua defini\c{c}\~{a}o, o tipo b\'{a}sico 
+\code{scala.AnyRef} \'{e} implicitamente assumido (para implementa\c{c}\~{o}es Java, este
+tipo \'{e} um apelido (alias) para \code{java.lang.Object}. Por exemplo, a classe 
+\code{Rational} pode ser equivalentemente definida como      
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // como antes
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% A class inherits all members from its superclass. It may also redefine
 %% (or: {\em override}) some inherited members. For instance, class
 %% \code{java.lang.Object} defines
 %% a method
 %% \code{toString} which returns a representation of the object as a string:
-%% \begin{lstlisting}
-%% class Object {
-%%   ...
-%%   def toString: String = ...
-%% }
-%% \end{lstlisting}
+Uma classe herda todos os membros de sua superclasse. Pode tamb\'{e}m redefinir
+(ou: {\em sobrescrever}) alguns membros herdados. Por exemplo, a classe 
+\code{java.lang.Object} define um m\'{e}todo \code{toString} que retorna uma 
+representa\c{c}\~{a}o do objeto como cadeia de caracteres (string): 
+\begin{lstlisting}
+class Object {
+  ...
+  def toString: String = ...
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% The implementation of \code{toString} in \code{Object}
 %% forms a string consisting of the object's class name and a number. It
 %% makes sense to redefine this method for objects that are rational
 %% numbers:
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%%   override def toString = "" + numer + "/" + denom
-%% }
-%% \end{lstlisting}
+A implementa\c{c}\~{a}o de \code{toString} em \code{Object} forma uma string que 
+consiste do nome da classe do objeto e um n\'{u}mero. Faz sentido redefinir este
+m\'{e}todo para objetos que s\~{a}o n\'{u}meros racionais:  
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // como antes
+  override def toString = "" + numer + "/" + denom
+}
+\end{lstlisting}
 %% Note that, unlike in Java, redefining definitions need to be preceded
 %% by an \code{override} modifier.
+Observe que, diferentemente de Java, defini\c{c}\~{o}es que redefinem precisam
+ser precedidas por um modificador \code{override}.  
+%----------
 
+%----------
 %% If class $A$ extends class $B$, then objects of type $A$ may be used
 %% wherever objects of type $B$ are expected. We say in this case that
 %% type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
 %% conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
 %% value to a variable of type \code{AnyRef}:
-%% \begin{lstlisting}
-%% var x: AnyRef = new Rational(1, 2)
-%% \end{lstlisting}
+Se a classe $A$ estende a classe $B$, ent\~{a}o objetos do tipo $A$ podem ser
+usados sempre que objetos do tipo $B$ s\~{a}o esperados. Nesse caso dizemos que o 
+tipo $A$ est\'{a} em {\em conformidade} com o tipo $B$. Por exemplo, \code{Rational}
+est\'{a} em conformidade com \code{AnyRef}, logo \'{e} legal atribuir um valor \code{Rational}
+à vari\'{a}vel do tipo \code{AnyRef}:
+ 
+ \begin{lstlisting}
+ var x: AnyRef = new Rational(1, 2)
+ \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Parameterless Methods}
 %% %Also unlike in Java, methods in Scala do not necessarily take a
 %% %parameter list. An example is \code{toString}; the method is invoked
 %% %by simply mentioning its name. For instance:
-%% %\begin{lstlisting}
-%% %val r = new Rational(1,2)
-%% %System.out.println(r.toString);      // prints``1/2''
-%% %\end{lstlisting}
+\paragraph{M\'{e}todos sem Par\^{a}metros}
+
+\begin{lstlisting}
+val r = new Rational(1,2)
+System.out.println(r.toString);      // prints``1/2''
+\end{lstlisting}
 %% Unlike in Java, methods in Scala do not necessarily take a
 %% parameter list. An example is the \code{square} method below. This
 %% method is invoked by simply mentioning its name. 
-%% \begin{lstlisting}
-%% class Rational(n: Int, d: Int) extends AnyRef {
-%%   ... // as before
-%%   def square = new Rational(numer*numer, denom*denom)
-%% }
-%% val r = new Rational(3, 4)
-%% println(r.square)           // prints``9/16''*
-%% \end{lstlisting}
+Distintamente de Java, m\'{e}todos em Scala n\~{a}o necessariamente precisam 
+receber uma lista de par\^{a}metros. Um exemplo \'{e} o m\'{e}todo abaixo \code{square}.
+Este m\'{e}todo \'{e} invocado simplesmente mencionando seu nome. 
+\begin{lstlisting}
+class Rational(n: Int, d: Int) extends AnyRef {
+  ... // como antes
+  def square = new Rational(numer*numer, denom*denom)
+}
+val r = new Rational(3, 4)
+println(r.square)           // prints``9/16''*
+\end{lstlisting}
+%----------
+
+%----------
 %% That is, parameterless methods are accessed just as value fields such
 %% as \code{numer} are. The difference between values and parameterless
 %% methods lies in their definition. The right-hand side of a value is
@@ -1834,8 +2329,21 @@ class Rational(n: Int, d: Int) {
 %% the implementer of a class. Often, a field in one version of a class
 %% becomes a computed value in the next version. Uniform access ensures
 %% that clients do not have to be rewritten because of that change.
+Ou seja, m\'{e}todos sem par\^{a}metros s\~{a}o acessados como campos valor, tais como 
+\code{numer} s\~{a}o. A diferen\c{c}a entre valores e m\'{e}todos sem par\^{a}metros 
+reside em suas defini\c{c}\~{o}es. O lado direito de um valor \'{e} avaliado quando o 
+objeto \'{e} criado, e o valor n\~{a}o muda depois. Um lado direito de um m\'{e}todo sem
+par\^{a}metros, por outro lado, \'{e} avaliado cada vez que o m\'{e}todo \'{e} chamado. O 
+acesso uniforme dos campos de m\'{e}todos sem par\^{a}metros resulta em crescente
+flexibilidade para o implementador de uma classe. Frequentemente, um campo
+em uma vers\~{a}o da classe torna-se um valor computado na pr\'{o}xima vers\~{a}o. 
+O acesso uniforme garante que clientes n\~{a}o tenham de ser reescritos 
+por conta desta mudan\c{c}a.
+%----------
 
+%----------
 %% \paragraph{Abstract Classes}
+\paragraph{Classes Abstratas}
 
 %% Consider the task of writing a class for sets of integer numbers with
 %% two operations, \code{incl} and \code{contains}. \code{(s incl x)}
@@ -1843,13 +2351,22 @@ class Rational(n: Int, d: Int) {
 %% with all the elements of set \code{s}. \code{(s contains x)} should
 %% return true if the set \code{s} contains the element \code{x}, and
 %% should return \code{false} otherwise. The interface of such sets is
-%% given by:  
-%% \begin{lstlisting}
-%% abstract class IntSet {
-%%   def incl(x: Int): IntSet
-%%   def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
+%% given by:
+Considere a tarefa de escrever uma classe para conjuntos de n\'{u}meros inteiros com 
+duas opera\c{c}\~{o}es, \code{incl} e \code{contains}. \code{(s incl x)} deve retornar
+um novo conjunto que cont\'{e}m o elemento \code{x} juntamente com todos os elementos 
+do conjunto \code{s}. \code{(s contains x)} deve retornar \code{true} se o conjunto 
+\code{s} contiver o elemento \code{x}, e deve retornar \code{false}, caso contr\'{a}rio.
+A interface para tais conjuntos \'{e} dada por:
+\begin{lstlisting}
+abstract class IntSet {
+  def incl(x: Int): IntSet
+  def contains(x: Int): Boolean
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% \code{IntSet} is labeled as an \emph{abstract class}. This has two
 %% consequences.  First, abstract classes may have {\em deferred} members
 %% which are declared but which do not have an implementation. In our
@@ -1858,8 +2375,17 @@ class Rational(n: Int, d: Int) {
 %% of that class may be created using \code{new}. By contrast, an
 %% abstract class may be used as a base class of some other class, which
 %% implements the deferred members.
+\code{IntSet} \'{e} tido como uma {\em classe abstrata}. Isso tem duas consequ\^{e}ncias. 
+Primeiro, classes abstratas podem ter membros {\em protelados (deferred)} que s\~{a}o 
+declarados, mas que n\~{a}o tem uma implementa\c{c}\~{a}o. No nosso caso, ambos \code{incl} e 
+\code{contains} s\~{a}o tais membros. Segundo, porque uma classe abstrata pode ter 
+membros n\~{a}o implementados, nenhum objeto daquela classe pode ser criado usando \code{new}.
+Em contraste, uma classe abstrata pode ser usada como uma classe base de alguma outra
+classe, que implementa os membros que foram postergados. 
+%----------
 
-%% \paragraph{Traits}
+%----------
+ \paragraph{Traits}
 
 %% Instead of \code{abstract class} one also often uses the keyword
 %% \code{trait} in Scala. Traits are abstract classes that are meant to
@@ -1869,64 +2395,93 @@ class Rational(n: Int, d: Int) {
 %% components. Another usage scenario is where the trait collects
 %% signatures of some functionality provided by different classes, much
 %% in the way a Java interface would work.
+Ao inv\'{e}s de \code{classe abstrata} frequentemente usa-se a palavra chave
+\code{trait} em Scala. Traits s\~{a}o classes abstratas que desejamos adicionar
+a alguma outra classe. Isso pode ser porque um trait adiciona alguns m\'{e}todos
+ou campos para uma classe pai desconhecida. Por exemplo, um trait \code{Bordered} 
+pode ser usado para adicionar uma borda a v\'{a}rios componentes gr\'{a}ficos. Um outro
+cen\'{a}rio de uso ocorre quando o trait coleta assinaturas de alguma funcionalidade 
+provida por diferentes classes, do mesmo modo que uma interface Java faria.
 
 %% Since \code{IntSet} falls in this category, one can alternatively
 %% define it as a trait:
-%% \begin{lstlisting}
-%% trait IntSet {
-%%   def incl(x: Int): IntSet
-%%   def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
+Como \code{IntSet} pertence a esta categoria, pode-se alternativamente 
+defin\'{i}-la como um trait:
+\begin{lstlisting}
+trait IntSet {
+  def incl(x: Int): IntSet
+  def contains(x: Int): Boolean
+}
+\end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Implementing Abstract Classes}
-
+\paragraph{Implementando Classes Abstratas}
 %% Let's say, we plan to implement sets as binary trees.  There are two
 %% possible forms of trees. A tree for the empty set, and a tree
 %% consisting of an integer and two subtrees. Here are their
 %% implementations.
 
-%% \begin{lstlisting}
-%% class EmptySet extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
-%% }
-%% \end{lstlisting}
+Vamos dizer que planejamos implementar conjuntos como \'{a}rvores bin\'{a}rias. H\'{a} 
+duas poss\'{i}veis formas de \'{a}rvores. Uma \'{a}rvore para o conjunto vazio, e uma 
+\'{a}rvore consistindo de um inteiro e duas sub\'{a}rvores. Aqui est\~{a}o suas implementa\c{c}\~{o}es:
+ 
+\begin{lstlisting}
+class EmptySet extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
+}
+\end{lstlisting}
 
-%% \begin{lstlisting}
-%% class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: Int): IntSet =
-%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
-%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
+\begin{lstlisting}
+class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: Int): IntSet =
+    if (x < elem) new NonEmptySet(elem, left incl x, right)
+    else if (x > elem) new NonEmptySet(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
 %% Both \code{EmptySet} and \code{NonEmptySet} extend class
 %% \code{IntSet}.  This implies that types \code{EmptySet} and
 %% \code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
+Ambos \code{EmptySet} e \code{NonEmptySet} estendem a classe \code{IntSet}. Isso implica
+que tipos \code{EmptySet} e \code{NonEmptySet} est\~{a}o em conformidade com o tipo \code{IntSet} -- 
+um valor do tipo \code{EmptySet} ou \code{NonEmptySet} pode ser usado sempre que um valor 
+ do tipo \code{IntSet} \'{e} requerido.
+%----------
 
+%----------
 %% \begin{exercise} Write methods \code{union} and \code{intersection} to form
 %% the union and intersection between two sets.
 %% \end{exercise}
-
-%% \begin{exercise} Add a method 
-%% \begin{lstlisting}
-%% def excl(x: Int)
-%% \end{lstlisting}
+\begin{exercise}
+Escreva os m\'{e}todos \code{uniao} e \code{intersecao} para formar a uni\~{a}o e interse\c{c}\~{a}o entre
+dois conjuntos.
+\end{exercise}
+ \begin{exercise} Adicione um m\'{e}todo  
+ \begin{lstlisting}
+ def excl(x: Int)
+ \end{lstlisting}
 %% to return the given set without the element \code{x}. To accomplish this,
 %% it is useful to also implement a test method
-%% \begin{lstlisting}
-%% def isEmpty: Boolean
-%% \end{lstlisting}
+para retornar um dado conjunto sem o elemento \code{x}. Para isso, \'{e} interessante tamb\'{e}m 
+implementar um m\'{e}todo teste
+ \begin{lstlisting}
+ def isEmpty: Boolean
+ \end{lstlisting}
 %% for sets.
-%% \end{exercise}
+para conjuntos.
+ \end{exercise}
+%----------
 
+%----------
 %% \paragraph{Dynamic Binding}
-
+\paragraph{Liga\c{c}\~{a}o Din\^{a}mica}
 %% Object-oriented languages (Scala included) use \emph{dynamic dispatch}
 %% for method invocations.  That is, the code invoked for a method call
 %% depends on the run-time type of the object which contains the method.
@@ -1935,50 +2490,74 @@ class Rational(n: Int, d: Int) {
 %% \code{contains} is executed depends on the type of value of \code{s} at run-time.
 %% If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
 %% This behavior is a direct consequence of our substitution model of evaluation.
+Linguagens orientadas a objetos (inclusive Scala) usam \emph{despacho din\^{a}mico} para 
+invoca\c{c}\~{o}es de m\'{e}todos. Ou seja, o c\'{o}digo invocado por uma chamada de m\'{e}todo depende
+do tipo em tempo de execu\c{c}\~{a}o do objeto que cont\'{e}m o m\'{e}todo. Por exemplo, considere
+a express\~{a}o \code{s contains 7} onde \code{s} \'{e} um valor do tipo declarado \code{s: IntSet}. 
+Qual c\'{o}digo para \code{contains} \'{e} executado depende do tipo do valor de \code{s} em 
+tempo de execu\c{c}\~{a}o. Se for um valor \code{EmptySet}, \'{e} a implementa\c{c}\~{a}o de \code{contains} na 
+classe \code{EmptySet} que \'{e} executada, e analogamente para valores \code{NonEmptySet}.
+Este comportamento \'{e} consequ\^{e}ncia direta do nosso modelo de substitui\c{c}\~{a}o da avalia\c{c}\~{a}o.
+%----------
+
+%----------
 %% For instance,
-%% \begin{lstlisting}
-%%     (new EmptySet).contains(7) 
+Por exemplo, 
+\begin{lstlisting}
+    (new EmptySet).contains(7) 
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-%%     false
-%% \end{lstlisting}
-%% Or,
-%% \begin{lstlisting}
-%%     new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
+    false
+\end{lstlisting}
+Ou,
+\begin{lstlisting}
+    new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
 
-%%     if (1 < 7) new EmptySet contains 1
-%%     else if (1 > 7) new EmptySet contains 1
-%%     else true
+    if (1 < 7) new EmptySet contains 1
+    else if (1 > 7) new EmptySet contains 1
+    else true
 
-%% ->  $\rewriteby{by rewriting the conditional}$
+->  $\rewriteby{by rewriting the conditional}$
 
-%%     new EmptySet contains 1
+    new EmptySet contains 1
 
-%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-%%     false .
-%% \end{lstlisting}
+    false .
+\end{lstlisting}
+%----------
 
+%----------
 %% Dynamic method dispatch is analogous to higher-order function
 %% calls. In both cases, the identity of code to be executed is known
 %% only at run-time. This similarity is not just superficial. Indeed,
 %% Scala represents every function value as an object (see
 %% Section~\ref{sec:functions}).
+Envio din\^{a}mico de m\'{e}todos \'{e} an\'{a}logo a chamadas para fun\c{c}\~{o}es de alta ordem. 
+Em ambos os casos, a identidade do c\'{o}digo  a ser executado \'{e} conhecida somente
+em tempo de execu\c{c}\~{a}o. Essa similaridade n\~{a}o \'{e} apenas superficial. Na verdade, 
+Scala representa cada valor de fun\c{c}\~{a}o como um objeto (veja Se\c{c}\~{a}o~\ref{sec:functions}).
+%----------
 
-
+%----------
 %% \paragraph{Objects}
-
+\paragraph{Objetos}
 %% In the previous implementation of integer sets, empty sets were
 %% expressed with \code{new EmptySet}; so a new object was created every time
 %% an empty set value was required. We could have avoided unnecessary
 %% object creations by defining a value \code{empty} once and then using
 %% this value instead of every occurrence of \code{new EmptySet}. For example:
-%% \begin{lstlisting}
-%% val EmptySetVal = new EmptySet
-%% \end{lstlisting}
+Na implementa\c{c}\~{a}o pr\'{e}via de conjuntos de inteiros, conjuntos vazios eram expressos
+com \code{new EmptySet}; ent\~{a}o um novo objeto era criado a cada vez que um valor
+conjunto vazio era requerido. Podemos evitar cria\c{c}\~{o}es desnecess\'{a}rias de objetos 
+definindo um valor \code{empty} uma vez e ent\~{a}o, usando este valor ao inv\'{e}s de cada 
+ocorr\^{e}ncia de \code{new EmptySet}. Por exemplo:
+ \begin{lstlisting}
+ val EmptySetVal = new EmptySet
+ \end{lstlisting}
 %% One problem with this approach is that a value definition such as the
 %% one above is not a legal top-level definition in Scala; it has to be
 %% part of another class or object. Also, the definition of class
@@ -1986,12 +2565,21 @@ class Rational(n: Int, d: Int) {
 %% if we are only interested in a single object of this class? A more
 %% direct approach is to use an {\em object definition}. Here is
 %% a more streamlined alternative definition of the empty set:
-%% \begin{lstlisting}
-%% object EmptySet extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
-%% }
-%% \end{lstlisting}
+Um problema com esse tratamento \'{e} que uma defini\c{c}\~{a}o de valor tal como a anterior
+n\~{a}o \'{e} uma defini\c{c}\~{a}o top-level legal em Scala; tem de ser parte de uma outra classe 
+ou objeto. Ainda, a defini\c{c}\~{a}o de classe \code{EmptySet} agora parece um pouco exagerada -- 
+por que definir uma classe de objetos, se somente estamos interessados em um \'{u}nico objeto 
+dessa classe? Um tratamento mais direto \'{e} usar uma {\em defini\c{c}\~{a}o de objeto}. Aqui est\'{a} 
+uma alternativa mais adequada para a defini\c{c}\~{a}o de conjunto vazio:
+\begin{lstlisting}
+object EmptySet extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% The syntax of an object definition follows the syntax of a class
 %% definition; it has an optional extends clause as well as an optional
 %% body. As is the case for classes, the extends clause defines inherited
@@ -2000,28 +2588,53 @@ class Rational(n: Int, d: Int) {
 %% it is not possible to create other objects with the same structure
 %% using \code{new}.  Therefore, object definitions also lack constructor
 %% parameters, which might be present in class definitions.
+A sintaxe de uma defini\c{c}\~{a}o de objeto segue a sintaxe da defini\c{c}\~{a}o de uma 
+classe; tem uma cl\'{a}usula opcional extends, bem como um corpo opcional. 
+Assim como em classes, a cl\'{a}usula extends define membros herdados do objeto 
+considerando que o corpo define novos membros ou sobrecarga. Entretanto, uma 
+defini\c{c}\~{a}o de objeto denota um \'{u}nico objeto somente se n\~{a}o for poss\'{i}vel criar
+outros objetos com a mesma estrutura usando \code{new}. Ent\~{a}o, defini\c{c}\~{o}es de
+objeto tamb\'{e}m carecem de par\^{a}metros construtores, que podem estar presentes
+nas defini\c{c}\~{o}es das classes.
+%----------
 
+%----------
 %% Object definitions can appear anywhere in a Scala program; including
 %% at top-level.  Since there is no fixed execution order of top-level
 %% entities in Scala, one might ask exactly when the object defined by an
 %% object definition is created and initialized. The answer is that the
 %% object is created the first time one of its members is accessed. This
 %% strategy is called {\em lazy evaluation}.
+Defini\c{c}\~{o}es de objetos podem aparecer em qualquer lugar em um programa Scala;
+incluindo o top-level. Como n\~{a}o h\'{a} ordem fixa de execu\c{c}\~{a}o de entidades
+top-level em Scala, pode-se questionar quando exatamente o objeto definido 
+pela defini\c{c}\~{a}o de objeto \'{e} criado e inicializado. A resposta \'{e} que o objeto 
+\'{e} criado assim que seus membros s\~{a}o acessados. Esta estrat\'{e}gia \'{e} chamada 
+{\em avalia\c{c}\~{a}o pregui\c{c}osa}.
+%----------
 
+%----------
 %% \paragraph{Standard Classes}
-
+\paragraph{Classes Padr\~{a}o}
 %% \todo{include picture}
 
 %% Scala is a pure object-oriented language. This means that every value
 %% in Scala can be regarded as an object.  In fact, even primitive types
 %% such as \code{int} or \code{boolean} are not treated specially. They
 %% are defined as type aliases of Scala classes in module \code{Predef}:
-%% \begin{lstlisting}
-%% type boolean = scala.Boolean
-%% type int = scala.Int
-%% type long = scala.Long
-%% ...
-%% \end{lstlisting}
+Scala \'{e} uma linguagem orientada a objetos pura. Isso significa que cada valor 
+em Scala pode ser visto como um objeto. De fato, mesmo tipos primitivos tais como 
+\code{int} ou \code{boolean} n\~{a}o s\~{a}o tratados de modo especial. S\~{a}o definidos
+como apelidos de tipos de classes Scala no m\'{o}dulo \code{Predef}.  
+\begin{lstlisting}
+type boolean = scala.Boolean
+type int = scala.Int
+type long = scala.Long
+...
+\end{lstlisting}
+%----------
+
+%----------
 %% For efficiency, the compiler usually represents values of type
 %% \code{scala.Int} by 32 bit integers, values of type
 %% \code{scala.Boolean} by Java's booleans, etc.  But it converts these
@@ -2030,143 +2643,208 @@ class Rational(n: Int, d: Int) {
 %% parameter of type \code{AnyRef}.  Hence, the special representation of
 %% primitive values is just an optimization, it does not change the
 %% meaning of a program.
+Por efici\^{e}ncia, o compilador geralmente representa valor de tipo
+\code{scala.Int} por inteiros de 32 bits, valores de tipo \code{scala.Boolean}
+por boleanos Java etc. Mas converte essas representa\c{c}\~{o}es especializadas para 
+objetos quando requeridos, por exemplo, quando um valor primitivo \code{Int} \'{e} 
+passada a uma fun\c{c}\~{a}o com um par\^{a}metro de tipo \code{AnyRef}. Consequentemente, a
+representa\c{c}\~{a}o de valores primitivos \'{e} apenas uma otimiza\c{c}\~{a}o, n\~{a}o muda o significado
+de um programa.
+%----------
 
+%----------
 %% Here is a specification of class \code{Boolean}.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Boolean {
-%%   def && (x: => Boolean): Boolean
-%%   def || (x: => Boolean): Boolean
-%%   def !                 : Boolean
+Aqui est\'{a} a especifica\c{c}\~{a}o da classe \code{Boolean}.
+\begin{lstlisting}
+package scala
+abstract class Boolean {
+  def && (x: => Boolean): Boolean
+  def || (x: => Boolean): Boolean
+  def !                 : Boolean
 
-%%   def == (x: Boolean)   : Boolean
-%%   def != (x: Boolean)   : Boolean
-%%   def <  (x: Boolean)   : Boolean
-%%   def >  (x: Boolean)   : Boolean
-%%   def <= (x: Boolean)   : Boolean
-%%   def >= (x: Boolean)   : Boolean
-%% }
-%% \end{lstlisting}
+  def == (x: Boolean)   : Boolean
+  def != (x: Boolean)   : Boolean
+  def <  (x: Boolean)   : Boolean
+  def >  (x: Boolean)   : Boolean
+  def <= (x: Boolean)   : Boolean
+  def >= (x: Boolean)   : Boolean
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Booleans can be defined using only classes and objects, without
 %% reference to a built-in type of booleans or numbers. A possible
 %% implementation of class \code{Boolean} is given below.  This is not
 %% the actual implementation in the standard Scala library. For
 %% efficiency reasons the standard implementation uses built-in
 %% booleans.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Boolean {
-%%   def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
+Boleanos podem ser definidos usando somente classes e objetos, sem
+refer\^{e}ncia ao tipos b\'{a}sicos para boleanos ou n\'{u}meros. Uma poss\'{i}vel 
+implementa\c{c}\~{a}o da claro \code{Boolean} \'{e} dada abaixo. Esta n\~{a}o \'{e} 
+a implementa\c{c}\~{a}o atual na biblioteca padr\~{a}o Scala. Por raz\~{o}es de 
+efici\^{e}ncia a implementa\c{c}\~{a}o padr\~{a}o usa boleanos primitivos.
+\begin{lstlisting}
+package scala
+abstract class Boolean {
+  def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
 
-%%   def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
-%%   def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
-%%   def !                 : Boolean  =  ifThenElse(false, true)
+  def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
+  def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
+  def !                 : Boolean  =  ifThenElse(false, true)
 
-%%   def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
-%%   def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
-%%   def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
-%%   def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
-%%   def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
-%%   def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
-%% }
-%% case object True extends Boolean {
-%%   def ifThenElse(t: => Boolean, e: => Boolean) = t
-%% }
-%% case object False extends Boolean {
-%%   def ifThenElse(t: => Boolean, e: => Boolean) = e
-%% }
-%% \end{lstlisting}
+  def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
+  def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
+  def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
+  def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
+  def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
+  def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
+}
+case object True extends Boolean {
+  def ifThenElse(t: => Boolean, e: => Boolean) = t
+}
+case object False extends Boolean {
+  def ifThenElse(t: => Boolean, e: => Boolean) = e
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Here is a partial specification of class \code{Int}.
+Aqui est\'{a} uma especifica\c{c}\~{a}o parcial da classe \code{Int}.
+\begin{lstlisting}
+package scala
+abstract class Int extends AnyVal {
+  def toLong: Long
+  def toFloat: Float
+  def toDouble: Double
 
-%% \begin{lstlisting}
-%% package scala
-%% abstract class Int extends AnyVal {
-%%   def toLong: Long
-%%   def toFloat: Float
-%%   def toDouble: Double
+  def + (that: Double): Double
+  def + (that: Float): Float
+  def + (that: Long): Long
+  def + (that: Int): Int         // an\'{a}logo para -, *, /, %
 
-%%   def + (that: Double): Double
-%%   def + (that: Float): Float
-%%   def + (that: Long): Long
-%%   def + (that: Int): Int         // analogous for -, *, /, %
+  def << (cnt: Int): Int         // an\'{a}logo para  >>, >>>
 
-%%   def << (cnt: Int): Int         // analogous for >>, >>>
+  def & (that: Long): Long
+  def & (that: Int): Int         // an\'{a}logo para |, ^
 
-%%   def & (that: Long): Long
-%%   def & (that: Int): Int         // analogous for |, ^
+  def == (that: Double): Boolean
+  def == (that: Float): Boolean
+  def == (that: Long): Boolean   // an\'{a}logo para !=, <, >, <=, >=
+}
+\end{lstlisting}
+%----------
 
-%%   def == (that: Double): Boolean
-%%   def == (that: Float): Boolean
-%%   def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
-%% }
-%% \end{lstlisting}
-
+%----------
 %% Class \code{Int} can in principle also be implemented using just
 %% objects and classes, without reference to a built in type of
 %% integers. To see how, we consider a slightly simpler problem, namely
 %% how to implement a type \code{Nat} of natural (i.e. non-negative)
 %% numbers. Here is the definition of an abstract class \code{Nat}:
-%% \begin{lstlisting}
-%% abstract class Nat {
-%%   def isZero: Boolean
-%%   def predecessor: Nat
-%%   def successor: Nat
-%%   def + (that: Nat): Nat
-%%   def - (that: Nat): Nat
-%% }
-%% \end{lstlisting}
+A classe \code{Int} pode em princ\'{i}pio tamb\'{e}m ser implementada usando
+apenas objetos e classes, sem refer\^{e}ncia a um tipo constru\'{i}do para 
+inteiros. Para ver como, vamos considerar um problema um pouco mais 
+simples, especificamente como implementar um tipo \code{Nat} de 
+n\'{u}meros naturais, ou seja, inteiros n\~{a}o negativo. Aqui est\'{a} uma defini\c{c}\~{a}o 
+para uma classe abstrata \code{Nat}:
+\begin{lstlisting}
+abstract class Nat {
+  def isZero: Boolean
+  def predecessor: Nat
+  def successor: Nat
+  def + (that: Nat): Nat
+  def - (that: Nat): Nat
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% To implement the operations of class \code{Nat}, we define a sub-object
 %% \code{Zero} and a subclass \code{Succ} (for successor). Each number
 %% \code{N} is represented as \code{N} applications of the \code{Succ}
 %% constructor to \code{Zero}:
-%% \[
-%% \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
-%% \]
+Para implementar as opera\c{c}\~{o}es da classe \code{Nat}, n\'{o}s definimos um
+sub-objeto \code{Zero} e uma subclasse \code{Succ} (para sucessor). Cada 
+n\'{u}mero \code{N} \'{e} representado como \code{N} aplica\c{c}\~{o}es do construtor \code{Succ}
+at\'{e} zero: 
+ \[
+ \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
+ \]
 %% The implementation of the \code{Zero} object is straightforward:
-%% \begin{lstlisting}
-%% object Zero extends Nat {
-%%   def isZero: Boolean = true
-%%   def predecessor: Nat = error("negative number")
-%%   def successor: Nat = new Succ(Zero)
-%%   def + (that: Nat): Nat = that
-%%   def - (that: Nat): Nat = if (that.isZero) Zero
-%%                            else error("negative number")
-%% }
-%% \end{lstlisting}
+A implementa\c{c}\~{a}o do objeto \code{Zero} \'{e} direta:
+\begin{lstlisting}
+object Zero extends Nat {
+  def isZero: Boolean = true
+  def predecessor: Nat = error("negative number")
+  def successor: Nat = new Succ(Zero)
+  def + (that: Nat): Nat = that
+  def - (that: Nat): Nat = if (that.isZero) Zero
+                           else error("negative number")
+}
+\end{lstlisting}
+%----------
 
+%----------
 %% The implementation of the predecessor and subtraction functions on
 %% \code{Zero} throws an \code{Error} exception, which aborts the program
 %% with the given error message.
 
 %% Here is the implementation of the successor class:
-%% \begin{lstlisting}
-%% class Succ(x: Nat) extends Nat  {
-%%   def isZero: Boolean = false
-%%   def predecessor: Nat = x
-%%   def successor: Nat = new Succ(this)
-%%   def + (that: Nat): Nat = x + that.successor
-%%   def - (that: Nat): Nat = if (that.isZero) this 
-%%                            else x - that.predecessor
-%% }
-%% \end{lstlisting}
+
+A implementa\c{c}\~{a}o das fun\c{c}\~{o}es  predecessor e subtra\c{c}\~{a}o sobre \code{Zero} leva a 
+um \code{Erro}, que aborta o programa com uma mensagem de erro.
+
+Aqui est\'{a} uma implementa\c{c}\~{a}o da classe sucessor: 
+
+\begin{lstlisting}
+class Succ(x: Nat) extends Nat  {
+  def isZero: Boolean = false
+  def predecessor: Nat = x
+  def successor: Nat = new Succ(this)
+  def + (that: Nat): Nat = x + that.successor
+  def - (that: Nat): Nat = if (that.isZero) this 
+                           else x - that.predecessor
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Note the implementation of method \code{successor}. To create the
 %% successor of a number, we need to pass the object itself as an
 %% argument to the \code{Succ} constructor.  The object itself is
-%% referenced by the reserved name \code{this}.   
+%% referenced by the reserved name \code{this}.
+Observe a implementa\c{c}\~{a}o do m\'{e}todo \code{successor}. Para criar o 
+sucessor de um n\'{u}mero, precisamos passar o pr\'{o}prio objeto como um 
+argumento para o construtor \code{Succ}. O pr\'{o}prio objeto \'{e} referenciado
+por uma palavra reservada \code{this}.   
+%----------
 
+%----------
 %% The implementations of \code{+} and \code{-} each contain a recursive
 %% call with the constructor argument as receiver. The recursion will
 %% terminate once the receiver is the \code{Zero} object (which is
 %% guaranteed to happen eventually because of the way numbers are formed).
+As implementa\c{c}\~{o}es de \code{+} e \code{-}, cada uma cont\'{e}m uma chamada 
+recursiva com o argumento do costrutor como destinat\'{a}rio. A recurs\~{a}o 
+terminar\'{a} assim que o destinat\'{a}rio for o objeto \code{Zero} (o que \'{e} 
+garantido de acontecer eventualmente dado o modo com que os n\'{u}meros s\~{a}o formados).
+%----------
 
+%----------
 %% \begin{exercise} Write an implementation \code{Integer} of integer numbers
 %% The implementation should support all operations of class \code{Nat}
 %% while adding two methods
-%% \begin{lstlisting}
-%% def isPositive: Boolean
-%% def negate: Integer
-%% \end{lstlisting}
-%% The first method should return \code{true} if the number is positive. The second method should negate the number.
+\begin{exercise}
+Escreva uma implementa\c{c}\~{a}o \code{Integer} dos n\'{u}meros inteiros. A implementa\c{c}\~{a}o deve
+suportar todas as opera\c{c}\~{o}es da classe \code{Nat} e mais dois m\'{e}todos.
+
+\begin{lstlisting}
+def isPositive: Boolean
+def negate: Integer
+\end{lstlisting}
+%% The first method should return \code{true} if the number is positive.
+%% The second method should negate the number.
 %% Do not use any of Scala's standard numeric classes in your
 %% implementation. (Hint: There are two possible ways to implement
 %% \code{Integer}. One can either make use the existing implementation of
@@ -2175,100 +2853,142 @@ class Rational(n: Int, d: Int) {
 %% \code{Integer}, using the three subclasses \code{Zero} for 0, 
 %% \code{Succ} for positive numbers and \code{Pred} for negative numbers.)
 %% \end{exercise}
+O primeiro m\'{e}todo deve retornar \code{true} se o n\'{u}mero for positivo. O segundo 
+m\'{e}todo deve negativar o n\'{u}mero. N\~{a}o utilize qualquer classe num\'{e}rica padr\~{a}o Scala
+em sua implementa\c{c}\~{a}o. (Dica: H\'{a} duas formas para implementar \code{Integer}. Uma
+pode ou fazer uso da implementa\c{c}\~{a}o existente de \code{Nat}, representando um inteiro 
+como um n\'{u}mero natural e um sinal. Ou pode-se generalizar a implementa\c{c}\~{a}o dada de 
+\code{Nat} para \code{Integer}, usando as tr\^{e}s subclasses \code{Zero} para 0, 
+\code{Succ} para n\'{u}meros positivos e \code{Pred} para n\'{u}meros negativos. 
+\end{exercise}
+%----------
 
-
-
+%----------
 %% \subsection*{Language Elements Introduced In This Chapter}
-
-%% \textbf{Types:}
-%% \begin{lstlisting}
-%% Type         = ...  |  ident
-%% \end{lstlisting}
+\subsection*{Elementos da Linguagem Introduzidos Neste Cap\'{i}tulo}
+ \textbf{Types:}
+ \begin{lstlisting}
+ Type         = ...  |  ident
+ \end{lstlisting}
 
 %% Types can now be arbitrary identifiers which represent classes.
+Tipos podem agora ser identificadores arbitr\'{a}rios que representam classes.
 
 %% \textbf{Expressions:}
-%% \begin{lstlisting}
-%% Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
-%% \end{lstlisting}
+\textbf{Express\~{o}es:}
+ \begin{lstlisting}
+ Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
+ \end{lstlisting}
 
 %% An expression can now be an object creation, or
 %% a selection \code{E.m} of a member \code{m}
 %% from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
+Uma express\~{a}o pode agora ser uma cria\c{c}\~{a}o de objeto, ou uma sele\c{c}\~{a}o
+\code{E.m} de um membro \code{m} a partir de uma express\~{a}o valorada objeto \code{E},
+ou pode ser a palavra reservada \code{this}.
+%----------
 
+%----------
 %% \textbf{Definitions and Declarations:}
-%% \begin{lstlisting}
-%% Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
-%% ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
-%%                ['extends' Expr] [`{' {TemplateDef} `}']
-%% TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
-%% ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
-%% TemplateDef  = [Modifier] (Def | Dcl)
-%% ObjectDef    = [Modifier] Def
-%% Modifier     = 'private'  |  'override'
-%% Dcl          = FunDcl  |  ValDcl
-%% FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
-%% ValDcl       = 'val' ident ':' Type
-%% \end{lstlisting}
+ \textbf{Defini\c{c}\~{o}es e Declara\c{c}\~{o}es}
+\begin{lstlisting}
+Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
+ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
+               ['extends' Expr] [`{' {TemplateDef} `}']
+TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
+ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
+TemplateDef  = [Modifier] (Def | Dcl)
+ObjectDef    = [Modifier] Def
+Modifier     = 'private'  |  'override'
+Dcl          = FunDcl  |  ValDcl
+FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
+ValDcl       = 'val' ident ':' Type
+\end{lstlisting}
 
-%% A definition can now be a class, trait or object definition such as
-%% \begin{lstlisting}
-%% class C(params) extends B { defs }
-%% trait T extends B { defs }
-%% object O extends B { defs }
-%% \end{lstlisting}
+%%A definition can now be a class, trait or object definition such as
+Uma defini\c{c}\~{a}o pode agora ser uma defini\c{c}\~{a}o de classe, trait ou objeto, tal como  
+\begin{lstlisting}
+class C(params) extends B { defs }
+trait T extends B { defs }
+object O extends B { defs }
+\end{lstlisting}
 %% The definitions \code{defs} in a class, trait or object may be
 %% preceded by modifiers \code{private} or \code{override}.
+As defini\c{c}\~{o}es \code{defs} na classe, trait ou objeto podem ser 
+precedidas pelos modificadores \code{private} ou \code{override}.
 
 %% Abstract classes and traits may also contain declarations. These
 %% introduce {\em deferred} functions or values with their types, but do
 %% not give an implementation. Deferred members have to be implemented in
 %% subclasses before objects of an abstract class or trait can be created.
+Classes abstratas e traits podem tamb\'{e}m conter declara\c{c}\~{o}es. Isso introduz
+fun\c{c}\~{o}es {\em deferred} (postergadas) ou valores com seus tipos, mas n\~{a}o 
+d\~{a}o uma implementa\c{c}\~{a}o. Membros deferred devem ser implementados nas subclasses 
+antes que objetos de uma classe abstrata ou trait sejam criados. 
+%----------
 
+
+%----------
 %% \chapter{Case Classes and Pattern Matching}
-
+\chapter{Classes Case e Casamento de Padr\~{o}es}
 %% Say, we want to write an interpreter for arithmetic expressions.  To
 %% keep things simple initially, we restrict ourselves to just numbers
 %% and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
 %% \code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
-%% \begin{lstlisting}
-%% new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
-%% \end{lstlisting}
+Digamos, queremos escrever um interpretador para express\~{o}es aritm\'{e}ticas. Para 
+deixar as coisas simples inicialmente, vamos nos restringir somente a n\'{u}meros e opera\c{c}\~{o}es \code{+}.
+Tais express\~{o}es podem ser representadas como hierarquia de classes, 
+com uma classe abstrata base \code{Expr} como raiz, e duas subclasses \code{Number} e \code{Sum}.
+Ent\~{a}o, uma express\~{a}o \code{1 + (3 + 7)} \'{e} representada como 
+ \begin{lstlisting}
+ new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
+ \end{lstlisting}
+%----------
+
+%----------
 %% Now, an evaluator of an expression like this needs to know of what
 %% form it is (either \code{Sum} or \code{Number}) and also needs to
 %% access the components of the expression.  The following
 %% implementation provides all necessary methods.
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def isNumber: Boolean
-%%   def isSum: Boolean
-%%   def numValue: Int
-%%   def leftOp: Expr
-%%   def rightOp: Expr
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def isNumber: Boolean = true
-%%   def isSum: Boolean = false
-%%   def numValue: Int = n
-%%   def leftOp: Expr = error("Number.leftOp")
-%%   def rightOp: Expr = error("Number.rightOp")
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def isNumber: Boolean = false
-%%   def isSum: Boolean = true
-%%   def numValue: Int = error("Sum.numValue")
-%%   def leftOp: Expr = e1
-%%   def rightOp: Expr = e2
-%% }
-%% \end{lstlisting}
-%% With these classification and access methods, writing an evaluator function is simple:
-%% \begin{lstlisting}
-%% def eval(e: Expr): Int = {
-%%   if (e.isNumber) e.numValue
-%%   else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
-%%   else error("unrecognized expression kind")
-%% }
-%% \end{lstlisting}
+Agora, um avaliador de uma express\~{a}o como esta precisa saber de 
+qual forma ela \'{e} (ou \code{Sum} ou \code{Number}) e tamb\'{e}m precisa
+acessar os componentes da express\~{a}o. A implementa\c{c}\~{a}o a seguir prov\^{e}
+todos os m\'{e}todos necess\'{a}rios.
+\begin{lstlisting}
+abstract class Expr {
+  def isNumber: Boolean
+  def isSum: Boolean
+  def numValue: Int
+  def leftOp: Expr
+  def rightOp: Expr
+}
+class Number(n: Int) extends Expr {
+  def isNumber: Boolean = true
+  def isSum: Boolean = false
+  def numValue: Int = n
+  def leftOp: Expr = error("Number.leftOp")
+  def rightOp: Expr = error("Number.rightOp")
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def isNumber: Boolean = false
+  def isSum: Boolean = true
+  def numValue: Int = error("Sum.numValue")
+  def leftOp: Expr = e1
+  def rightOp: Expr = e2
+}
+\end{lstlisting}
+%----------
+
+%----------
+%%With these classification and access methods, writing an evaluator function is simple:
+Com esta classifica\c{c}\~{a}o e m\'{e}todos de acesso, escrever uma fun\c{c}\~{a}o avaliador \'{e} simples:
+\begin{lstlisting}
+def eval(e: Expr): Int = {
+  if (e.isNumber) e.numValue
+  else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
+  else error("unrecognized expression kind")
+}
+\end{lstlisting}
 %% However, defining all these methods in classes \code{Sum} and
 %% \code{Number} is rather tedious. Furthermore, the problem becomes worse 
 %% when we want to add new forms of expressions. For instance, consider
@@ -2277,7 +2997,18 @@ class Rational(n: Int, d: Int) {
 %% new abstract method \code{isProduct} in class \code{Expr} and
 %% implement that method in subclasses \code{Number}, \code{Sum}, and
 %% \code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
+Entretanto, definir todos esses m\'{e}todos dentro das classes \code{Sum} e \code{Number}
+\'{e} um tanto quanto tedioso. Al\'{e}m do mais, o problema fica ainda pior se desejarmos 
+adicionar novas formas de express\~{o}es. Por exemplo, considere adicionar uma nova 
+forma de express\~{a}o \code{Prod} para produtos. N\~{a}o apenas teremos de implementar uma nova classe 
+\code{Prod}, com todos os m\'{e}todos de acesso e classifica\c{c}\~{a}o pr\'{e}vios; tamb\'{e}m teremos de 
+introduzir um novo m\'{e}todo abstrato \code{isProduct} dentro da classe \code{Expr} e 
+implementar aquele m\'{e}todo na subclasse \code{Number}, \code{Sum}, e \code{Prod}.
+Ter de  modificar c\'{o}digo existente quando um sistema cresce \'{e} sempre problem\'{a}tico, pois
+introduz problemas de vers\~{a}o e manuten\c{c}\~{a}o.  
+%----------
 
+%----------
 %% The promise of object-oriented programming is that such modifications
 %% should be unnecessary, because they can be avoided by re-using
 %% existing, unmodified code through inheritance. Indeed, a more
@@ -2287,23 +3018,36 @@ class Rational(n: Int, d: Int) {
 %% outside the expression class hierarchy, as we have done
 %% before. Because \code{eval} is now a member of all expression nodes,
 %% all classification and access methods become superfluous, and the implementation is simplified considerably:
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def eval: Int
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def eval: Int = n
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval + e2.eval
-%% }
-%% \end{lstlisting}
-%% Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
-%% \begin{lstlisting}
-%% class Prod(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval * e2.eval
-%% }
-%% \end{lstlisting}
+A promessa da programa\c{c}\~{a}o orientada a objetos \'{e} que tais modifica\c{c}\~{o}es 
+s\~{a}o desnecess\'{a}rias, dado que podem ser evitadas pela reutiliza\c{c}\~{a}o de c\'{o}digo 
+existente e n\~{a}o modificado, atrav\'{e}s da heran\c{c}a. De fato, uma decomposi\c{c}\~{a}o 
+mais orientada a objetos para nosso problema resolve a quest\~{a}o. A id\'{e}ia \'{e} tornar
+a opera\c{c}\~{a}o de alto n\'{i}vel \code{eval} um m\'{e}todo para cada classe express\~{a}o, ao 
+inv\'{e}s de implement\'{a}-lo como uma fun\c{c}\~{a}o fora da hierarquia de classes express\~{o}es, como 
+fizemos anteriormente. Como \code{eval} \'{e} agora um membro de todos os n\'{o}s de express\~{a}o, 
+quaisquer m\'{e}todos de classifica\c{c}\~{a}o e acesso tornam-se sup\'{e}rfluos, e a implementa\c{c}\~{a}o 
+\'{e} simplificada consideravelmente:  
+\begin{lstlisting}
+abstract class Expr {
+  def eval: Int
+}
+class Number(n: Int) extends Expr {
+  def eval: Int = n
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval + e2.eval
+}
+\end{lstlisting}
+%----------
+
+%----------
+%%Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
+Al\'{e}m disso, adicionar uma nova classe \code{Prod} n\~{a}o leva a qualquer mudan\c{c}a ao c\'{o}digo existente:
+\begin{lstlisting}
+class Prod(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval * e2.eval
+}
+\end{lstlisting}
 
 %% The conclusion we can draw from this example is that object-oriented
 %% decomposition is the technique of choice for constructing systems that
@@ -2311,47 +3055,66 @@ class Rational(n: Int, d: Int) {
 %% possible way we might want to extend the expression example. We might
 %% want to add new {\em operations} on expressions.  For instance, we might
 %% want to add an operation that pretty-prints an expression tree to standard output.
+A conclus\~{a}o que tiramos deste exemplo \'{e} que a decomposi\c{c}\~{a}o orientada a objetos
+\'{e} a t\'{e}cnica de escolha para a constru\c{c}\~{a}o de sistemas que devem ser estens\'{i}veis
+com novos tipos de dados. Mas h\'{a} tamb\'{e}m um outro poss\'{i}vel modo para estender a 
+express\~{a}o exemplo. Podemos querer adicionar novas {\em opera\c{c}\~{o}es} sobre express\~{o}es.
+Por exemplo, podemos querer adicionar uma opera\c{c}\~{a}o que imprime uma \'{a}rvore-express\~{a}o
+para a sa\'{i}da padr\~{a}o.  
+%----------
 
+%----------
 %% If we have defined all classification and access methods, such an
 %% operation can easily be written as an external function. Here is an
 %% example:
-%% \begin{lstlisting}
-%% def print(e: Expr) {
-%%   if (e.isNumber) Console.print(e.numValue)
-%%   else if (e.isSum) {
-%%     Console.print("(")
-%%     print(e.leftOp)
-%%     Console.print("+")
-%%     print(e.rightOp)
-%%     Console.print(")")
-%%   } else error("unrecognized expression kind")
-%% }
-%% \end{lstlisting}
+Se definimos todos os m\'{e}todos de classifica\c{c}\~{a}o e acesso, tal opera\c{c}\~{a}o pode ser 
+facilmente escrita como uma fun\c{c}\~{a}o externa. Aqui est\'{a} um exemplo: 
+\begin{lstlisting}
+def print(e: Expr) {
+  if (e.isNumber) Console.print(e.numValue)
+  else if (e.isSum) {
+    Console.print("(")
+    print(e.leftOp)
+    Console.print("+")
+    print(e.rightOp)
+    Console.print(")")
+  } else error("unrecognized expression kind")
+}
+\end{lstlisting}
 %% However, if we had opted for an object-oriented decomposition of
 %% expressions, we would need to add a new \code{print} procedure
 %% to each class:
-%% \begin{lstlisting}
-%% abstract class Expr {
-%%   def eval: Int
-%%   def print
-%% }
-%% class Number(n: Int) extends Expr {
-%%   def eval: Int = n
-%%   def print { Console.print(n) }
-%% }
-%% class Sum(e1: Expr, e2: Expr) extends Expr {
-%%   def eval: Int = e1.eval + e2.eval
-%%   def print {
-%%     Console.print("(")
-%%     print(e1)
-%%     Console.print("+")
-%%     print(e2)
-%%     Console.print(")")
-%%   }
-%% }
-%% \end{lstlisting}
+Entretanto, se optamos por uma decomposi\c{c}\~{a}o orientada a objetos das 
+express\~{o}es, precisaremos adicionar um novo procedimento \code{print} 
+para cada classe: 
+\begin{lstlisting}
+abstract class Expr {
+  def eval: Int
+  def print
+}
+class Number(n: Int) extends Expr {
+  def eval: Int = n
+  def print { Console.print(n) }
+}
+class Sum(e1: Expr, e2: Expr) extends Expr {
+  def eval: Int = e1.eval + e2.eval
+  def print {
+    Console.print("(")
+    print(e1)
+    Console.print("+")
+    print(e2)
+    Console.print(")")
+  }
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
+Consequentemente, decomposi\c{c}\~{a}o orientada a objetos cl\'{a}ssica requer modifica\c{c}\~{a}o 
+de todas as classes existentes quando um sistema for estendido com novas
+opera\c{c}\~{o}es.
 
 %% As yet another way we might want to extend the interpreter, consider
 %% expression simplification. For instance, we might want to write a
@@ -2364,36 +3127,72 @@ class Rational(n: Int, d: Int) {
 %% seems to bring us back to square one, with all the problems of
 %% verbosity and extensibility.
 
+Ainda como uma outra forma, podemos querer estender o interpretador. 
+Considere a simplifica\c{c}\~{a}o de express\~{o}es. Por exemplo, podemos querer criar 
+uma fun\c{c}\~{a}o que reescreve express\~{o}es da forma \code{a * b + a * c} para 
+\code{a * (b + c)}. Esta opera\c{c}\~{a}o requer inspe\c{c}\~{a}o de mais de um n\'{o} para a 
+\'{a}rvore de express\~{o}es ao mesmo tempo. Consequentemente, n\~{a}o pode ser implementada
+por um m\'{e}todo dentro de cada tipo de express\~{a}o, a n\~{a}o ser que tal m\'{e}todo tamb\'{e}m 
+possa inspecionar outros n\'{o}s. Portanto somos for\c{c}ados a ter m\'{e}todos de acesso e 
+classifica\c{c}\~{a}o neste caso. Isto parece nos levar para a casa inicial, com todos os 
+problemas de estensibilidade e expressividade.
+%----------
+
+%----------
 %% Taking a closer look, one observes that the only purpose of the
 %% classification and access functions is to {\em reverse} the data
 %% construction process.  They let us determine, first, which sub-class
 %% of an abstract base class was used and, second, what were the
 %% constructor arguments. Since this situation is quite common, Scala has
 %% a way to automate it with case classes. 
+Olhando mais de perto, observa-se que o \'{u}nico prop\'{o}sito das fun\c{c}\~{o}es de acesso
+e classifica\c{c}\~{a}o  \'{e} {\em reverter} o processo de constru\c{c}\~{a}o de dados. Elas nos 
+permitem determinar, primeiro, qual subclasse de uma classe base abstrata foi 
+usada e, segundo, quais foram os argumentos construtores. Como essa situa\c{c}\~{a}o \'{e} 
+bem comum, Scala tem um modo de automatiz\'{a}-lo para classes case.
+%----------
 
+%----------
 %% \section{Case Classes and Case Objects}
+\section{Classes Case e Objetos Case}
 
 %% {\em Case classes} and {\em case objects} are defined like a normal
 %% classes or objects, except that the definition is prefixed with the modifier
 %% \code{case}.  For instance, the definitions
-%% \begin{lstlisting}
-%% abstract class Expr
-%% case class Number(n: Int) extends Expr
-%% case class Sum(e1: Expr, e2: Expr) extends Expr
-%% \end{lstlisting}
+{\em Classes Case} e {\em objetos case} s\~{a}o definidos como classes e objetos 
+normais, exceto que a defini\c{c}\~{a}o \'{e} prefixada com um modificador \code{case}. 
+Por exemplo, as defini\c{c}\~{o}es:
+
+\begin{lstlisting}
+abstract class Expr
+case class Number(n: Int) extends Expr
+case class Sum(e1: Expr, e2: Expr) extends Expr
+\end{lstlisting}
 %% introduce \code{Number} and \code{Sum} as case classes.
 %% The \code{case} modifier in front of a class or object 
 %% definition has the following effects.
 %% \begin{enumerate}
-%% \item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
-%% \begin{lstlisting}
-%% def Number(n: Int) = new Number(n)
-%% def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
-%% \end{lstlisting}
-%% would be added. Hence, one can now construct expression trees a bit more concisely, as in
-%% \begin{lstlisting}
-%% Sum(Sum(Number(1), Number(2)), Number(3))
-%% \end{lstlisting} 
+%% \item Case classes implicitly come with a constructor function, with the same name as the class. 
+%%In our example, the two functions
+introduzem \code{Number} e \code{Sum} como classes case.
+O modificador \code{case} em frente a uma defini\c{c}\~{a}o de classe ou objeto tem 
+os seguintes efeitos.
+\begin{enumerate}
+\item Classes case implicitamente vem com uma fun\c{c}\~{a}o construtora, com o mesmo nome da classe.
+No nosso exemplo, as duas fun\c{c}\~{o}es
+\begin{lstlisting}
+def Number(n: Int) = new Number(n)
+def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
+\end{lstlisting}
+%----------
+
+%----------
+%%would be added. Hence, one can now construct expression trees a bit more concisely, as in
+ser\~{a}o adicionadas. Consequentemente, pode-se agora construir \'{a}rvores-express\~{o}es de modo um 
+pouco mais conciso, como em
+\begin{lstlisting}
+Sum(Sum(Number(1), Number(2)), Number(3))
+\end{lstlisting} 
 %% \item Case classes and case objects 
 %% implicitly come with implementations of methods
 %% \code{toString}, \code{equals} and \code{hashCode}, which override the
@@ -2401,9 +3200,18 @@ class Rational(n: Int, d: Int) {
 %% of these methods takes in each case the structure of a member of a
 %% case class into account. The \code{toString} method represents an
 %% expression tree the way it was constructed. So,
-%% \begin{lstlisting}
-%% Sum(Sum(Number(1), Number(2)), Number(3))
-%% \end{lstlisting} 
+\item Classes case e objetos case implicitamente vem com implementa\c{c}\~{o}es dos m\'{e}todos 
+\code{toString}, \code{equals} e \code{hashCode}, que sobrescrevem os
+m\'{e}todos com o mesmo nome na classe \code{AnyRef}. A implementa\c{c}\~{a}o desses 
+m\'{e}todos leva em considera\c{c}\~{a}o em cada caso a estrutura de um membro de uma classe 
+case. O m\'{e}todo \code{toString} representa uma \'{a}rvore express\~{a}o do modo como foi
+constru\'{i}da. Ent\~{a}o,  
+\begin{lstlisting}
+Sum(Sum(Number(1), Number(2)), Number(3))
+\end{lstlisting} 
+%----------
+
+%----------
 %% would be converted to exactly that string, whereas the default
 %% implementation in class \code{AnyRef} would return a string consisting
 %% of the outermost constructor name \code{Sum} and a number.  The
@@ -2412,9 +3220,19 @@ class Rational(n: Int, d: Int) {
 %% arguments which are themselves pairwise equal. This also affects the
 %% implementation of \code{==} and \code{!=}, which are implemented in
 %% terms of \code{equals} in Scala. So,
-%% \begin{lstlisting}
-%% Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
-%% \end{lstlisting}
+ser\'{a} convertida exatamente naquela cadeia de caracteres, onde a implementa\c{c}\~{a}o 
+default dentro da classe \code{AnyRef} retornar\'{a} uma cadeia de caracteres 
+consistindo construtor \code{Sum} mais externo e um n\'{u}mero. O m\'{e}todo 
+\code{equals} trata dois membros case da classe case do mesmo modo, caso
+eles tenham sido constru\'{i}dos com o mesmo construtor e com argumentos que 
+s\~{a}o par a par iguais. Isso tamb\'{e}m afeta a implementa\c{c}\~{a}o de \code{==} e 
+\code{!=}, que s\~{a}o implementados em termos de \code{equals} em Scala. Ent\~{a}o,  
+ \begin{lstlisting}
+ Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
+ \end{lstlisting}
+%----------
+
+%----------
 %% will yield \code{true}. If \code{Sum} or \code{Number} were not case
 %% classes, the same expression would be \code{false}, since the standard
 %% implementation of \code{equals} in class \code{AnyRef} always treats
@@ -2427,13 +3245,27 @@ class Rational(n: Int, d: Int) {
 %% Case classes implicitly come with nullary accessor methods which
 %% retrieve the constructor arguments.
 %% In our example, \code{Number} would obtain an accessor method
-%% \begin{lstlisting}
-%% def n: Int
-%% \end{lstlisting}
+dar\'{a} \code{true}. Se \code{Sum} ou \code{Number} n\~{a}o fossem classes case, a 
+mesma express\~{a}o seria \code{false}, pois a implementa\c{c}\~{a}o padr\~{a}o de \code{equals} na 
+classe \code{AnyRef} sempre trata objetos criados por diferentes chamadas de construtores 
+como sendo diferentes. O m\'{e}todo \code{hashCode} segue a mesmo princ\'{i}pio dos 
+outros dois m\'{e}todos. Computa um c\'{o}digo hash a partir do nome do construtor da classe case
+e os c\'{o}digos hash dos argumentos do construtor, ao inv\'{e}s de o fazer a partir do endere\c{c}o 
+do objeto, que \'{e} o que a implementa\c{c}\~{a}o default de \code{hashCode} faz.
+\item
+Classes case implicitamente vem com m\'{e}todos de acesso nulos que recuperam os argumentos 
+do construtor. Em nosso exemplo, \code{Number} obteria um m\'{e}todo de acesso  
+ \begin{lstlisting}
+ def n: Int
+ \end{lstlisting}
+%----------
+
+%----------
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
-%% \begin{lstlisting}
-%% def e1: Expr, e2: Expr
-%% \end{lstlisting}
+que retorna o par\^{a}metro \code{n} do construtor, onde \code{Sum} obter\'{a} dois m\'{e}todos de acesso
+ \begin{lstlisting}
+ def e1: Expr, e2: Expr
+ \end{lstlisting}
 %% Hence, if for a value \code{s} of type \code{Sum}, say, one can now
 %% write \code{s.e1}, to access the left operand. However, for a value
 %% \code{e} of type \code{Expr}, the term \code{e.e1} would be illegal
@@ -2445,9 +3277,24 @@ class Rational(n: Int, d: Int) {
 %% \item 
 %% Case classes allow the constructions of {\em patterns} which refer to
 %% the case class constructor.
-%% \end{enumerate}
 
+Consequentemente, para um valor \code{s} de tipo \code{Sum}, digamos, 
+podemos escrever \code{s.e1} para acessar o operando esquerdo. Entretanto, 
+para um valor \code{e} de tipo \code{Expr}, o termo \code{e.e1} ser\'{a} ilegal,
+pois \code{e1} \'{e} definido em \code{Sum}; n\~{a}o \'{e} um membro da classe base
+\code{Expr}.
+Ent\~{a}o, como determinar o construtor e os argumentos do construtor de acesso
+para valores cujo tipo est\'{a}tico \'{e} a classe base \code{Expr}? Isso \'{e} resolvido
+pela quarta e \'{u}ltima particularidade das classes case.
+\item
+Classes case permitem constru\c{c}\~{o}es de {\em padr\~{o}es} que se referem ao construtor 
+da classe case.
+ \end{enumerate}
+%----------
+
+%----------
 %% \section{Pattern Matching}
+\section{Casamento de Padr\~{o}es}
 
 %% Pattern matching is a generalization of C or Java's \code{switch}
 %% statement to class hierarchies. Instead of a \code{switch} statement,
@@ -2456,12 +3303,22 @@ class Rational(n: Int, d: Int) {
 %% The \code{match} method takes as argument a number of cases. 
 %% For instance, here is an implementation of \code{eval} using 
 %% pattern matching.
-%% \begin{lstlisting}
-%% def eval(e: Expr): Int = e match {
-%%   case Number(n) => n 
-%%   case Sum(l, r) => eval(l) + eval(r) 
-%% }
-%% \end{lstlisting}
+O casamento de padr\~{o}es \'{e} uma generaliza\c{c}\~{a}o do comando \code{switch} do C ou
+Java para hierarquias de classes. Ao inv\'{e}s de um comando \code{switch}, h\'{a} um 
+m\'{e}todo padr\~{a}o \code{match}, que \'{e} definido na classe ra\'{i}z Scala \code{Any}, e 
+portanto est\'{a} dispon\'{i}vel para todos os objetos. O m\'{e}todo \code{match} recebe como 
+argumento um n\'{u}mero de cases. Por exemplo, aqui est\'{a} uma implementa\c{c}\~{a}o de \code{eval}
+usando casamento de padr\~{o}es.
+
+\begin{lstlisting}
+def eval(e: Expr): Int = e match {
+  case Number(n) => n 
+  case Sum(l, r) => eval(l) + eval(r) 
+}
+\end{lstlisting}
+%----------
+
+%----------
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -2472,7 +3329,16 @@ class Rational(n: Int, d: Int) {
 %% \code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
 %% \code{l} and \code{r} 
 %% to \code{v}$_1$ and \code{v}$_2$, respectively. 
+Neste exemplo, h\'{a} dois cases. Cada case associa um padr\~{a}o a uma express\~{a}o. 
+Padr\~{o}es s\~{a}o casados contra o valor do seletor \code{e}. O primeiro padr\~{a}o do
+nosso exemplo, \code{Number(n)}, casa todos os valores da forma \code{Number(v)},
+onde \code{v} \'{e} um valor arbitr\'{a}rio. Naquele caso, a {\em vari\'{a}vel padr\~{a}o} \code{n}
+\'{e} ligada ao valor \code{v}. Similarmente, o padr\~{a}o \code{Sum(l, r)} casa com todos 
+os valores do seletor da forma \code{Sum(v}$_1$\code{, v}$_2$\code{)} e liga as 
+vari\'{a}veis padr\~{a}o \code{l} e \code{r} a \code{v}$_1$ e \code{v}$_2$, respectivamente. 
+%----------
 
+%----------
 %% In general, patterns are built from
 %% \begin{itemize}
 %% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
@@ -2482,4177 +3348,4221 @@ class Rational(n: Int, d: Int) {
 %% \item literals, e.g. \code{1}, \code{true}, "abc", 
 %% \item constant identifiers, e.g. \code{MAXINT}, \code{EmptySet}.
 %% \end{itemize}
+
+Em geral, padr\~{o}es s\~{a}o constru\'{i}dos a partir
+
+\begin{itemize}
+\item Construtores de classes case, por exemplo \code{Number}, \code{Sum}, cujos
+argumentos s\~{a}o, novamente, padr\~{o}es, 
+\item vari\'{a}veis padr\~{a}o, por exemplo \code{n}, \code{e1}, \code{e2}, 
+\item o padr\~{a}o ``coringa'' \code{_},
+\item literais, tal como \code{1}, \code{true},  "abc", 
+\item identificadores constantes, tais como \code{MAXINT}, \code{EmptySet}.  
+\end{itemize}
 %% Pattern variables always start with a lower-case letter, so that they
 %% can be distinguished from constant identifiers, which start with an
 %% upper case letter.  Each variable name may occur only once in a
 %% pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
 %% since the pattern variable \code{x} occurs twice in it.
 
+Vari\'{a}veis padr\~{a}o sempre iniciam com uma letra min\'{u}scula, para que possamos
+distingu\'{i}-las de identificadores constantes, que iniciam com uma letra 
+mai\'{u}scula. Cada nome de vari\'{a}vel pode ocorrer somente uma vez em um padr\~{a}o. 
+Por exemplo, \code{Sum(x, x)} seria ilegal como padr\~{a}o, pois a vari\'{a}vel padr\~{a}o 
+\code{x} ocorre duas vezes dentro dele.  
+
+%----------
+
+%----------
 %% \paragraph{Meaning of Pattern Matching}
 %% A pattern matching expression 
-%% \begin{lstlisting}
-%% e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
-%% \end{lstlisting}
+\paragraph{Significado do Casamento de Padr\~{o}es}
+Uma express\~{a}o de casamento de padr\~{o}es
+
+\begin{lstlisting}
+e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
+\end{lstlisting}
 %% matches the patterns $p_1 \commadots p_n$ in the order they
 %% are written against the selector value \code{e}.
-%% \begin{itemize}
-%% \item
-%% A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
-%% are of type \code{C} (or a subtype thereof) and that have been constructed with 
-%% \code{C}-arguments matching patterns $p_1 \commadots p_n$.
-%% \item 
-%% A variable pattern \code{x} matches any value and binds the variable
-%% name to that value.  
-%% \item 
-%% The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
-%% \item A constant pattern \code{C} matches a value which is
-%% equal (in terms of \code{==}) to \code{C}.
-%% \end{itemize}
-%% The pattern matching expression rewrites to the right-hand-side of the
-%% first case whose pattern matches the selector value. References to
-%% pattern variables are replaced by corresponding constructor arguments.
-%% If none of the patterns matches, the pattern matching expression is
-%% aborted with a \code{MatchError} exception.
-
-%% \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
-%% \begin{lstlisting}
-%%      eval(Sum(Number(1), Number(2)))
-
-%% ->   $\mbox{\tab\tab\rm(by rewriting the application)}$
-
-%%      Sum(Number(1), Number(2)) match {
-%%          case Number(n) => n
-%%          case Sum(e1, e2) => eval(e1) + eval(e2)
-%%      }
-
-%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
-
-%%      eval(Number(1)) + eval(Number(2))
-
-%% ->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
-
-%%      Number(1) match {
-%%          case Number(n) => n
-%%          case Sum(e1, e2) => eval(e1) + eval(e2)
-%%      } + eval(Number(2))
-
-%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
-
-%%      1 + eval(Number(2))
-
-%% ->$^*$ 1 + 2 -> 3
-%% \end{lstlisting}
-
-%% \paragraph{Pattern Matching and Methods}
-%% In the previous example, we have used pattern
-%% matching in a function which was defined outside the class hierarchy
-%% over which it matches.  Of course, it is also possible to define a
-%% pattern matching function in that class hierarchy itself. For
-%% instance, we could have defined
-%% \code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
-%% \begin{lstlisting}
-%% abstract class Expr { 
-%%   def eval: Int = this match {
-%%     case Number(n) => n
-%%     case Sum(e1, e2) => e1.eval + e2.eval 
-%%   } 
-%% }
-%% \end{lstlisting}
-
-%% \begin{exercise} Consider the following definitions representing trees
-%% of integers.  These definitions can be seen as an alternative
-%% representation of \code{IntSet}:
-%% \begin{lstlisting}
-%% abstract class IntTree
-%% case object EmptyTree extends IntTree
-%% case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
-%% \end{lstlisting}
-%% Complete the following implementations of function \code{contains} and \code{insert} for 
-%% \code{IntTree}'s.
-%% \begin{lstlisting}
-%% def contains(t: IntTree, v: Int): Boolean = t match { ...
-%%   ...
-%% }
-%% def insert(t: IntTree, v: Int): IntTree = t match { ...
-%%   ...
-%% }
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% \paragraph{Pattern Matching Anonymous Functions}
-
-%% So far, case-expressions always appeared in conjunction with a
-%% \verb@match@ operation. But it is also possible to use
-%% case-expressions by themselves. A block of case-expressions such as
-%% \begin{lstlisting}
-%% { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
-%% \end{lstlisting}
-%% is seen by itself as a function which matches its arguments
-%% against the patterns $P_1 \commadots P_n$, and produces the result of
-%% one of $E_1 \commadots E_n$. (If no pattern matches, the function
-%% would throw a \code{MatchError} exception instead).
-%% In other words, the expression above is seen as a shorthand for the anonymous function
-%% \begin{lstlisting}
-%% (x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
-%% \end{lstlisting}
-%% where \code{x} is a fresh variable which is not used 
-%% otherwise in the expression.
-
-%% \chapter{Generic Types and Methods}
-
-%% Classes in Scala can have type parameters. We demonstrate the use of
-%% type parameters with functional stacks as an example. Say, we want to
-%% write a data type of stacks of integers, with methods \code{push},
-%% \code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
-%% following class hierarchy:
-%% \begin{lstlisting}
-%% abstract class IntStack {
-%%   def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
-%%   def isEmpty: Boolean
-%%   def top: Int
-%%   def pop: IntStack
-%% }
-%% class IntEmptyStack extends IntStack {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
-%% Of course, it would also make sense to define an abstraction for a
-%% stack of Strings. To do that, one could take the existing abstraction
-%% for \code{IntStack}, rename it to \code{StringStack} and at the same
-%% time rename all occurrences of type \code{Int} to \code{String}.
-
-%% A better way, which does not entail code duplication, is to
-%% parameterize the stack definitions with the element type.
-%% Parameterization lets us generalize from a specific instance of a
-%% problem to a more general one. So far, we have used parameterization
-%% only for values, but it is available also for types. To arrive at a
-%% {\em generic} version of \code{Stack}, we equip it with a type
-%% parameter.
-%% \begin{lstlisting}
-%% abstract class Stack[A] {
-%%   def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
-%%   def isEmpty: Boolean
-%%   def top: A
-%%   def pop: Stack[A]
-%% }
-%% class EmptyStack[A] extends Stack[A] {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
-%% In the definitions above, `\code{A}' is a {\em type parameter} of
-%% class \code{Stack} and its subclasses.  Type parameters are arbitrary
-%% names; they are enclosed in brackets instead of parentheses, so that
-%% they can be easily distinguished from value parameters.  Here is an
-%% example how the generic classes are used:
-%% \begin{lstlisting}
-%% val x = new EmptyStack[Int]
-%% val y = x.push(1).push(2)
-%% println(y.pop.top)
-%% \end{lstlisting}
-%% The first line creates a new empty stack of \code{Int}'s. Note the
-%% actual type argument \code{[Int]} which replaces the formal type
-%% parameter \code{A}.
-
-%% It is also possible to parameterize methods with types. As an example,
-%% here is a generic method which determines whether one stack is a
-%% prefix of another.
-%% \begin{lstlisting}
-%% def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
-%%   p.isEmpty ||
-%%   p.top == s.top && isPrefix[A](p.pop, s.pop)
-%% }
-%% \end{lstlisting}  
-%% The method parameters are called {\em polymorphic}.  Generic methods are
-%% also called {\em polymorphic}.  The term comes from the Greek, where it
-%% means ``having many forms''.  To apply a polymorphic method such as
-%% \code{isPrefix}, we pass type parameters as well as value parameters
-%% to it. For instance,
-%% \begin{lstlisting}
-%% val s1 = new EmptyStack[String].push("abc")
-%% val s2 = new EmptyStack[String].push("abx").push(s1.top)
-%% println(isPrefix[String](s1, s2))
-%% \end{lstlisting}
-
-%% \paragraph{Local Type Inference}
-%% Passing type parameters such as \code{[Int]} or \code{[String]} all
-%% the time can become tedious in applications where generic functions
-%% are used a lot. Quite often, the information in a type parameter is
-%% redundant, because the correct parameter type can also be determined
-%% by inspecting the function's value parameters or expected result type.
-%% Taking the expression \code{isPrefix[String](s1, s2)} as an
-%% example, we know that its value parameters are both of type
-%% \code{Stack[String]}, so we can deduce that the type parameter must
-%% be \code{String}. Scala has a fairly powerful type inferencer which
-%% allows one to omit type parameters to polymorphic functions and
-%% constructors in situations like these.  In the example above, one
-%% could have written \code{isPrefix(s1, s2)} and the missing type argument
-%% \code{[String]} would have been inserted by the type inferencer. 
-
-%% \section{Type Parameter Bounds}
-
-%% Now that we know how to make classes generic it is natural to
-%% generalize some of the earlier classes we have written. For instance
-%% class \code{IntSet} could be generalized to sets with arbitrary
-%% element types. Let's try. The abstract class for generic sets is easily
-%% written.
-%% \begin{lstlisting}
-%% abstract class Set[A] {
-%%   def incl(x: A): Set[A]
-%%   def contains(x: A): Boolean
-%% }
-%% \end{lstlisting}
-%% However, if we still want to implement sets as binary search trees, we
-%% encounter a problem. The \code{contains} and \code{incl} methods both
-%% compare elements using methods \code{<} and \code{>}. For
-%% \code{IntSet} this was OK, since type \code{Int} has these two
-%% methods. But for an arbitrary type parameter \code{a}, we cannot
-%% guarantee this. Therefore, the previous implementation of, say,
-%% \code{contains} would generate a compiler error.
-%% \begin{lstlisting}
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%           ^ < $\mbox{\sl not a member of type}$ A.
-%% \end{lstlisting}
-%% One way to solve the problem is to restrict the legal types that can
-%% be substituted for type \code{A} to only those types that contain methods
-%% \code{<} and \code{>} of the correct types. There is a trait
-%% \code{Ordered[A]} in the standard class library Scala which represents
-%% values which are comparable (via \code{<} and \code{>}) to values of
-%% type \code{A}. This trait is defined as follows:
-%% \begin{lstlisting}
-%% /** A class for totally ordered data. */
-%% trait Ordered[A] {
-
-%%   /** Result of comparing `this' with operand `that'.
-%%    *  returns `x' where
-%%    *  x < 0    iff    this < that
-%%    *  x == 0   iff    this == that
-%%    *  x > 0    iff    this > that
-%%    */
-%%   def compare(that: A): Int
-
-%%   def <  (that: A): Boolean = (this compare that) <  0
-%%   def >  (that: A): Boolean = (this compare that) >  0
-%%   def <= (that: A): Boolean = (this compare that) <= 0
-%%   def >= (that: A): Boolean = (this compare that) >= 0
-%%   def compareTo(that: A): Int = compare(that)
-%% }
-%% \end{lstlisting}
-%% We can enforce the comparability of a type by demanding
-%% that the type is a subtype of \code{Ordered}. This is done by giving an
-%% upper bound to the type parameter of \code{Set}:
-%% \begin{lstlisting}
-%% trait Set[A <: Ordered[A]] {
-%%   def incl(x: A): Set[A]
-%%   def contains(x: A): Boolean
-%% }
-%% \end{lstlisting}
-%% The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
-%% type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
-%% must be comparable to values of the same type.
-
-%% With this restriction, we can now implement the rest of the generic
-%% set abstraction as we did in the case of \code{IntSet}s before.
-
-%% \begin{lstlisting}
-%% class EmptySet[A <: Ordered[A]] extends Set[A] {
-%%   def contains(x: A): Boolean = false
-%%   def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
-%% }
-%% \end{lstlisting}
-
-%% \begin{lstlisting}
-%% class NonEmptySet[A <: Ordered[A]]
-%%         (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
-%%   def contains(x: A): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: A): Set[A] =
-%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
-%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
-%% Note that we have left out the type argument in the object creations
-%% \code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
-%% missing type arguments in constructor calls are inferred from value
-%% arguments and/or the expected result type.
-
-%% Here is an example that uses the generic set abstraction. Let's first
-%% create a subclass of \lstinline@Ordered@, like this:
-%% \begin{lstlisting}
-%% case class Num(value: Double) extends Ordered[Num] {
-%%   def compare(that: Num): Int =
-%%     if (this.value < that.value) -1
-%%     else if (this.value > that.value) 1
-%%     else 0
-%% }
-%% \end{lstlisting}
-%% Then:
-%% \begin{lstlisting}
-%% val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
-%% s.contains(Num(1.5))
-%% \end{lstlisting}
-%% This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
-%% However, the following example is in error.
-%% \begin{lstlisting}
-%% val s = new EmptySet[java.io.File]
-%%                     ^ java.io.File $\mbox{\sl does not conform to type}$
-%%                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
-%% \end{lstlisting}
-%% One probem with type parameter bounds is that they require
-%% forethought: if we had not declared \lstinline@Num@ a subclass of
-%% \lstinline@Ordered@, we would not have been able to use \lstinline@Num@
-%% elements in sets. By the same token, types inherited from Java, 
-%% such as \lstinline@Int@, \lstinline@Double@, or
-%% \lstinline@String@ are not subclasses of \lstinline@Ordered@, so
-%% values of these types cannot be used as set elements.
-
-%% A more flexible design, which admits elements of these types, uses
-%% {\em view bounds} instead of the plain type bounds we have seen so
-%% far. The only change this entails in the example above is in the type
-%% parameters:
-%% \begin{lstlisting}
-%% trait Set[A <% Ordered[A]] ...
-%% class EmptySet[A <% Ordered[A]] ...
-%% class NonEmptySet[A <% Ordered[A]] ...
-%% \end{lstlisting}
-%% View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
-%% A view bounded type parameter clause \lstinline@[A <% T]@ only
-%% specifies that the bounded type \lstinline@A@ must be {\em convertible} to
-%% the bound type \lstinline@T@, using an implicit conversion.
-
-%% The Scala library predefines implicit conversions for a number of
-%% types, including the primitive types and \lstinline@String@.
-%% Therefore, the redesign set abstraction can be instantiated with these
-%% types as well. More explanations on implicit conversions and view
-%% bounds are given in Section~\ref{sec:implicits}.
-
-%% \section{Variance Annotations}\label{sec:first-arrays}
-
-%% The combination of type parameters and subtyping poses some
-%% interesting questions. For instance, should \code{Stack[String]} be a
-%% subtype of \code{Stack[AnyRef]}? Intuitively, this seems OK, since a
-%% stack of \code{String}s is a special case of a stack of
-%% \code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
-%% then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
-%% This property is called {\em co-variant} subtyping.
-
-%% In Scala, generic types have by default non-variant subtyping. That
-%% is, with \code{Stack} defined as above, stacks with different element
-%% types would never be in a subtype relation. However, we can enforce
-%% co-variant subtyping of stacks by changing the first line of the
-%% definition of class \code{Stack} as follows.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%% \end{lstlisting}
-%% Prefixing a formal type parameter with a \code{+} indicates that
-%% subtyping is covariant in that parameter. 
-%% Besides \code{+}, there is also a prefix \code{-} which indicates
-%% contra-variant subtyping. If \code{Stack} was defined \code{class
-%% Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
-%% that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
-%% case of stacks would be rather surprising!).
-
-%% In a purely functional world, all types could be co-variant. However,
-%% the situation changes once we introduce mutable data. Consider the
-%% case of arrays in Java or .NET. Such arrays are represented in Scala
-%% by a generic class \code{Array}. Here is a partial definition of this
-%% class.
-%% \begin{lstlisting}
-%% class Array[A] {
-%%   def apply(index: Int): A
-%%   def update(index: Int, elem: A)
-%% }
-%% \end{lstlisting}
-%% The class above defines the way Scala arrays are seen from Scala user
-%% programs. The Scala compiler will map this abstraction to the
-%% underlying arrays of the host system in most cases where this
-%% possible.
-
-%% In Java, arrays are indeed covariant; that is, for reference types
-%% \code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
-%% \code{Array[T]} is a subtype of \code{Array[S]}. This might seem
-%% natural but leads to safety problems that require special runtime
-%% checks. Here is an example:
-%% \begin{lstlisting}
-%% val x = new Array[String](1)
-%% val y: Array[Any] = x
-%% y(0) = new Rational(1, 2)  // this is syntactic sugar for
-%%                            // y.update(0, new Rational(1, 2))
-%% \end{lstlisting}
-%% In the first line, a new array of strings is created. In the second
-%% line, this array is bound to a variable \code{y}, of type
-%% \code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
-%% \code{Array[String]} is a subtype of \code{Array[Any]}. Finally, in
-%% the last line a rational number is stored in the array. This is also
-%% OK, since type \code{Rational} is a subtype of the element type
-%% \code{Any} of the array \code{y}. We thus end up storing a rational
-%% number in an array of strings, which clearly violates type soundness. 
-
-%% Java solves this problem by introducing a run-time check in the third
-%% line which tests whether the stored element is compatible with the
-%% element type with which the array was created. We have seen in the
-%% example that this element type is not necessarily the static element
-%% type of the array being updated. If the test fails, an
-%% \code{ArrayStoreException} is raised.
-
-%% Scala solves this problem instead statically, by disallowing the
-%% second line at compile-time, because arrays in Scala have non-variant
-%% subtyping. This raises the question how a Scala compiler verifies that
-%% variance annotations are correct. If we had simply declared arrays
-%% co-variant, how would the potential problem have been detected?
-
-%% Scala uses a conservative approximation to verify soundness of
-%% variance annotations.  A covariant type parameter of a class may only
-%% appear in co-variant positions inside the class.  Among the co-variant
-%% positions are the types of values in the class, the result types of
-%% methods in the class, and type arguments to other covariant types. Not
-%% co-variant are types of formal method parameters. Hence, the following
-%% class definition would have been rejected
-%% \begin{lstlisting}
-%% class Array[+A] {
-%%   def apply(index: Int): A
-%%   def update(index: Int, elem: A)
-%%                                ^ $\mbox{\sl covariant type parameter}$ A
-%%                                  $\mbox{\sl appears in contravariant position.}$
-%% }
-%% \end{lstlisting}
-%% So far, so good. Intuitively, the compiler was correct in rejecting
-%% the \code{update} procedure in a co-variant class because \code{update}
-%% potentially changes state, and therefore undermines the soundness of
-%% co-variant subtyping. 
-
-%% However, there are also methods which do not mutate state, but where a
-%% type parameter still appears contra-variantly. An example is
-%% \code{push} in type \code{Stack}. Again the Scala compiler will reject
-%% the definition of this method for co-variant stacks.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%%   def push(x: A): Stack[A] =
-%%               ^ $\mbox{\sl covariant type parameter}$ A
-%%                 $\mbox{\sl appears in contravariant position.}$
-%% \end{lstlisting}
-%% This is a pity, because, unlike arrays, stacks are purely functional data
-%% structures and therefore should enable co-variant subtyping. However,
-%% there is a a way to solve the problem by using a polymorphic method
-%% with a lower type parameter bound.
-
-%% \section{Lower Bounds}
-
-%% We have seen upper bounds for type parameters. In a type parameter
-%% declaration such as \code{T <: U}, the type parameter \code{T} is
-%% restricted to range only over subtypes of type \code{U}. Symmetrical
-%% to this are lower bounds in Scala. In a type parameter declaration
-%% \code{T >: S}, the type parameter \code{T} is restricted to range only
-%% over {\em supertypes} of type \code{S}. (One can also combine lower and
-%% upper bounds, as in \code{T >: S <: U}.)
-
-%% Using lower bounds, we can generalize the \code{push} method in
-%% \code{Stack} as follows.
-%% \begin{lstlisting}
-%% class Stack[+A] {
-%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-%% \end{lstlisting}
-%% Technically, this solves our variance problem since now the type
-%% parameter \code{A} appears no longer as a parameter type of method
-%% \code{push}. Instead, it appears as lower bound for another type
-%% parameter of a method, which is classified as a co-variant position.
-%% Hence, the Scala compiler accepts the new definition of \code{push}.
-
-%% In fact, we have not only solved the technical variance problem but
-%% also have generalized the definition of \code{push}.  Before, we were
-%% required to push only elements with types that conform to the declared
-%% element type of the stack. Now, we can push also elements of a
-%% supertype of this type, but the type of the returned stack will change
-%% accordingly. For instance, we can now push an \code{AnyRef} onto a
-%% stack of \code{String}s, but the resulting stack will be a stack of
-%% \code{AnyRef}s instead of a stack of \code{String}s!
-
-%% In summary, one should not hesitate to add variance annotations to
-%% your data structures, as this yields rich natural subtyping
-%% relationships. The compiler will detect potential soundness
-%% problems. Even if the compiler's approximation is too conservative, as
-%% in the case of method \code{push} of class \code{Stack}, this will
-%% often suggest a useful generalization of the contested method.
-
-%% \section{Least Types}
-
-%% Scala does not allow one to parameterize objects with types. That's
-%% why we originally defined a generic class \code{EmptyStack[A]}, even
-%% though a single value denoting empty stacks of arbitrary type would
-%% do. For co-variant stacks, however, one can use the following idiom:
-%% \begin{lstlisting}
-%% object EmptyStack extends Stack[Nothing] { ... }
-%% \end{lstlisting}
-%% The bottom type \code{Nothing} contains no value, so the type
-%% \code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
-%% contains no elements. Furthermore, \code{Nothing} is a subtype of all
-%% other types. Hence, for co-variant stacks, \code{Stack[Nothing]} is a
-%% subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
-%% possible to use a single empty stack object in user code. For
-%% instance:
-%% \begin{lstlisting}
-%% val s = EmptyStack.push("abc").push(new AnyRef())
-%% \end{lstlisting}
-%% Let's analyze the type assignment for this expression in detail.  The
-%% \code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
-%% method
-%% \begin{lstlisting}
-%% push[B >: Nothing](elem: B): Stack[B] .
-%% \end{lstlisting}
-%% Local type inference will determine that the type parameter \code{B}
-%% should be instantiated to \code{String} in the application 
-%% \code{EmptyStack.push("abc")}. The result type of that application is hence
-%% \code{Stack[String]}, which in turn has a method
-%% \begin{lstlisting}
-%% push[B >: String](elem: B): Stack[B] .
-%% \end{lstlisting}
-%% The final part of the value definition above is the application of
-%% this method to \code{new AnyRef()}. Local type inference will
-%% determine that the type parameter \code{b} should this time be
-%% instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
-%% Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
-
-%% Besides \code{Nothing}, which is a subtype of every other type, there
-%% is also the type \code{Null}, which is a subtype of
-%% \code{scala.AnyRef}, and every class derived from it. The \code{null}
-%% literal in Scala is the only value of that type. This makes
-%% \code{null} compatible with every reference type, but not with a value
-%% type such as \code{Int}.
-
-%% We conclude this section with the complete improved definition of
-%% stacks. Stacks have now co-variant subtyping, the \code{push} method
-%% has been generalized, and the empty stack is represented by a single
-%% object.
-%% \begin{lstlisting}
-%% abstract class Stack[+A] {
-%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-%%   def isEmpty: Boolean
-%%   def top: A
-%%   def pop: Stack[A]
-%% }
-%% object EmptyStack extends Stack[Nothing] {
-%%   def isEmpty = true
-%%   def top = error("EmptyStack.top")
-%%   def pop = error("EmptyStack.pop")
-%% }
-%% class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
-%%   def isEmpty = false
-%%   def top = elem
-%%   def pop = rest
-%% }
-%% \end{lstlisting}
-%% Many classes in the Scala library are generic. We now present two
-%% commonly used families of generic classes, tuples and functions. The
-%% discussion of another common class, lists, is deferred to the next
-%% chapter.
-
-%% \section{Tuples}
-
-%% Sometimes, a function needs to return more than one result. For
-%% instance, take the function \code{divmod} which returns the integer quotient
-%% and rest of two given integer arguments.  Of course, one can define a
-%% class to hold the two results of \code{divmod}, as in:
-%% \begin{lstlisting}
-%% case class TwoInts(first: Int, second: Int)
-%% def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
-%% \end{lstlisting}
-%% However, having to define a new class for every possible pair of
-%% result types is very tedious. In Scala one can use instead a
-%% generic class \lstinline@Tuple$2$@, which is defined as follows:
-%% \begin{lstlisting}
-%% package scala
-%% case class Tuple2[A, B](_1: A, _2: B)
-%% \end{lstlisting}
-%% With \code{Tuple2}, the \code{divmod} method can be written as follows.
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
-%% \end{lstlisting}
-%% As usual, type parameters to constructors can be omitted if they are
-%% deducible from value arguments. There exist also tuple classes for
-%% every other number of elements (the current Scala implementation
-%% limits this to tuples of some reasonable number of elements).  
-
-%% \comment{
-%% Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
-%% \code{Triple} for \code{Tuple3}).  With these conventions,
-%% \code{divmod} can equivalently be written as follows.
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
-%% \end{lstlisting}
-%% }
-%% How are elements of tuples accessed? Since tuples are case classes,
-%% there are two possibilities. One can either access a tuple's fields
-%% using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
-%% \begin{lstlisting}
-%% val xy = divmod(x, y)
-%% println("quotient: " + xy._1 + ", rest: " + xy._2)
-%% \end{lstlisting}
-%% Or one uses pattern matching on tuples, as in the following example:
-%% \begin{lstlisting}
-%% divmod(x, y) match {
-%%   case Tuple2(n, d) =>
-%%     println("quotient: " + n + ", rest: " + d)
-%% }
-%% \end{lstlisting}
-%% Note that type parameters are never used in patterns; it would have
-%% been illegal to write case \code{Tuple2[Int, Int](n, d)}.
-
-%% Tuples are so convenient that Scala defines special syntax for
-%% them. To form a tuple with $n$ elements $x_1 \commadots x_n$ one can
-%% write $(x_1 \commadots x_n)$. This is equivalent to
-%% \lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
-%% equivalently for types and for patterns. With that tuple syntax, the
-%% \lstinline@divmod@ example is written as follows:
-%% \begin{lstlisting}
-%% def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
-%% divmod(x, y) match {
-%%   case (n, d) => println("quotient: " + n + ", rest: " + d)
-%% }
-%% \end{lstlisting}
-%% \section{Functions}\label{sec:functions}
-
-%% Scala is a functional language in that functions are first-class
-%% values.  Scala is also an object-oriented language in that every value
-%% is an object.  It follows that functions are objects in Scala.  For
-%% instance, a function from type \code{String} to type \code{Int} is
-%% represented as an instance of the trait \code{Function1[String, Int]}.
-%% The \code{Function1} trait is defined as follows.
-%% \begin{lstlisting}
-%% package scala
-%% trait Function1[-A, +B] {
-%%   def apply(x: A): B
-%% }
-%% \end{lstlisting}
-%% Besides \code{Function1}, there are also definitions of for functions
-%% of all other arities (the current implementation implements this only
-%% up to a reasonable limit).  That is, there is one definition for each
-%% possible number of function parameters.  Scala's function type syntax
-%% ~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
-%% for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
-%% T_n, S$]@~.
-
-%% Scala uses the same syntax $f(x)$ for function application, no matter
-%% whether $f$ is a method or a function object. This is made possible by
-%% the following convention: A function application $f(x)$ where $f$ is
-%% an object (as opposed to a method) is taken to be a shorthand for
-%% \lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
-%% function type is inserted automatically where this is necessary.
-
-%% That's also why we defined array subscripting in
-%% Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
-%% array \code{a}, the subscript operation \code{a(i)} is taken to be a
-%% shorthand for \code{a.apply(i)}.
-
-%% Functions are an example where a contra-variant type parameter
-%% declaration is useful. For example, consider the following code:
-%% \begin{lstlisting}
-%% val f: (AnyRef => Int)  =  x => x.hashCode()
-%% val g: (String => Int)  =  f
-%% g("abc")
-%% \end{lstlisting}
-%% It's sound to bind the value \code{g} of type \code{String => Int} to
-%% \code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
-%% do with function of type \code{String => Int} is pass it a string in
-%% order to obtain an integer. Clearly, the same works for function
-%% \code{f}: If we pass it a string (or any other object), we obtain an
-%% integer.  This demonstrates that function subtyping is contra-variant
-%% in its argument type whereas it is covariant in its result type.
-%% In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
-%% $S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
-
-%% \example Consider the Scala code
-%% \begin{lstlisting}
-%% val plus1: (Int => Int)  =  (x: Int) => x + 1
-%% plus1(2)
-%% \end{lstlisting}
-%% This is expanded into the following object code.
-%% \begin{lstlisting}
-%% val plus1: Function1[Int, Int] = new Function1[Int, Int] {
-%%   def apply(x: Int): Int = x + 1
-%% }
-%% plus1.apply(2)
-%% \end{lstlisting}
-%% Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
-%% represents an instance of an {\em anonymous class}. It combines the
-%% creation of a new \code{Function1} object with an implementation of 
-%% the \code{apply} method (which is abstract in \code{Function1}).
-%% Equivalently, but more verbosely, one could have used a local class:
-%% \begin{lstlisting}
-%% val plus1: Function1[Int, Int] = {
-%%   class Local extends Function1[Int, Int] {
-%%     def apply(x: Int): Int = x + 1
-%%   }
-%%   new Local: Function1[Int, Int]
-%% }
-%% plus1.apply(2)
-%% \end{lstlisting}
- 
-%% \chapter{Lists}
-
-%% Lists are an important data structure in many Scala programs.  
-%% A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
-%% \code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
-%% \begin{lstlisting}
-%% val fruit = List("apples", "oranges", "pears")
-%% val nums  = List(1, 2, 3, 4)
-%% val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-%% val empty = List()
-%% \end{lstlisting}
-%% Lists are similar to arrays in languages such as C or Java, but there
-%% are also three important differences. First, lists are immutable. That
-%% is, elements of a list cannot be changed by assignment. Second, 
-%% lists have a recursive structure, whereas arrays are flat. Third,
-%% lists support a much richer set of operations than arrays usually do.
-
-%% \section{Using Lists}
-
-%% \paragraph{The List type}
-%% Like arrays, lists are {\em homogeneous}. That is, the elements of a
-%% list all have the same type.  The type of a list with elements of type
-%% \code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
-%% \begin{lstlisting}
-%% val fruit: List[String]    = List("apples", "oranges", "pears")
-%% val nums : List[Int]       = List(1, 2, 3, 4)
-%% val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-%% val empty: List[Int]       = List()
-%% \end{lstlisting}
-
-%% \paragraph{List constructors}
-%% All lists are built from two more fundamental constructors, \code{Nil}
-%% and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
-%% list. The infix operator \code{::} expresses list extension. That is,
-%% \code{x :: xs} represents a list whose first element is \code{x},
-%% which is followed by (the elements of) list \code{xs}.  Hence, the
-%% list values above could also have been defined as follows (in fact
-%% their previous definition is simply syntactic sugar for the definitions below).
-%% \begin{lstlisting}
-%% val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
-%% val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
-%% val diag3  = (1 :: (0 :: (0 :: Nil))) ::
-%%              (0 :: (1 :: (0 :: Nil))) ::
-%%              (0 :: (0 :: (1 :: Nil))) :: Nil
-%% val empty  = Nil
-%% \end{lstlisting}
-%% The `\code{::}' operation associates to the right: \code{A :: B :: C} is
-%% interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
-%% parentheses in the definitions above. For instance, we can write
-%% shorter
-%% \begin{lstlisting}
-%% val nums  =  1 :: 2 :: 3 :: 4 :: Nil
-%% \end{lstlisting}
-
-%% \paragraph{Basic operations on lists}
-%% All operations on lists can be expressed in terms of the following three:
-
-%% \begin{tabular}{ll}
-%% \code{head}  &  returns the first element of a list,\\
-%% \code{tail}  &  returns the list consisting of all elements except the\\
-%% & first element,\\
-%% \code{isEmpty} & returns \code{true} iff the list is empty
-%% \end{tabular}
-
-%% These operations are defined as methods of list objects. So we invoke
-%% them by selecting from the list that's operated on. Examples:
-%% \begin{lstlisting}
-%% empty.isEmpty   = true
-%% fruit.isEmpty   = false
-%% fruit.head      = "apples"
-%% fruit.tail.head = "oranges"
-%% diag3.head      = List(1, 0, 0)
-%% \end{lstlisting}
-%% The \code{head} and \code{tail} methods are defined only for non-empty
-%% lists.  When selected from an empty list, they throw an exception.
-
-%% As an example of how lists can be processed, consider sorting the
-%% elements of a list of numbers into ascending order. One simple way to
-%% do so is {\em insertion sort}, which works as follows: To sort a
-%% non-empty list with first element \code{x} and rest \code{xs}, sort
-%% the remainder \code{xs} and insert the element \code{x} at the right
-%% position in the result. Sorting an empty list will yield the
-%% empty list. Expressed as Scala code:
-%% \begin{lstlisting}
-%% def isort(xs: List[Int]): List[Int] =
-%%   if (xs.isEmpty) Nil
-%%   else insert(xs.head, isort(xs.tail))
-%% \end{lstlisting}
-
-%% \begin{exercise} Provide an implementation of the missing function
-%% \code{insert}.
-%% \end{exercise}
-
-%% \paragraph{List patterns} In fact, \code{::} is defined as a case
-%% class in Scala's standard library. Hence, it is possible to decompose
-%% lists by pattern matching, using patterns composed from the \code{Nil}
-%% and \code{::} constructors. For instance, \code{isort} can be written
-%% alternatively as follows.
-%% \begin{lstlisting}
-%% def isort(xs: List[Int]): List[Int] = xs match {
-%%   case List() => List()
-%%   case x :: xs1 => insert(x, isort(xs1))
-%% }
-%% \end{lstlisting}
-%% where
-%% \begin{lstlisting}
-%% def insert(x: Int, xs: List[Int]): List[Int] = xs match {
-%%   case List() => List(x)
-%%   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
-%% }
-%% \end{lstlisting}
-
-%% \section{Definition of class List I: First Order Methods}
-%% \label{sec:list-first-order}
-
-%% Lists are not built in in Scala; they are defined by an abstract class
-%% \code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
-%% In the following we present a tour through class \code{List}.
-%% \begin{lstlisting}
-%% package scala
-%% abstract class List[+A] {
-%% \end{lstlisting}
-%% \code{List} is an abstract class, so one cannot define elements by
-%% calling the empty \code{List} constructor (e.g. by
-%% \code{new List}).  The class has a type parameter \code{a}. It is
-%% co-variant in this parameter, which means that
-%% \code{List[S] <: List[T]} for all types \code{S} and \code{T} such that
-%% \code{S <: T}.  The class is situated in the package
-%% \code{scala}. This is a package containing the most important standard
-%% classes of Scala.
-%%  \code{List} defines a number of methods, which are
-%% explained in the following.
-
-%% \paragraph{Decomposing lists}
-%% First, there are the three basic methods \code{isEmpty},
-%% \code{head}, \code{tail}. Their implementation in terms of pattern
-%% matching is straightforward:
-%% \begin{lstlisting}
-%% def isEmpty: Boolean = this match {
-%%   case Nil => true
-%%   case x :: xs => false
-%% }
-%% def head: A = this match {
-%%   case Nil => error("Nil.head")
-%%   case x :: xs => x
-%% }
-%% def tail: List[A] = this match {
-%%   case Nil => error("Nil.tail")
-%%   case x :: xs => xs
-%% }
-%% \end{lstlisting}
-
-%% The next function computes the length of a list.
-%% \begin{lstlisting}
-%% def length: Int = this match {
-%%   case Nil => 0
-%%   case x :: xs => 1 + xs.length
-%% }
-%% \end{lstlisting}
-%% \begin{exercise} Design a tail-recursive version of \code{length}.
-%% \end{exercise}
-
-%% The next two functions are the complements of \code{head} and
-%% \code{tail}.
-%% \begin{lstlisting}
-%% def last: A
-%% def init: List[A]
-%% \end{lstlisting}
-%% \code{xs.last} returns the last element of list \code{xs}, whereas
-%% \code{xs.init} returns all elements of \code{xs} except the last.
-%% Both functions have to traverse the entire list, and are thus less
-%% efficient than their \code{head} and \code{tail} analogues.
-%% Here is the implementation of \code{last}.
-%% \begin{lstlisting}
-%% def last: A = this match {
-%%   case Nil      => error("Nil.last")
-%%   case x :: Nil => x
-%%   case x :: xs  => xs.last
-%% }
-%% \end{lstlisting}
-%% The implementation of \code{init} is analogous.
-
-%% The next three functions return a prefix of the list, or a suffix, or
-%% both.
-%% \begin{lstlisting}
-%% def take(n: Int): List[A] =
-%%   if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
-
-%% def drop(n: Int): List[A] =
-%%   if (n == 0 || isEmpty) this else tail.drop(n-1)
-
-%% def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
-%% \end{lstlisting}
-%% \code{(xs take n)} returns the first \code{n} elements of list
-%% \code{xs}, or the whole list, if its length is smaller than \code{n}.
-%% \code{(xs drop n)} returns all elements of \code{xs} except the
-%% \code{n} first ones. Finally, \code{(xs split n)} returns a pair
-%% consisting of the lists resulting from \code{xs take n} and
-%% \code{xs drop n}.
-
-%% The next function returns an element at a given index in a list.
-%% It is thus analogous to array subscripting. Indices start at 0.
-%% \begin{lstlisting}
-%% def apply(n: Int): A = drop(n).head
-%% \end{lstlisting}
-%% The \code{apply} method has a special meaning in Scala. An object with
-%% an \code{apply} method can be applied to arguments as if it was a
-%% function. For instance, to pick the 3'rd element of a list \code{xs},
-%% one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
-%% expression expands into the first.
-
-%% With \code{take} and \code{drop}, we can extract sublists consisting
-%% of consecutive elements of the original list.  To extract the sublist
-%% $xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
-
-%% \begin{lstlisting}
-%% xs.drop(m).take(n - m)
-%% \end{lstlisting}
-
-%% \paragraph{Zipping lists} The next function combines two lists into a list of pairs.
-%% Given two lists
-%% \begin{lstlisting}
-%% xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
-%% ys = List(y$_1$, ..., y$_n$)   ,
-%% \end{lstlisting}
-%% \code{xs zip ys} constructs the list
-%% \lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
-%% If the two lists have different lengths, the longer one of the two is
-%% truncated. Here is the definition of \code{zip} -- note that it is a
-%% polymorphic method.
-%% \begin{lstlisting}
-%% def zip[B](that: List[B]): List[(a,b)] =
-%%   if (this.isEmpty || that.isEmpty) Nil
-%%   else (this.head, that.head) :: (this.tail zip that.tail)
-%% \end{lstlisting}
-
-%% \paragraph{Consing lists.}
-%% Like any infix operator, \code{::}
-%% is also implemented as a method of an object. In this case, the object
-%% is the list that is extended. This is possible, because operators
-%% ending with a `\code{:}' character are treated specially in Scala.  
-%% All such operators are treated as methods of their right operand. E.g.,
-%% \begin{lstlisting}
-%%     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
-%% \end{lstlisting}
-%% Note, however, that operands of a binary operation are in each case
-%% evaluated from left to right.  So, if \code{D} and \code{E} are
-%% expressions with possible side-effects, \code{D :: E} is translated to
-%% \lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
-%% order of operand evaluation.
-
-%% Another difference between operators ending in a `\code{:}' and other
-%% operators concerns their associativity.  Operators ending in
-%% `\code{:}' are right-associative, whereas other operators are
-%% left-associative.  E.g.,
-%% \begin{lstlisting}
-%%     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
-%% \end{lstlisting}
-%% The definition of \code{::} as a method in
-%% class \code{List} is as follows:
-%% \begin{lstlisting}
-%% def ::[B >: A](x: B): List[B] = new scala.::(x, this)
-%% \end{lstlisting}
-%% Note that \code{::} is defined for all elements \code{x} of type
-%% \code{B} and lists of type \code{List[A]} such that the type \code{B}
-%% of \code{x} is a supertype of the list's element type \code{A}. The result
-%% is in this case a list of \code{B}'s. This
-%% is expressed by the type parameter \code{B} with lower bound \code{A}
-%% in the signature of \code{::}. 
-
-%% \paragraph{Concatenating lists}
-%% An operation similar to \code{::} is list concatenation, written
-%% `\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
-%% all elements of \code{xs}, followed by all elements of \code{ys}.
-%% Because it ends in a colon, \code{:::} is right-associative and is
-%% considered as a method of its right-hand operand. Therefore,
-%% \begin{lstlisting}
-%% xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
-%%                   =   zs.:::(ys).:::(xs)
-%% \end{lstlisting}
-%% Here is the implementation of the \code{:::} method:
-%% \begin{lstlisting}
-%%   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
-%%     case Nil => this
-%%     case p :: ps => this.:::(ps).::(p)
-%%   }
-%% \end{lstlisting}
-
-%% \paragraph{Reversing lists} Another useful operation
-%% is list reversal. There is a method \code{reverse} in \code{List} to
-%% that effect. Let's try to give its implementation:
-%% \begin{lstlisting}
-%% def reverse[A](xs: List[A]): List[A] = xs match {
-%%   case Nil => Nil
-%%   case x :: xs => reverse(xs) ::: List(x)
-%% }
-%% \end{lstlisting}
-%% This implementation has the advantage of being simple, but it is not
-%% very efficient.  Indeed, one concatenation is executed for every
-%% element in the list. List concatenation takes time proportional to the
-%% length of its first operand. Therefore, the complexity of
-%% \code{reverse(xs)} is
-%% \[
-%% n + (n - 1) + ... + 1 = n(n+1)/2
-%% \]
-%% where $n$ is the length of \code{xs}. Can \code{reverse} be
-%% implemented more efficiently? We will see later that there exists
-%% another implementation which has only linear complexity.
-
-%% \section{Example: Merge sort}
-
-%% The insertion sort presented earlier in this chapter is simple to
-%% formulate, but also not very efficient. It's average complexity is
-%% proportional to the square of the length of the input list. We now
-%% design a program to sort the elements of a list which is more
-%% efficient than insertion sort. A good algorithm for this is {\em merge
-%% sort}, which works as follows.
-
-%% First, if the list has zero or one elements, it is already sorted, so
-%% one returns the list unchanged. Longer lists are split into two
-%% sub-lists, each containing about half the elements of the original
-%% list. Each sub-list is sorted by a recursive call to the sort
-%% function, and the resulting two sorted lists are then combined in a
-%% merge operation.
-
-%% For a general implementation of merge sort, we still have to specify
-%% the type of list elements to be sorted, as well as the function to be
-%% used for the comparison of elements. We obtain a function of maximal
-%% generality by passing these two items as parameters. This leads to the
-%% following implementation.
-%% \begin{lstlisting}
-%% def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
-%%   def merge(xs1: List[A], xs2: List[A]): List[A] =
-%%     if (xs1.isEmpty) xs2
-%%     else if (xs2.isEmpty) xs1
-%%     else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
-%%     else xs2.head :: merge(xs1, xs2.tail)
-%%   val n = xs.length/2
-%%   if (n == 0) xs
-%%   else merge(msort(less)(xs take n), msort(less)(xs drop n))
-%% }
-%% \end{lstlisting}
-%% The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
-%% length of the input list. To see why, note that splitting a list in
-%% two and merging two sorted lists each take time proportional to the
-%% length of the argument list(s). Each recursive call of \code{msort}
-%% halves the number of elements in its input, so there are $O(log(N))$
-%% consecutive recursive calls until the base case of lists of length 1
-%% is reached.  However, for longer lists each call spawns off two
-%% further calls. Adding everything up we obtain that at each of the
-%% $O(log(N))$ call levels, every element of the original lists takes
-%% part in one split operation and in one merge operation. Hence, every
-%% call level has a total cost proportional to $O(N)$. Since there are
-%% $O(log(N))$ call levels, we obtain an overall cost of
-%% $O(N;log(N))$. That cost does not depend on the initial distribution
-%% of elements in the list, so the worst case cost is the same as the
-%% average case cost. This makes merge sort an attractive algorithm for
-%% sorting lists.
-
-%% Here is an example how \code{msort} is used.
-%% \begin{lstlisting}
-%% msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
-%% \end{lstlisting}
-%% The definition of \code{msort} is curried, to make it easy to specialize it with particular
-%% comparison functions. For instance,
-%% \begin{lstlisting}
-
-%% val intSort = msort((x: Int, y: Int) => x < y)
-%% val reverseSort = msort((x: Int, y: Int) => x > y)
-%% \end{lstlisting}
-
-%% \section{Definition of class List II: Higher-Order Methods}
-
-%% The examples encountered so far show that functions over lists often
-%% have similar structures. We can identify several patterns of
-%% computation over lists, like:
-%% \begin{itemize}
-%%       \item transforming every element of a list in some way.
-%%       \item extracting from a list all elements satisfying a criterion.
-%%       \item combine the elements of a list using some operator.
-%% \end{itemize}
-%% Functional programming languages enable programmers to write general
-%% functions which implement patterns like this by means of higher order
-%% functions. We now discuss a set of commonly used higher-order
-%% functions, which are implemented as methods in class \code{List}.
-
-%% \paragraph{Mapping over lists}
-%% A common operation is to transform each element of a list and then
-%% return the lists of results.  For instance, to scale each element of a
-%% list by a given factor.
-%% \begin{lstlisting}
-%% def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
-%%   case Nil => xs
-%%   case x :: xs1 => x * factor :: scaleList(xs1, factor)
-%% }
-%% \end{lstlisting}
-%% This pattern can be generalized to the \code{map} method of class \code{List}:
-%% \begin{lstlisting}
-%% abstract class List[A] { ...
-%%   def map[B](f: A => B): List[B] = this match {
-%%     case Nil => this
-%%     case x :: xs => f(x) :: xs.map(f)
-%%   }
-%% \end{lstlisting}
-%% Using \code{map}, \code{scaleList} can be more concisely written as follows.
-%% \begin{lstlisting}
-%% def scaleList(xs: List[Double], factor: Double) =
-%%   xs map (x => x * factor)
-%% \end{lstlisting}
-
-%% As another example, consider the problem of returning a given column
-%% of a matrix which is represented as a list of rows, where each row is
-%% again a list. This is done by the following function \code{column}.
-
-%% \begin{lstlisting}
-%% def column[A](xs: List[List[A]], index: Int): List[A] =
-%%   xs map (row => row(index))
-%% \end{lstlisting}
-
-%% Closely related to \code{map} is the \code{foreach} method, which
-%% applies a given function to all elements of a list, but does not
-%% construct a list of results. The function is thus applied only for its
-%% side effect. \code{foreach} is defined as follows.
-%% \begin{lstlisting}
-%%   def foreach(f: A => Unit) {
-%%     this match {
-%%       case Nil => ()
-%%       case x :: xs => f(x); xs.foreach(f)
-%%     }
-%%   }
-%% \end{lstlisting}
-%% This function can be used for printing all elements of a list, for instance:
-%% \begin{lstlisting}
-%%   xs foreach (x => println(x))
-%% \end{lstlisting} 
-
-%% \begin{exercise} Consider a function which squares all elements of a list and
-%% returns a list with the results. Complete the following two equivalent
-%% definitions of \code{squareList}.
-
-%% \begin{lstlisting}
-%% def squareList(xs: List[Int]): List[Int] = xs match {
-%%   case List() => ??
-%%   case y :: ys => ??
-%% }
-%% def squareList(xs: List[Int]): List[Int] =
-%%   xs map ??
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% \paragraph{Filtering Lists}
-%% Another common operation selects from a list all elements fulfilling a
-%% given criterion. For instance, to return a list of all positive
-%% elements in some given lists of integers:
-%% \begin{lstlisting}
-%% def posElems(xs: List[Int]): List[Int] = xs match {
-%%   case Nil => xs
-%%   case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
-%% }
-%% \end{lstlisting}
-%% This pattern is generalized to the \code{filter} method of class \code{List}:
-%% \begin{lstlisting}
-%%   def filter(p: A => Boolean): List[A] = this match {
-%%     case Nil => this
-%%     case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
-%%   }
-%% \end{lstlisting}
-%% Using \code{filter}, \code{posElems} can be more concisely written as
-%% follows.
-%% \begin{lstlisting}
-%% def posElems(xs: List[Int]): List[Int] =
-%%   xs filter (x => x > 0)
-%% \end{lstlisting}
-
-%% An operation related to filtering is testing whether all elements of a
-%% list satisfy a certain condition. Dually, one might also be interested
-%% in the question whether there exists an element in a list that
-%% satisfies a certain condition. These operations are embodied in the
-%% higher-order functions \code{forall} and \code{exists} of class
-%% \code{List}.
-%% \begin{lstlisting}
-%% def forall(p: A => Boolean): Boolean =
-%%   isEmpty || (p(head) && (tail forall p))
-%% def exists(p: A => Boolean): Boolean =
-%%   !isEmpty && (p(head) || (tail exists p))
-%% \end{lstlisting}
-%% To illustrate the use of \code{forall}, consider the question of whether
-%% a number if prime. Remember that a number $n$ is prime of it can be
-%% divided without remainder only by one and itself. The most direct
-%% translation of this definition would test that $n$ divided by all
-%% numbers from 2 up to and excluding itself gives a non-zero
-%% remainder. This list of numbers can be generated using a function
-%% \code{List.range} which is defined in object \code{List} as follows.
-%% \begin{lstlisting}
-%% package scala
-%% object List { ...
-%%   def range(from: Int, end: Int): List[Int] =
-%%     if (from >= end) Nil else from :: range(from + 1, end)
-%% \end{lstlisting}
-%% For example, \code{List.range(2, n)}
-%% generates the list of all integers from 2 up to and excluding $n$.
-%% The function \code{isPrime} can now simply be defined as follows.
-%% \begin{lstlisting}
-%% def isPrime(n: Int) =
-%%   List.range(2, n) forall (x => n % x != 0)
-%% \end{lstlisting}
-%% We see that the mathematical definition of prime-ness has been
-%% translated directly into Scala code. 
-
-%% Exercise: Define \code{forall} and \code{exists} in terms of \code{filter}.
-
-
-%% \paragraph{Folding and Reducing Lists}
-%% Another common operation is to combine the elements of a list with
-%% some operator.  For instance:
-%% \begin{lstlisting}
-%% sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
-%% product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
-%% \end{lstlisting}
-%% Of course, we can implement both functions with a
-%% recursive scheme:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int]): Int = xs match {
-%%   case Nil => 0
-%%   case y :: ys => y + sum(ys)
-%% }
-%% def product(xs: List[Int]): Int = xs match {
-%%   case Nil => 1
-%%   case y :: ys => y * product(ys)
-%% }
-%% \end{lstlisting}
-%% But we can also use the generalization of this program scheme embodied
-%% in the \code{reduceLeft} method of class \code{List}.  This method
-%% inserts a given binary operator between adjacent elements of a given list.
-%% E.g.\ 
-%% \begin{lstlisting}
-%% List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
-%% \end{lstlisting}
-%% Using \code{reduceLeft}, we can make the common pattern
-%% in \code{sum} and \code{product} apparent:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
-%% def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
-%% \end{lstlisting}
-%% Here is the implementation of \code{reduceLeft}.
-%% \begin{lstlisting}
-%%   def reduceLeft(op: (A, A) => A): A = this match {
-%%     case Nil     => error("Nil.reduceLeft")
-%%     case x :: xs => (xs foldLeft x)(op)
-%%   }
-%%   def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
-%%     case Nil => z
-%%     case x :: xs => (xs foldLeft op(z, x))(op)
-%%   }
-%% }
-%% \end{lstlisting}
-%% We see that the \code{reduceLeft} method is defined in terms of
-%% another generally useful method, \code{foldLeft}.  The latter takes as
-%% additional parameter an {\em accumulator} \code{z}, which is returned
-%% when \code{foldLeft} is applied on an empty list. That is,
-%% \begin{lstlisting}
-%% (List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
-%% \end{lstlisting}
-%% The \code{sum} and \code{product} methods can be defined alternatively
-%% using \code{foldLeft}:
-%% \begin{lstlisting}
-%% def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
-%% def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
-%% \end{lstlisting}
-
-%% \paragraph{FoldRight and ReduceRight}
-%% Applications of \code{foldLeft} and \code{reduceLeft} expand to
-%% left-leaning trees. \todo{insert pictures}.  They have duals
-%% \code{foldRight} and \code{reduceRight}, which produce right-leaning
-%% trees.
-%% \begin{lstlisting}
-%% List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
-%% (List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
-%% \end{lstlisting}
-%% These are defined as follows.
-%% \begin{lstlisting}
-%%   def reduceRight(op: (A, A) => A): A = this match {
-%%     case Nil => error("Nil.reduceRight")
-%%     case x :: Nil => x
-%%     case x :: xs => op(x, xs.reduceRight(op))
-%%   }
-%%   def foldRight[B](z: B)(op: (A, B) => B): B = this match {
-%%     case Nil => z
-%%     case x :: xs => op(x, (xs foldRight z)(op))
-%%   }
-%% \end{lstlisting}
-
-%% Class \code{List} defines also two symbolic abbreviations for
-%% \code{foldLeft} and \code{foldRight}:
-%% \begin{lstlisting}
-%%   def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
-%%   def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
-%% \end{lstlisting}
-%% The method names picture the left/right leaning trees of the fold
-%% operations by forward or backward slashes. The \code{:} points in each
-%% case to the list argument whereas the end of the slash points to the
-%% accumulator (or: zero) argument \code{z}. 
-%% That is, 
-%% \begin{lstlisting}
-%% (z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
-%% (List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
-%% \end{lstlisting}
-%% For associative and commutative operators, \code{/:} and
-%% \code{:\\} are equivalent (even though there may be a difference
-%% in efficiency).  
-%% %But sometimes, only one of the two operators is
-%% %appropriate or has the right type:
-
-%% \begin{exercise} Consider the problem of writing a function \code{flatten},
-%% which takes a list of element lists as arguments. The result of
-%% \code{flatten} should be the concatenation of all element lists into a
-%% single list. Here is an implementation of this method in terms of 
-%% \code{:\\}.
-%% \begin{lstlisting}
-%% def flatten[A](xs: List[List[A]]): List[A] =
-%%   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
-%% \end{lstlisting} 
-%% Consider replacing the body of \lstinline@flatten@
-%% by 
-%% \begin{lstlisting}
-%%   ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
-%% \end{lstlisting}
-%% What would be the difference in asymptotic
-%% complexity between the two versions of \lstinline@flatten@?
-
-%% In fact \code{flatten} is predefined together with a set of other
-%% userful function in an object called \code{List} in the standatd Scala
-%% library. It can be accessed from user program by calling
-%% \code{List.flatten}. Note that \code{flatten} is not a method of class
-%% \code{List} -- it would not make sense there, since it applies only
-%% to lists of lists, not to all lists in general.
-%% \end{exercise}
-
-%% \paragraph{List Reversal Again} We have seen in 
-%% Section~\ref{sec:list-first-order} an implementation of method
-%% \code{reverse} whose run-time was quadratic in the length of the list
-%% to be reversed. We now develop a new implementation of \code{reverse},
-%% which has linear cost.  The idea is to use a \code{foldLeft}
-%% operation based on the following program scheme.
-%% \begin{lstlisting}
-%% class List[+A] { ...
-%%   def reverse: List[A] = (z? /: this)(op?)
-%% \end{lstlisting}
-%% It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
-%% try to deduce them from examples.
-%% \begin{lstlisting}
-%%   Nil
-%% = Nil.reverse                 // by specification
-%% = (z /: Nil)(op)              // by the template for reverse
-%% = (Nil foldLeft z)(op)        // by the definition of /:
-%% = z                           // by definition of foldLeft
-%% \end{lstlisting}
-%% Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
-%% let's study reversal of a list of length one.
-%% \begin{lstlisting}
-%%   List(x)
-%% = List(x).reverse             // by specification
-%% = (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
-%% = (List(x) foldLeft Nil)(op)  // by the definition of /:
-%% = op(Nil, x)                  // by definition of foldLeft
-%% \end{lstlisting}
-%% Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
-%% as \code{x :: Nil}. This suggests to take as \code{op} the
-%% \code{::} operator with its operands exchanged.  Hence, we arrive at
-%% the following implementation for \code{reverse}, which has linear complexity.
-%% \begin{lstlisting}
-%% def reverse: List[A] =
-%%   ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
-%% \end{lstlisting}
-%% (Remark: The type annotation of \code{Nil} is necessary 
-%% to make the type inferencer work.)
-
-%% \begin{exercise} Fill in the missing expressions to complete the following
-%% definitions of some basic list-manipulation operations as fold
-%% operations.
-%% \begin{lstlisting}
-%% def mapFun[A, B](xs: List[A], f: A => B): List[B] =
-%%   (xs :\ List[B]()){ ?? }
-
-%% def lengthFun[A](xs: List[A]): int =
-%%   (0 /: xs){ ?? }
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% \paragraph{Nested Mappings}
-
-%% We can employ higher-order list processing functions to express many
-%% computations that are normally expressed as nested loops in imperative
-%% languages. 
-
-%% As an example, consider the following problem: Given a positive
-%% integer $n$, find all pairs of positive integers $i$ and $j$, where 
-%% $1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
-%% the pairs are
-%% \bda{c|lllllll}
-%% i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
-%% j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
-%% i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
-%% \eda
-
-%% A natural way to solve this problem consists of two steps. In a first step,
-%% one generates the sequence of all pairs $(i, j)$ of integers such that
-%% $1 \leq j < i < n$. In a second step one then filters from this sequence
-%% all pairs $(i, j)$ such that $i + j$ is prime.
-
-%% Looking at the first step in more detail, a natural way to generate
-%% the sequence of pairs consists of three sub-steps.  First, generate
-%% all integers between $1$ and $n$ for $i$.  
-%% \item
-%% Second, for each integer $i$ between $1$ and $n$, generate the list of
-%% pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
-%% combination of \code{range} and \code{map}:
-%% \begin{lstlisting}
-%%   List.range(1, i) map (x => (i, x))
-%% \end{lstlisting}
-%% Finally, combine all sublists using \code{foldRight} with \code{:::}.
-%% Putting everything together gives the following expression:
-%% \begin{lstlisting}
-%% List.range(1, n)
-%%   .map(i => List.range(1, i).map(x => (i, x)))
-%%   .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
-%%   .filter(pair => isPrime(pair._1 + pair._2))
-%% \end{lstlisting}
-
-%% \paragraph{Flattening Maps}
-%% The combination of mapping and then concatenating sublists 
-%% resulting from the map
-%% is so common that we there is a special method 
-%% for it in class \code{List}:
-%% \begin{lstlisting}
-%% abstract class List[+A] { ...
-%%   def flatMap[B](f: A => List[B]): List[B] = this match {
-%%     case Nil => Nil
-%%     case x :: xs => f(x) ::: (xs flatMap f)
-%%   }
-%% }
-%% \end{lstlisting}
-%% With \code{flatMap}, the pairs-whose-sum-is-prime expression 
-%% could have been written more concisely as follows.
-%% \begin{lstlisting}
-%% List.range(1, n)
-%%   .flatMap(i => List.range(1, i).map(x => (i, x)))
-%%   .filter(pair => isPrime(pair._1 + pair._2))
-%% \end{lstlisting}
-
-
-
-%% \section{Summary}
-
-%% This chapter has introduced lists as a fundamental data structure in
-%% programming. Since lists are immutable, they are a common data type in
-%% functional programming languages. They have a role comparable to
-%% arrays in imperative languages. However, the access patterns between
-%% arrays and lists are quite different. Where array accessing is always
-%% done by indexing, this is much less common for lists.  We have seen
-%% that \code{scala.List} defines a method called \code{apply} for indexing
-%% however this operation is much more costly than in the case of arrays
-%% (linear as opposed to constant time). Instead of indexing, lists are
-%% usually traversed recursively, where recursion steps are usually based
-%% on a pattern match over the traversed list. There is also a rich set of
-%% higher-order combinators which allow one to instantiate a set of
-%% predefined patterns of computations over lists.
-
-%% \comment{
-%% \bsh{Reasoning About Lists}
-
-%% Recall the concatenation operation for lists:
-
-%% \begin{lstlisting}
-%% class List[+A] {
-%%   ...
-%%   def ::: (that: List[A]): List[A] =
-%%     if (isEmpty) that
-%%     else head :: (tail ::: that)
-%% }
-%% \end{lstlisting}
-
-%% We would like to verify that concatenation is associative, with the
-%% empty list \code{List()} as left and right identity:
-%% \bda{lcl}
-%%    (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
-%%    xs ::: List()          &=& xs \gap =\ List() ::: xs
-%% \eda
-%% \emph{Q}: How can we prove statements like the one above?
-
-%% \emph{A}: By \emph{structural induction} over lists.
-%% \es
-%% \bsh{Reminder: Natural Induction}
-
-%% Recall the proof principle of \emph{natural induction}:
-
-%% To show a property \mathtext{P(n)} for all numbers \mathtext{n \geq b}:
-%% \be
-%% \item Show that \mathtext{P(b)} holds (\emph{base case}).
-%% \item For arbitrary \mathtext{n \geq b} show:
-%% \begin{quote}
-%%      if \mathtext{P(n)} holds, then \mathtext{P(n+1)} holds as well
-%% \end{quote}
-%% (\emph{induction step}).
-%% \ee
-%% %\es\bs
-%% \emph{Example}: Given
-%% \begin{lstlisting}
-%% def factorial(n: Int): Int =
-%%   if (n == 0) 1
-%%   else n * factorial(n-1)
-%% \end{lstlisting}
-%% show that, for all \code{n >= 4},
-%% \begin{lstlisting}
-%%    factorial(n) >= 2$^n$
-%% \end{lstlisting}
-%% \es\bs
-%% \Case{\code{4}}
-%% is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
-
-%% \Case{\code{n+1}} 
-%% We have for \code{n >= 4}:
-%% \begin{lstlisting}
-%%     \= factorial(n + 1)
-%%  =     \> $\expl{by the second clause of factorial(*)}$
-%%        \> (n + 1) * factorial(n)
-%%  >=    \> $\expl{by calculation}$
-%%        \> 2 * factorial(n)
-%%  >=    \> $\expl{by the induction hypothesis}$
-%%        \> 2 * 2$^n$.
-%% \end{lstlisting}
-%% Note that in our proof we can freely apply reduction steps such as in (*)
-%% anywhere in a term.
-
-
-%% This works because purely functional programs do not have side
-%% effects; so a term is equivalent to the term it reduces to.
-
-%% The principle is called {\em\emph{referential transparency}}.
-%% \es
-%% \bsh{Structural Induction}
-
-%% The principle of structural induction is analogous to natural induction:
-
-%% In the case of lists, it is as follows:
-
-%% To prove a property \mathtext{P(xs)} for all lists \mathtext{xs},
-%% \be
-%% \item Show that \code{P(List())} holds (\emph{base case}).
-%% \item For arbitrary lists \mathtext{xs} and elements \mathtext{x} 
-%%       show:
-%% \begin{quote}
-%%      if \mathtext{P(xs)} holds, then \mathtext{P(x :: xs)} holds as well
-%% \end{quote}
-%% (\emph{induction step}).
-%% \ee
-
-%% \es
-%% \bsh{Example}
-
-%% We show \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} by structural induction
-%% on \code{xs}.
-
-%% \Case{\code{List()}}
-%% For the left-hand side, we have:
-%% \begin{lstlisting}
-%%     \= (List() ::: ys) ::: zs
-%%  =     \> $\expl{by first clause of \prog{:::}}$
-%%        \> ys ::: zs
-%% \end{lstlisting}
-%% For the right-hand side, we have:
-%% \begin{lstlisting}
-%%     \= List() ::: (ys ::: zs)
-%%  =     \> $\expl{by first clause of \prog{:::}}$
-%%        \> ys ::: zs
-%% \end{lstlisting}
-%% So the case is established.
-
-%% \es
-%% \bs
-%% \Case{\code{x :: xs}} 
-
-%% For the left-hand side, we have:
-%% \begin{lstlisting}
-%%     \= ((x :: xs) ::: ys) ::: zs
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> (x :: (xs ::: ys)) ::: zs
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> x :: ((xs ::: ys) ::: zs)
-%%  =     \> $\expl{by the induction hypothesis}$
-%%        \> x :: (xs ::: (ys ::: zs))
-%% \end{lstlisting}
-
-%% For the right-hand side, we have:
-%% \begin{lstlisting}
-%%     \= (x :: xs) ::: (ys ::: zs)
-%%  =     \> $\expl{by second clause of \prog{:::}}$
-%%        \> x :: (xs ::: (ys ::: zs))
-%% \end{lstlisting}
-%% So the case (and with it the property) is established.
-
-%% \begin{exercise}
+casa os padr\~{o}es $p_1 \commadots p_n$ na ordem em que eles s\~{a}o 
+escritos contra o valor seletor \code{e}.
+%----------
+
+%----------xpto
+\begin{itemize}
+\item
+A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
+are of type \code{C} (or a subtype thereof) and that have been constructed with 
+\code{C}-arguments matching patterns $p_1 \commadots p_n$.
+\item 
+A variable pattern \code{x} matches any value and binds the variable
+name to that value.  
+\item 
+The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
+\item A constant pattern \code{C} matches a value which is
+equal (in terms of \code{==}) to \code{C}.
+\end{itemize}
+The pattern matching expression rewrites to the right-hand-side of the
+first case whose pattern matches the selector value. References to
+pattern variables are replaced by corresponding constructor arguments.
+If none of the patterns matches, the pattern matching expression is
+aborted with a \code{MatchError} exception.
+
+%----------
+\example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
+\begin{lstlisting}
+     eval(Sum(Number(1), Number(2)))
+
+->   $\mbox{\tab\tab\rm(by rewriting the application)}$
+
+     Sum(Number(1), Number(2)) match {
+         case Number(n) => n
+         case Sum(e1, e2) => eval(e1) + eval(e2)
+     }
+
+->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+
+     eval(Number(1)) + eval(Number(2))
+
+->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
+
+     Number(1) match {
+         case Number(n) => n
+         case Sum(e1, e2) => eval(e1) + eval(e2)
+     } + eval(Number(2))
+
+->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+
+     1 + eval(Number(2))
+
+->$^*$ 1 + 2 -> 3
+\end{lstlisting}
+%----------
+
+\paragraph{Pattern Matching and Methods}
+In the previous example, we have used pattern
+matching in a function which was defined outside the class hierarchy
+over which it matches.  Of course, it is also possible to define a
+pattern matching function in that class hierarchy itself. For
+instance, we could have defined
+\code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
+\begin{lstlisting}
+abstract class Expr { 
+  def eval: Int = this match {
+    case Number(n) => n
+    case Sum(e1, e2) => e1.eval + e2.eval 
+  } 
+}
+\end{lstlisting}
+%----------
+
+
+\begin{exercise} Consider the following definitions representing trees
+of integers.  These definitions can be seen as an alternative
+representation of \code{IntSet}:
+\begin{lstlisting}
+abstract class IntTree
+case object EmptyTree extends IntTree
+case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
+\end{lstlisting}
+Complete the following implementations of function \code{contains} and \code{insert} for 
+\code{IntTree}'s.
+\begin{lstlisting}
+def contains(t: IntTree, v: Int): Boolean = t match { ...
+  ...
+}
+def insert(t: IntTree, v: Int): IntTree = t match { ...
+  ...
+}
+\end{lstlisting}
+\end{exercise}
+
+\paragraph{Pattern Matching Anonymous Functions}
+
+So far, case-expressions always appeared in conjunction with a
+\verb@match@ operation. But it is also possible to use
+case-expressions by themselves. A block of case-expressions such as
+\begin{lstlisting}
+{ case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
+\end{lstlisting}
+is seen by itself as a function which matches its arguments
+against the patterns $P_1 \commadots P_n$, and produces the result of
+one of $E_1 \commadots E_n$. (If no pattern matches, the function
+would throw a \code{MatchError} exception instead).
+In other words, the expression above is seen as a shorthand for the anonymous function
+\begin{lstlisting}
+(x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
+\end{lstlisting}
+where \code{x} is a fresh variable which is not used 
+otherwise in the expression.
+
+\chapter{Generic Types and Methods}
+
+Classes in Scala can have type parameters. We demonstrate the use of
+type parameters with functional stacks as an example. Say, we want to
+write a data type of stacks of integers, with methods \code{push},
+\code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
+following class hierarchy:
+\begin{lstlisting}
+abstract class IntStack {
+  def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
+  def isEmpty: Boolean
+  def top: Int
+  def pop: IntStack
+}
+class IntEmptyStack extends IntStack {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
+Of course, it would also make sense to define an abstraction for a
+stack of Strings. To do that, one could take the existing abstraction
+for \code{IntStack}, rename it to \code{StringStack} and at the same
+time rename all occurrences of type \code{Int} to \code{String}.
+
+A better way, which does not entail code duplication, is to
+parameterize the stack definitions with the element type.
+Parameterization lets us generalize from a specific instance of a
+problem to a more general one. So far, we have used parameterization
+only for values, but it is available also for types. To arrive at a
+{\em generic} version of \code{Stack}, we equip it with a type
+parameter.
+\begin{lstlisting}
+abstract class Stack[A] {
+  def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
+  def isEmpty: Boolean
+  def top: A
+  def pop: Stack[A]
+}
+class EmptyStack[A] extends Stack[A] {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
+In the definitions above, `\code{A}' is a {\em type parameter} of
+class \code{Stack} and its subclasses.  Type parameters are arbitrary
+names; they are enclosed in brackets instead of parentheses, so that
+they can be easily distinguished from value parameters.  Here is an
+example how the generic classes are used:
+\begin{lstlisting}
+val x = new EmptyStack[Int]
+val y = x.push(1).push(2)
+println(y.pop.top)
+\end{lstlisting}
+The first line creates a new empty stack of \code{Int}'s. Note the
+actual type argument \code{[Int]} which replaces the formal type
+parameter \code{A}.
+
+It is also possible to parameterize methods with types. As an example,
+here is a generic method which determines whether one stack is a
+prefix of another.
+\begin{lstlisting}
+def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
+  p.isEmpty ||
+  p.top == s.top && isPrefix[A](p.pop, s.pop)
+}
+\end{lstlisting}
+The method parameters are called {\em polymorphic}.  Generic methods are
+also called {\em polymorphic}.  The term comes from the Greek, where it
+means ``having many forms''.  To apply a polymorphic method such as
+\code{isPrefix}, we pass type parameters as well as value parameters
+to it. For instance,
+\begin{lstlisting}
+val s1 = new EmptyStack[String].push("abc")
+val s2 = new EmptyStack[String].push("abx").push(s1.top)
+println(isPrefix[String](s1, s2))
+\end{lstlisting}
+%----------
+
+\paragraph{Local Type Inference}
+Passing type parameters such as \code{[Int]} or \code{[String]} all
+the time can become tedious in applications where generic functions
+are used a lot. Quite often, the information in a type parameter is
+redundant, because the correct parameter type can also be determined
+by inspecting the function's value parameters or expected result type.
+Taking the expression \code{isPrefix[String](s1, s2)} as an
+example, we know that its value parameters are both of type
+\code{Stack[String]}, so we can deduce that the type parameter must
+be \code{String}. Scala has a fairly powerful type inferencer which
+allows one to omit type parameters to polymorphic functions and
+constructors in situations like these.  In the example above, one
+could have written \code{isPrefix(s1, s2)} and the missing type argument
+\code{[String]} would have been inserted by the type inferencer. 
+
+\section{Type Parameter Bounds}
+
+Now that we know how to make classes generic it is natural to
+generalize some of the earlier classes we have written. For instance
+class \code{IntSet} could be generalized to sets with arbitrary
+element types. Let's try. The abstract class for generic sets is easily
+written.
+\begin{lstlisting}
+abstract class Set[A] {
+  def incl(x: A): Set[A]
+  def contains(x: A): Boolean
+}
+\end{lstlisting}
+However, if we still want to implement sets as binary search trees, we
+encounter a problem. The \code{contains} and \code{incl} methods both
+compare elements using methods \code{<} and \code{>}. For
+\code{IntSet} this was OK, since type \code{Int} has these two
+methods. But for an arbitrary type parameter \code{a}, we cannot
+guarantee this. Therefore, the previous implementation of, say,
+\code{contains} would generate a compiler error.
+\begin{lstlisting}
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+          ^ < $\mbox{\sl not a member of type}$ A.
+\end{lstlisting}
+One way to solve the problem is to restrict the legal types that can
+be substituted for type \code{A} to only those types that contain methods
+\code{<} and \code{>} of the correct types. There is a trait
+\code{Ordered[A]} in the standard class library Scala which represents
+values which are comparable (via \code{<} and \code{>}) to values of
+type \code{A}. This trait is defined as follows:
+\begin{lstlisting}
+/** A class for totally ordered data. */
+trait Ordered[A] {
+
+  /** Result of comparing `this' with operand `that'.
+   *  returns `x' where
+   *  x < 0    iff    this < that
+   *  x == 0   iff    this == that
+   *  x > 0    iff    this > that
+   */
+  def compare(that: A): Int
+
+  def <  (that: A): Boolean = (this compare that) <  0
+  def >  (that: A): Boolean = (this compare that) >  0
+  def <= (that: A): Boolean = (this compare that) <= 0
+  def >= (that: A): Boolean = (this compare that) >= 0
+  def compareTo(that: A): Int = compare(that)
+}
+\end{lstlisting}
+We can enforce the comparability of a type by demanding
+that the type is a subtype of \code{Ordered}. This is done by giving an
+upper bound to the type parameter of \code{Set}:
+\begin{lstlisting}
+trait Set[A <: Ordered[A]] {
+  def incl(x: A): Set[A]
+  def contains(x: A): Boolean
+}
+\end{lstlisting}
+The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
+type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
+must be comparable to values of the same type.
+
+With this restriction, we can now implement the rest of the generic
+set abstraction as we did in the case of \code{IntSet}s before.
+
+\begin{lstlisting}
+class EmptySet[A <: Ordered[A]] extends Set[A] {
+  def contains(x: A): Boolean = false
+  def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
+}
+\end{lstlisting}
+
+\begin{lstlisting}
+class NonEmptySet[A <: Ordered[A]]
+        (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
+  def contains(x: A): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: A): Set[A] =
+    if (x < elem) new NonEmptySet(elem, left incl x, right)
+    else if (x > elem) new NonEmptySet(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
+Note that we have left out the type argument in the object creations
+\code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
+missing type arguments in constructor calls are inferred from value
+arguments and/or the expected result type.
+
+Here is an example that uses the generic set abstraction. Let's first
+create a subclass of \lstinline@Ordered@, like this:
+\begin{lstlisting}
+case class Num(value: Double) extends Ordered[Num] {
+  def compare(that: Num): Int =
+    if (this.value < that.value) -1
+    else if (this.value > that.value) 1
+    else 0
+}
+\end{lstlisting}
+Then:
+\begin{lstlisting}
+val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
+s.contains(Num(1.5))
+\end{lstlisting}
+This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
+However, the following example is in error.
+\begin{lstlisting}
+val s = new EmptySet[java.io.File]
+                    ^ java.io.File $\mbox{\sl does not conform to type}$
+                      $\mbox{\sl parameter bound}$ Ordered[java.io.File].
+\end{lstlisting}
+One probem with type parameter bounds is that they require
+forethought: if we had not declared \lstinline@Num@ a subclass of
+\lstinline@Ordered@, we would not have been able to use \lstinline@Num@
+elements in sets. By the same token, types inherited from Java, 
+such as \lstinline@Int@, \lstinline@Double@, or
+\lstinline@String@ are not subclasses of \lstinline@Ordered@, so
+values of these types cannot be used as set elements.
+
+A more flexible design, which admits elements of these types, uses
+{\em view bounds} instead of the plain type bounds we have seen so
+far. The only change this entails in the example above is in the type
+parameters:
+\begin{lstlisting}
+trait Set[A <% Ordered[A]] ...
+class EmptySet[A <% Ordered[A]] ...
+class NonEmptySet[A <% Ordered[A]] ...
+\end{lstlisting}
+View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
+A view bounded type parameter clause \lstinline@[A <% T]@ only
+specifies that the bounded type \lstinline@A@ must be {\em convertible} to
+the bound type \lstinline@T@, using an implicit conversion.
+
+The Scala library predefines implicit conversions for a number of
+types, including the primitive types and \lstinline@String@.
+Therefore, the redesign set abstraction can be instantiated with these
+types as well. More explanations on implicit conversions and view
+bounds are given in Section~\ref{sec:implicits}.
+
+\section{Variance Annotations}\label{sec:first-arrays}
+
+The combination of type parameters and subtyping poses some
+interesting questions. For instance, should \code{Stack[String]} be a
+subtype of \code{Stack[AnyRef]}? Intuitively, this seems OK, since a
+stack of \code{String}s is a special case of a stack of
+\code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
+then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
+This property is called {\em co-variant} subtyping.
+
+In Scala, generic types have by default non-variant subtyping. That
+is, with \code{Stack} defined as above, stacks with different element
+types would never be in a subtype relation. However, we can enforce
+co-variant subtyping of stacks by changing the first line of the
+definition of class \code{Stack} as follows.
+\begin{lstlisting}
+class Stack[+A] {
+\end{lstlisting}
+Prefixing a formal type parameter with a \code{+} indicates that
+subtyping is covariant in that parameter. 
+Besides \code{+}, there is also a prefix \code{-} which indicates
+contra-variant subtyping. If \code{Stack} was defined \code{class
+Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
+that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
+case of stacks would be rather surprising!).
+
+In a purely functional world, all types could be co-variant. However,
+the situation changes once we introduce mutable data. Consider the
+case of arrays in Java or .NET. Such arrays are represented in Scala
+by a generic class \code{Array}. Here is a partial definition of this
+class.
+\begin{lstlisting}
+class Array[A] {
+  def apply(index: Int): A
+  def update(index: Int, elem: A)
+}
+\end{lstlisting}
+The class above defines the way Scala arrays are seen from Scala user
+programs. The Scala compiler will map this abstraction to the
+underlying arrays of the host system in most cases where this
+possible.
+
+In Java, arrays are indeed covariant; that is, for reference types
+\code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
+\code{Array[T]} is a subtype of \code{Array[S]}. This might seem
+natural but leads to safety problems that require special runtime
+checks. Here is an example:
+\begin{lstlisting}
+val x = new Array[String](1)
+val y: Array[Any] = x
+y(0) = new Rational(1, 2)  // this is syntactic sugar for
+                           // y.update(0, new Rational(1, 2))
+\end{lstlisting}
+In the first line, a new array of strings is created. In the second
+line, this array is bound to a variable \code{y}, of type
+\code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
+\code{Array[String]} is a subtype of \code{Array[Any]}. Finally, in
+the last line a rational number is stored in the array. This is also
+OK, since type \code{Rational} is a subtype of the element type
+\code{Any} of the array \code{y}. We thus end up storing a rational
+number in an array of strings, which clearly violates type soundness. 
+
+Java solves this problem by introducing a run-time check in the third
+line which tests whether the stored element is compatible with the
+element type with which the array was created. We have seen in the
+example that this element type is not necessarily the static element
+type of the array being updated. If the test fails, an
+\code{ArrayStoreException} is raised.
+
+Scala solves this problem instead statically, by disallowing the
+second line at compile-time, because arrays in Scala have non-variant
+subtyping. This raises the question how a Scala compiler verifies that
+variance annotations are correct. If we had simply declared arrays
+co-variant, how would the potential problem have been detected?
+
+Scala uses a conservative approximation to verify soundness of
+variance annotations.  A covariant type parameter of a class may only
+appear in co-variant positions inside the class.  Among the co-variant
+positions are the types of values in the class, the result types of
+methods in the class, and type arguments to other covariant types. Not
+co-variant are types of formal method parameters. Hence, the following
+class definition would have been rejected
+\begin{lstlisting}
+class Array[+A] {
+  def apply(index: Int): A
+  def update(index: Int, elem: A)
+                               ^ $\mbox{\sl covariant type parameter}$ A
+                                 $\mbox{\sl appears in contravariant position.}$
+}
+\end{lstlisting}
+So far, so good. Intuitively, the compiler was correct in rejecting
+the \code{update} procedure in a co-variant class because \code{update}
+potentially changes state, and therefore undermines the soundness of
+co-variant subtyping. 
+
+However, there are also methods which do not mutate state, but where a
+type parameter still appears contra-variantly. An example is
+\code{push} in type \code{Stack}. Again the Scala compiler will reject
+the definition of this method for co-variant stacks.
+\begin{lstlisting}
+class Stack[+A] {
+  def push(x: A): Stack[A] =
+              ^ $\mbox{\sl covariant type parameter}$ A
+                $\mbox{\sl appears in contravariant position.}$
+\end{lstlisting}
+This is a pity, because, unlike arrays, stacks are purely functional data
+structures and therefore should enable co-variant subtyping. However,
+there is a a way to solve the problem by using a polymorphic method
+with a lower type parameter bound.
+
+\section{Lower Bounds}
+
+We have seen upper bounds for type parameters. In a type parameter
+declaration such as \code{T <: U}, the type parameter \code{T} is
+restricted to range only over subtypes of type \code{U}. Symmetrical
+to this are lower bounds in Scala. In a type parameter declaration
+\code{T >: S}, the type parameter \code{T} is restricted to range only
+over {\em supertypes} of type \code{S}. (One can also combine lower and
+upper bounds, as in \code{T >: S <: U}.)
+
+Using lower bounds, we can generalize the \code{push} method in
+\code{Stack} as follows.
+\begin{lstlisting}
+class Stack[+A] {
+  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+\end{lstlisting}
+Technically, this solves our variance problem since now the type
+parameter \code{A} appears no longer as a parameter type of method
+\code{push}. Instead, it appears as lower bound for another type
+parameter of a method, which is classified as a co-variant position.
+Hence, the Scala compiler accepts the new definition of \code{push}.
+
+In fact, we have not only solved the technical variance problem but
+also have generalized the definition of \code{push}.  Before, we were
+required to push only elements with types that conform to the declared
+element type of the stack. Now, we can push also elements of a
+supertype of this type, but the type of the returned stack will change
+accordingly. For instance, we can now push an \code{AnyRef} onto a
+stack of \code{String}s, but the resulting stack will be a stack of
+\code{AnyRef}s instead of a stack of \code{String}s!
+
+In summary, one should not hesitate to add variance annotations to
+your data structures, as this yields rich natural subtyping
+relationships. The compiler will detect potential soundness
+problems. Even if the compiler's approximation is too conservative, as
+in the case of method \code{push} of class \code{Stack}, this will
+often suggest a useful generalization of the contested method.
+
+\section{Least Types}
+
+Scala does not allow one to parameterize objects with types. That's
+why we originally defined a generic class \code{EmptyStack[A]}, even
+though a single value denoting empty stacks of arbitrary type would
+do. For co-variant stacks, however, one can use the following idiom:
+\begin{lstlisting}
+object EmptyStack extends Stack[Nothing] { ... }
+\end{lstlisting}
+The bottom type \code{Nothing} contains no value, so the type
+\code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
+contains no elements. Furthermore, \code{Nothing} is a subtype of all
+other types. Hence, for co-variant stacks, \code{Stack[Nothing]} is a
+subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
+possible to use a single empty stack object in user code. For
+instance:
+\begin{lstlisting}
+val s = EmptyStack.push("abc").push(new AnyRef())
+\end{lstlisting}
+Let's analyze the type assignment for this expression in detail.  The
+\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
+method
+\begin{lstlisting}
+push[B >: Nothing](elem: B): Stack[B] .
+\end{lstlisting}
+Local type inference will determine that the type parameter \code{B}
+should be instantiated to \code{String} in the application 
+\code{EmptyStack.push("abc")}. The result type of that application is hence
+\code{Stack[String]}, which in turn has a method
+\begin{lstlisting}
+push[B >: String](elem: B): Stack[B] .
+\end{lstlisting}
+The final part of the value definition above is the application of
+this method to \code{new AnyRef()}. Local type inference will
+determine that the type parameter \code{b} should this time be
+instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
+Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
+
+Besides \code{Nothing}, which is a subtype of every other type, there
+is also the type \code{Null}, which is a subtype of
+\code{scala.AnyRef}, and every class derived from it. The \code{null}
+literal in Scala is the only value of that type. This makes
+\code{null} compatible with every reference type, but not with a value
+type such as \code{Int}.
+
+We conclude this section with the complete improved definition of
+stacks. Stacks have now co-variant subtyping, the \code{push} method
+has been generalized, and the empty stack is represented by a single
+object.
+\begin{lstlisting}
+abstract class Stack[+A] {
+  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+  def isEmpty: Boolean
+  def top: A
+  def pop: Stack[A]
+}
+object EmptyStack extends Stack[Nothing] {
+  def isEmpty = true
+  def top = error("EmptyStack.top")
+  def pop = error("EmptyStack.pop")
+}
+class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
+  def isEmpty = false
+  def top = elem
+  def pop = rest
+}
+\end{lstlisting}
+Many classes in the Scala library are generic. We now present two
+commonly used families of generic classes, tuples and functions. The
+discussion of another common class, lists, is deferred to the next
+chapter.
+
+\section{Tuples}
+
+Sometimes, a function needs to return more than one result. For
+instance, take the function \code{divmod} which returns the integer quotient
+and rest of two given integer arguments.  Of course, one can define a
+class to hold the two results of \code{divmod}, as in:
+\begin{lstlisting}
+case class TwoInts(first: Int, second: Int)
+def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
+\end{lstlisting}
+However, having to define a new class for every possible pair of
+result types is very tedious. In Scala one can use instead a
+generic class \lstinline@Tuple$2$@, which is defined as follows:
+\begin{lstlisting}
+package scala
+case class Tuple2[A, B](_1: A, _2: B)
+\end{lstlisting}
+With \code{Tuple2}, the \code{divmod} method can be written as follows.
+\begin{lstlisting}
+def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
+\end{lstlisting}
+As usual, type parameters to constructors can be omitted if they are
+deducible from value arguments. There exist also tuple classes for
+every other number of elements (the current Scala implementation
+limits this to tuples of some reasonable number of elements).  
+
+\comment{
+Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
+\code{Triple} for \code{Tuple3}).  With these conventions,
+\code{divmod} can equivalently be written as follows.
+\begin{lstlisting}
+def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
+\end{lstlisting}
+}
+How are elements of tuples accessed? Since tuples are case classes,
+there are two possibilities. One can either access a tuple's fields
+using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
+\begin{lstlisting}
+val xy = divmod(x, y)
+println("quotient: " + xy._1 + ", rest: " + xy._2)
+\end{lstlisting}
+Or one uses pattern matching on tuples, as in the following example:
+\begin{lstlisting}
+divmod(x, y) match {
+  case Tuple2(n, d) =>
+    println("quotient: " + n + ", rest: " + d)
+}
+\end{lstlisting}
+Note that type parameters are never used in patterns; it would have
+been illegal to write case \code{Tuple2[Int, Int](n, d)}.
+
+Tuples are so convenient that Scala defines special syntax for
+them. To form a tuple with $n$ elements $x_1 \commadots x_n$ one can
+write $(x_1 \commadots x_n)$. This is equivalent to
+\lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
+equivalently for types and for patterns. With that tuple syntax, the
+\lstinline@divmod@ example is written as follows:
+\begin{lstlisting}
+def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
+divmod(x, y) match {
+  case (n, d) => println("quotient: " + n + ", rest: " + d)
+}
+\end{lstlisting}
+\section{Functions}\label{sec:functions}
+
+Scala is a functional language in that functions are first-class
+values.  Scala is also an object-oriented language in that every value
+is an object.  It follows that functions are objects in Scala.  For
+instance, a function from type \code{String} to type \code{Int} is
+represented as an instance of the trait \code{Function1[String, Int]}.
+The \code{Function1} trait is defined as follows.
+\begin{lstlisting}
+package scala
+trait Function1[-A, +B] {
+  def apply(x: A): B
+}
+\end{lstlisting}
+Besides \code{Function1}, there are also definitions of for functions
+of all other arities (the current implementation implements this only
+up to a reasonable limit).  That is, there is one definition for each
+possible number of function parameters.  Scala's function type syntax
+~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
+for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
+T_n, S$]@~.
+
+Scala uses the same syntax $f(x)$ for function application, no matter
+whether $f$ is a method or a function object. This is made possible by
+the following convention: A function application $f(x)$ where $f$ is
+an object (as opposed to a method) is taken to be a shorthand for
+\lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
+function type is inserted automatically where this is necessary.
+
+That's also why we defined array subscripting in
+Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
+array \code{a}, the subscript operation \code{a(i)} is taken to be a
+shorthand for \code{a.apply(i)}.
+
+Functions are an example where a contra-variant type parameter
+declaration is useful. For example, consider the following code:
+\begin{lstlisting}
+val f: (AnyRef => Int)  =  x => x.hashCode()
+val g: (String => Int)  =  f
+g("abc")
+\end{lstlisting}
+It's sound to bind the value \code{g} of type \code{String => Int} to
+\code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
+do with function of type \code{String => Int} is pass it a string in
+order to obtain an integer. Clearly, the same works for function
+\code{f}: If we pass it a string (or any other object), we obtain an
+integer.  This demonstrates that function subtyping is contra-variant
+in its argument type whereas it is covariant in its result type.
+In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
+$S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
+
+\example Consider the Scala code
+\begin{lstlisting}
+val plus1: (Int => Int)  =  (x: Int) => x + 1
+plus1(2)
+\end{lstlisting}
+This is expanded into the following object code.
+\begin{lstlisting}
+val plus1: Function1[Int, Int] = new Function1[Int, Int] {
+  def apply(x: Int): Int = x + 1
+}
+plus1.apply(2)
+\end{lstlisting}
+Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
+represents an instance of an {\em anonymous class}. It combines the
+creation of a new \code{Function1} object with an implementation of 
+the \code{apply} method (which is abstract in \code{Function1}).
+Equivalently, but more verbosely, one could have used a local class:
+\begin{lstlisting}
+val plus1: Function1[Int, Int] = {
+  class Local extends Function1[Int, Int] {
+    def apply(x: Int): Int = x + 1
+  }
+  new Local: Function1[Int, Int]
+}
+plus1.apply(2)
+\end{lstlisting}
+%----------
+
+\chapter{Lists}
+
+Lists are an important data structure in many Scala programs.  
+A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
+\code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
+\begin{lstlisting}
+val fruit = List("apples", "oranges", "pears")
+val nums  = List(1, 2, 3, 4)
+val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+val empty = List()
+\end{lstlisting}
+Lists are similar to arrays in languages such as C or Java, but there
+are also three important differences. First, lists are immutable. That
+is, elements of a list cannot be changed by assignment. Second, 
+lists have a recursive structure, whereas arrays are flat. Third,
+lists support a much richer set of operations than arrays usually do.
+
+\section{Using Lists}
+
+\paragraph{The List type}
+Like arrays, lists are {\em homogeneous}. That is, the elements of a
+list all have the same type.  The type of a list with elements of type
+\code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
+\begin{lstlisting}
+val fruit: List[String]    = List("apples", "oranges", "pears")
+val nums : List[Int]       = List(1, 2, 3, 4)
+val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+val empty: List[Int]       = List()
+\end{lstlisting}
+%----------
+
+\paragraph{List constructors}
+All lists are built from two more fundamental constructors, \code{Nil}
+and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
+list. The infix operator \code{::} expresses list extension. That is,
+\code{x :: xs} represents a list whose first element is \code{x},
+which is followed by (the elements of) list \code{xs}.  Hence, the
+list values above could also have been defined as follows (in fact
+their previous definition is simply syntactic sugar for the definitions below).
+\begin{lstlisting}
+val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
+val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
+val diag3  = (1 :: (0 :: (0 :: Nil))) ::
+             (0 :: (1 :: (0 :: Nil))) ::
+             (0 :: (0 :: (1 :: Nil))) :: Nil
+val empty  = Nil
+\end{lstlisting}
+The `\code{::}' operation associates to the right: \code{A :: B :: C} is
+interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
+parentheses in the definitions above. For instance, we can write
+shorter
+\begin{lstlisting}
+val nums  =  1 :: 2 :: 3 :: 4 :: Nil
+\end{lstlisting}
+%----------
+
+\paragraph{Basic operations on lists}
+All operations on lists can be expressed in terms of the following three:
+
+\begin{tabular}{ll}
+\code{head}  &  returns the first element of a list,\\
+\code{tail}  &  returns the list consisting of all elements except the\\
+& first element,\\
+\code{isEmpty} & returns \code{true} iff the list is empty
+\end{tabular}
+
+These operations are defined as methods of list objects. So we invoke
+them by selecting from the list that's operated on. Examples:
+\begin{lstlisting}
+empty.isEmpty   = true
+fruit.isEmpty   = false
+fruit.head      = "apples"
+fruit.tail.head = "oranges"
+diag3.head      = List(1, 0, 0)
+\end{lstlisting}
+The \code{head} and \code{tail} methods are defined only for non-empty
+lists.  When selected from an empty list, they throw an exception.
+
+As an example of how lists can be processed, consider sorting the
+elements of a list of numbers into ascending order. One simple way to
+do so is {\em insertion sort}, which works as follows: To sort a
+non-empty list with first element \code{x} and rest \code{xs}, sort
+the remainder \code{xs} and insert the element \code{x} at the right
+position in the result. Sorting an empty list will yield the
+empty list. Expressed as Scala code:
+\begin{lstlisting}
+def isort(xs: List[Int]): List[Int] =
+  if (xs.isEmpty) Nil
+  else insert(xs.head, isort(xs.tail))
+\end{lstlisting}
+%----------
+
+\begin{exercise} Provide an implementation of the missing function
+\code{insert}.
+\end{exercise}
+
+\paragraph{List patterns} In fact, \code{::} is defined as a case
+class in Scala's standard library. Hence, it is possible to decompose
+lists by pattern matching, using patterns composed from the \code{Nil}
+and \code{::} constructors. For instance, \code{isort} can be written
+alternatively as follows.
+\begin{lstlisting}
+def isort(xs: List[Int]): List[Int] = xs match {
+  case List() => List()
+  case x :: xs1 => insert(x, isort(xs1))
+}
+\end{lstlisting}
+onde
+\begin{lstlisting}
+def insert(x: Int, xs: List[Int]): List[Int] = xs match {
+  case List() => List(x)
+  case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
+}
+\end{lstlisting}
+%----------
+
+\section{Definition of class List I: First Order Methods}
+\label{sec:list-first-order}
+
+Lists are not built in in Scala; they are defined by an abstract class
+\code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
+In the following we present a tour through class \code{List}.
+\begin{lstlisting}
+package scala
+abstract class List[+A] {
+\end{lstlisting}
+\code{List} is an abstract class, so one cannot define elements by
+calling the empty \code{List} constructor (e.g. by
+\code{new List}).  The class has a type parameter \code{a}. It is
+co-variant in this parameter, which means that
+\code{List[S] <: List[T]} for all types \code{S} and \code{T} such that
+\code{S <: T}.  The class is situated in the package
+\code{scala}. This is a package containing the most important standard
+classes of Scala.
+ \code{List} defines a number of methods, which are
+explained in the following.
+
+\paragraph{Decomposing lists}
+First, there are the three basic methods \code{isEmpty},
+\code{head}, \code{tail}. Their implementation in terms of pattern
+matching is straightforward:
+\begin{lstlisting}
+def isEmpty: Boolean = this match {
+  case Nil => true
+  case x :: xs => false
+}
+def head: A = this match {
+  case Nil => error("Nil.head")
+  case x :: xs => x
+}
+def tail: List[A] = this match {
+  case Nil => error("Nil.tail")
+  case x :: xs => xs
+}
+\end{lstlisting}
+%----------
+
+The next function computes the length of a list.
+\begin{lstlisting}
+def length: Int = this match {
+  case Nil => 0
+  case x :: xs => 1 + xs.length
+}
+\end{lstlisting}
+\begin{exercise} Design a tail-recursive version of \code{length}.
+\end{exercise}
+
+The next two functions are the complements of \code{head} and
+\code{tail}.
+\begin{lstlisting}
+def last: A
+def init: List[A]
+\end{lstlisting}
+\code{xs.last} returns the last element of list \code{xs}, whereas
+\code{xs.init} returns all elements of \code{xs} except the last.
+Both functions have to traverse the entire list, and are thus less
+efficient than their \code{head} and \code{tail} analogues.
+Here is the implementation of \code{last}.
+\begin{lstlisting}
+def last: A = this match {
+  case Nil      => error("Nil.last")
+  case x :: Nil => x
+  case x :: xs  => xs.last
+}
+\end{lstlisting}
+The implementation of \code{init} is analogous.
+
+The next three functions return a prefix of the list, or a suffix, or
+both.
+\begin{lstlisting}
+def take(n: Int): List[A] =
+  if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
+
+def drop(n: Int): List[A] =
+  if (n == 0 || isEmpty) this else tail.drop(n-1)
+
+def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
+\end{lstlisting}
+\code{(xs take n)} returns the first \code{n} elements of list
+\code{xs}, or the whole list, if its length is smaller than \code{n}.
+\code{(xs drop n)} returns all elements of \code{xs} except the
+\code{n} first ones. Finally, \code{(xs split n)} returns a pair
+consisting of the lists resulting from \code{xs take n} and
+\code{xs drop n}.
+
+The next function returns an element at a given index in a list.
+It is thus analogous to array subscripting. Indices start at 0.
+\begin{lstlisting}
+def apply(n: Int): A = drop(n).head
+\end{lstlisting}
+The \code{apply} method has a special meaning in Scala. An object with
+an \code{apply} method can be applied to arguments as if it was a
+function. For instance, to pick the 3'rd element of a list \code{xs},
+one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
+expression expands into the first.
+
+With \code{take} and \code{drop}, we can extract sublists consisting
+of consecutive elements of the original list.  To extract the sublist
+$xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
+
+\begin{lstlisting}
+xs.drop(m).take(n - m)
+\end{lstlisting}
+%----------
+
+\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
+Given two lists
+\begin{lstlisting}
+xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
+ys = List(y$_1$, ..., y$_n$)   ,
+\end{lstlisting}
+\code{xs zip ys} constructs the list
+\lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
+If the two lists have different lengths, the longer one of the two is
+truncated. Here is the definition of \code{zip} -- note that it is a
+polymorphic method.
+\begin{lstlisting}
+def zip[B](that: List[B]): List[(a,b)] =
+  if (this.isEmpty || that.isEmpty) Nil
+  else (this.head, that.head) :: (this.tail zip that.tail)
+\end{lstlisting}
+%----------
+
+\paragraph{Consing lists.}
+Like any infix operator, \code{::}
+is also implemented as a method of an object. In this case, the object
+is the list that is extended. This is possible, because operators
+ending with a `\code{:}' character are treated specially in Scala.  
+All such operators are treated as methods of their right operand. E.g.,
+\begin{lstlisting}
+    x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
+\end{lstlisting}
+Note, however, that operands of a binary operation are in each case
+evaluated from left to right.  So, if \code{D} and \code{E} are
+expressions with possible side-effects, \code{D :: E} is translated to
+\lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
+order of operand evaluation.
+
+Another difference between operators ending in a `\code{:}' and other
+operators concerns their associativity.  Operators ending in
+`\code{:}' are right-associative, whereas other operators are
+left-associative.  E.g.,
+\begin{lstlisting}
+    x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
+\end{lstlisting}
+The definition of \code{::} as a method in
+class \code{List} is as follows:
+\begin{lstlisting}
+def ::[B >: A](x: B): List[B] = new scala.::(x, this)
+\end{lstlisting}
+Note that \code{::} is defined for all elements \code{x} of type
+\code{B} and lists of type \code{List[A]} such that the type \code{B}
+of \code{x} is a supertype of the list's element type \code{A}. The result
+is in this case a list of \code{B}'s. This
+is expressed by the type parameter \code{B} with lower bound \code{A}
+in the signature of \code{::}. 
+
+\paragraph{Concatenating lists}
+An operation similar to \code{::} is list concatenation, written
+`\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
+all elements of \code{xs}, followed by all elements of \code{ys}.
+Because it ends in a colon, \code{:::} is right-associative and is
+considered as a method of its right-hand operand. Therefore,
+\begin{lstlisting}
+xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
+                  =   zs.:::(ys).:::(xs)
+\end{lstlisting}
+Here is the implementation of the \code{:::} method:
+\begin{lstlisting}
+  def :::[B >: A](prefix: List[B]): List[B] = prefix match {
+    case Nil => this
+    case p :: ps => this.:::(ps).::(p)
+  }
+\end{lstlisting}
+%----------
+
+
+\paragraph{Reversing lists} Another useful operation
+is list reversal. There is a method \code{reverse} in \code{List} to
+that effect. Let's try to give its implementation:
+\begin{lstlisting}
+def reverse[A](xs: List[A]): List[A] = xs match {
+  case Nil => Nil
+  case x :: xs => reverse(xs) ::: List(x)
+}
+\end{lstlisting}
+This implementation has the advantage of being simple, but it is not
+very efficient.  Indeed, one concatenation is executed for every
+element in the list. List concatenation takes time proportional to the
+length of its first operand. Therefore, the complexity of
+\code{reverse(xs)} is
+\[
+n + (n - 1) + ... + 1 = n(n+1)/2
+\]
+where $n$ is the length of \code{xs}. Can \code{reverse} be
+implemented more efficiently? We will see later that there exists
+another implementation which has only linear complexity.
+
+\section{Example: Merge sort}
+
+The insertion sort presented earlier in this chapter is simple to
+formulate, but also not very efficient. It's average complexity is
+proportional to the square of the length of the input list. We now
+design a program to sort the elements of a list which is more
+efficient than insertion sort. A good algorithm for this is {\em merge
+sort}, which works as follows.
+
+First, if the list has zero or one elements, it is already sorted, so
+one returns the list unchanged. Longer lists are split into two
+sub-lists, each containing about half the elements of the original
+list. Each sub-list is sorted by a recursive call to the sort
+function, and the resulting two sorted lists are then combined in a
+merge operation.
+
+For a general implementation of merge sort, we still have to specify
+the type of list elements to be sorted, as well as the function to be
+used for the comparison of elements. We obtain a function of maximal
+generality by passing these two items as parameters. This leads to the
+following implementation.
+\begin{lstlisting}
+def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
+  def merge(xs1: List[A], xs2: List[A]): List[A] =
+    if (xs1.isEmpty) xs2
+    else if (xs2.isEmpty) xs1
+    else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
+    else xs2.head :: merge(xs1, xs2.tail)
+  val n = xs.length/2
+  if (n == 0) xs
+  else merge(msort(less)(xs take n), msort(less)(xs drop n))
+}
+\end{lstlisting}
+The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
+length of the input list. To see why, note that splitting a list in
+two and merging two sorted lists each take time proportional to the
+length of the argument list(s). Each recursive call of \code{msort}
+halves the number of elements in its input, so there are $O(log(N))$
+consecutive recursive calls until the base case of lists of length 1
+is reached.  However, for longer lists each call spawns off two
+further calls. Adding everything up we obtain that at each of the
+$O(log(N))$ call levels, every element of the original lists takes
+part in one split operation and in one merge operation. Hence, every
+call level has a total cost proportional to $O(N)$. Since there are
+$O(log(N))$ call levels, we obtain an overall cost of
+$O(N;log(N))$. That cost does not depend on the initial distribution
+of elements in the list, so the worst case cost is the same as the
+average case cost. This makes merge sort an attractive algorithm for
+sorting lists.
+
+Here is an example how \code{msort} is used.
+\begin{lstlisting}
+msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
+\end{lstlisting}
+The definition of \code{msort} is curried, to make it easy to specialize it with particular
+comparison functions. For instance,
+\begin{lstlisting}
+
+val intSort = msort((x: Int, y: Int) => x < y)
+val reverseSort = msort((x: Int, y: Int) => x > y)
+\end{lstlisting}
+
+\section{Definition of class List II: Higher-Order Methods}
+
+The examples encountered so far show that functions over lists often
+have similar structures. We can identify several patterns of
+computation over lists, like:
+\begin{itemize}
+      \item transforming every element of a list in some way.
+      \item extracting from a list all elements satisfying a criterion.
+      \item combine the elements of a list using some operator.
+\end{itemize}
+Functional programming languages enable programmers to write general
+functions which implement patterns like this by means of higher order
+functions. We now discuss a set of commonly used higher-order
+functions, which are implemented as methods in class \code{List}.
+
+\paragraph{Mapping over lists}
+A common operation is to transform each element of a list and then
+return the lists of results.  For instance, to scale each element of a
+list by a given factor.
+\begin{lstlisting}
+def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
+  case Nil => xs
+  case x :: xs1 => x * factor :: scaleList(xs1, factor)
+}
+\end{lstlisting}
+This pattern can be generalized to the \code{map} method of class \code{List}:
+\begin{lstlisting}
+abstract class List[A] { ...
+  def map[B](f: A => B): List[B] = this match {
+    case Nil => this
+    case x :: xs => f(x) :: xs.map(f)
+  }
+\end{lstlisting}
+Using \code{map}, \code{scaleList} can be more concisely written as follows.
+\begin{lstlisting}
+def scaleList(xs: List[Double], factor: Double) =
+  xs map (x => x * factor)
+\end{lstlisting}
+
+As another example, consider the problem of returning a given column
+of a matrix which is represented as a list of rows, where each row is
+again a list. This is done by the following function \code{column}.
+
+\begin{lstlisting}
+def column[A](xs: List[List[A]], index: Int): List[A] =
+  xs map (row => row(index))
+\end{lstlisting}
+
+Closely related to \code{map} is the \code{foreach} method, which
+applies a given function to all elements of a list, but does not
+construct a list of results. The function is thus applied only for its
+side effect. \code{foreach} is defined as follows.
+\begin{lstlisting}
+  def foreach(f: A => Unit) {
+    this match {
+      case Nil => ()
+      case x :: xs => f(x); xs.foreach(f)
+    }
+  }
+\end{lstlisting}
+This function can be used for printing all elements of a list, for instance:
+\begin{lstlisting}
+  xs foreach (x => println(x))
+\end{lstlisting} 
+
+\begin{exercise} Consider a function which squares all elements of a list and
+returns a list with the results. Complete the following two equivalent
+definitions of \code{squareList}.
+
+\begin{lstlisting}
+def squareList(xs: List[Int]): List[Int] = xs match {
+  case List() => ??
+  case y :: ys => ??
+}
+def squareList(xs: List[Int]): List[Int] =
+  xs map ??
+\end{lstlisting}
+\end{exercise}
+
+\paragraph{Filtering Lists}
+Another common operation selects from a list all elements fulfilling a
+given criterion. For instance, to return a list of all positive
+elements in some given lists of integers:
+\begin{lstlisting}
+def posElems(xs: List[Int]): List[Int] = xs match {
+  case Nil => xs
+  case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
+}
+\end{lstlisting}
+This pattern is generalized to the \code{filter} method of class \code{List}:
+\begin{lstlisting}
+  def filter(p: A => Boolean): List[A] = this match {
+    case Nil => this
+    case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
+  }
+\end{lstlisting}
+Using \code{filter}, \code{posElems} can be more concisely written as
+follows.
+\begin{lstlisting}
+def posElems(xs: List[Int]): List[Int] =
+  xs filter (x => x > 0)
+\end{lstlisting}
+
+An operation related to filtering is testing whether all elements of a
+list satisfy a certain condition. Dually, one might also be interested
+in the question whether there exists an element in a list that
+satisfies a certain condition. These operations are embodied in the
+higher-order functions \code{forall} and \code{exists} of class
+\code{List}.
+\begin{lstlisting}
+def forall(p: A => Boolean): Boolean =
+  isEmpty || (p(head) && (tail forall p))
+def exists(p: A => Boolean): Boolean =
+  !isEmpty && (p(head) || (tail exists p))
+\end{lstlisting}
+To illustrate the use of \code{forall}, consider the question of whether
+a number if prime. Remember that a number $n$ is prime of it can be
+divided without remainder only by one and itself. The most direct
+translation of this definition would test that $n$ divided by all
+numbers from 2 up to and excluding itself gives a non-zero
+remainder. This list of numbers can be generated using a function
+\code{List.range} which is defined in object \code{List} as follows.
+\begin{lstlisting}
+package scala
+object List { ...
+  def range(from: Int, end: Int): List[Int] =
+    if (from >= end) Nil else from :: range(from + 1, end)
+\end{lstlisting}
+For example, \code{List.range(2, n)}
+generates the list of all integers from 2 up to and excluding $n$.
+The function \code{isPrime} can now simply be defined as follows.
+\begin{lstlisting}
+def isPrime(n: Int) =
+  List.range(2, n) forall (x => n % x != 0)
+\end{lstlisting}
+We see that the mathematical definition of prime-ness has been
+translated directly into Scala code. 
+
+Exercise: Define \code{forall} and \code{exists} in terms of \code{filter}.
+
+
+\paragraph{Folding and Reducing Lists}
+Another common operation is to combine the elements of a list with
+some operator.  For instance:
+\begin{lstlisting}
+sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
+product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
+\end{lstlisting}
+Of course, we can implement both functions with a
+recursive scheme:
+\begin{lstlisting}
+def sum(xs: List[Int]): Int = xs match {
+  case Nil => 0
+  case y :: ys => y + sum(ys)
+}
+def product(xs: List[Int]): Int = xs match {
+  case Nil => 1
+  case y :: ys => y * product(ys)
+}
+\end{lstlisting}
+But we can also use the generalization of this program scheme embodied
+in the \code{reduceLeft} method of class \code{List}.  This method
+inserts a given binary operator between adjacent elements of a given list.
+E.g.\ 
+\begin{lstlisting}
+List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
+\end{lstlisting}
+Using \code{reduceLeft}, we can make the common pattern
+in \code{sum} and \code{product} apparent:
+\begin{lstlisting}
+def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
+def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
+\end{lstlisting}
+Here is the implementation of \code{reduceLeft}.
+\begin{lstlisting}
+  def reduceLeft(op: (A, A) => A): A = this match {
+    case Nil     => error("Nil.reduceLeft")
+    case x :: xs => (xs foldLeft x)(op)
+  }
+  def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
+    case Nil => z
+    case x :: xs => (xs foldLeft op(z, x))(op)
+  }
+}
+\end{lstlisting}
+We see that the \code{reduceLeft} method is defined in terms of
+another generally useful method, \code{foldLeft}.  The latter takes as
+additional parameter an {\em accumulator} \code{z}, which is returned
+when \code{foldLeft} is applied on an empty list. That is,
+\begin{lstlisting}
+(List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
+\end{lstlisting}
+The \code{sum} and \code{product} methods can be defined alternatively
+using \code{foldLeft}:
+\begin{lstlisting}
+def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
+def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
+\end{lstlisting}
+
+\paragraph{FoldRight and ReduceRight}
+Applications of \code{foldLeft} and \code{reduceLeft} expand to
+left-leaning trees. \todo{insert pictures}.  They have duals
+\code{foldRight} and \code{reduceRight}, which produce right-leaning
+trees.
+\begin{lstlisting}
+List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
+(List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
+\end{lstlisting}
+These are defined as follows.
+\begin{lstlisting}
+  def reduceRight(op: (A, A) => A): A = this match {
+    case Nil => error("Nil.reduceRight")
+    case x :: Nil => x
+    case x :: xs => op(x, xs.reduceRight(op))
+  }
+  def foldRight[B](z: B)(op: (A, B) => B): B = this match {
+    case Nil => z
+    case x :: xs => op(x, (xs foldRight z)(op))
+  }
+\end{lstlisting}
+
+Class \code{List} defines also two symbolic abbreviations for
+\code{foldLeft} and \code{foldRight}:
+\begin{lstlisting}
+  def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
+  def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
+\end{lstlisting}
+The method names picture the left/right leaning trees of the fold
+operations by forward or backward slashes. The \code{:} points in each
+case to the list argument whereas the end of the slash points to the
+accumulator (or: zero) argument \code{z}. 
+That is, 
+\begin{lstlisting}
+(z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
+(List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
+\end{lstlisting}
+For associative and commutative operators, \code{/:} and
+\code{:\\} are equivalent (even though there may be a difference
+in efficiency).  
+%But sometimes, only one of the two operators is
+%appropriate or has the right type:
+
+\begin{exercise} Consider the problem of writing a function \code{flatten},
+which takes a list of element lists as arguments. The result of
+\code{flatten} should be the concatenation of all element lists into a
+single list. Here is an implementation of this method in terms of 
+\code{:\\}.
+\begin{lstlisting}
+def flatten[A](xs: List[List[A]]): List[A] =
+  (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
+\end{lstlisting} 
+Consider replacing the body of \lstinline@flatten@
+by 
+\begin{lstlisting}
+  ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
+\end{lstlisting}
+What would be the difference in asymptotic
+complexity between the two versions of \lstinline@flatten@?
+
+In fact \code{flatten} is predefined together with a set of other
+userful function in an object called \code{List} in the standatd Scala
+library. It can be accessed from user program by calling
+\code{List.flatten}. Note that \code{flatten} is not a method of class
+\code{List} -- it would not make sense there, since it applies only
+to lists of lists, not to all lists in general.
+\end{exercise}
+
+\paragraph{List Reversal Again} We have seen in 
+Section~\ref{sec:list-first-order} an implementation of method
+\code{reverse} whose run-time was quadratic in the length of the list
+to be reversed. We now develop a new implementation of \code{reverse},
+which has linear cost.  The idea is to use a \code{foldLeft}
+operation based on the following program scheme.
+\begin{lstlisting}
+class List[+A] { ...
+  def reverse: List[A] = (z? /: this)(op?)
+\end{lstlisting}
+It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
+try to deduce them from examples.
+\begin{lstlisting}
+  Nil
+= Nil.reverse                 // by specification
+= (z /: Nil)(op)              // by the template for reverse
+= (Nil foldLeft z)(op)        // by the definition of /:
+= z                           // by definition of foldLeft
+\end{lstlisting}
+Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
+let's study reversal of a list of length one.
+\begin{lstlisting}
+  List(x)
+= List(x).reverse             // by specification
+= (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
+= (List(x) foldLeft Nil)(op)  // by the definition of /:
+= op(Nil, x)                  // by definition of foldLeft
+\end{lstlisting}
+Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
+as \code{x :: Nil}. This suggests to take as \code{op} the
+\code{::} operator with its operands exchanged.  Hence, we arrive at
+the following implementation for \code{reverse}, which has linear complexity.
+\begin{lstlisting}
+def reverse: List[A] =
+  ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
+\end{lstlisting}
+(Remark: The type annotation of \code{Nil} is necessary 
+to make the type inferencer work.)
+
+\begin{exercise} Fill in the missing expressions to complete the following
+definitions of some basic list-manipulation operations as fold
+operations.
+\begin{lstlisting}
+def mapFun[A, B](xs: List[A], f: A => B): List[B] =
+  (xs :\ List[B]()){ ?? }
+
+def lengthFun[A](xs: List[A]): int =
+  (0 /: xs){ ?? }
+\end{lstlisting}
+\end{exercise}
+
+\paragraph{Nested Mappings}
+
+We can employ higher-order list processing functions to express many
+computations that are normally expressed as nested loops in imperative
+languages. 
+
+As an example, consider the following problem: Given a positive
+integer $n$, find all pairs of positive integers $i$ and $j$, where 
+$1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
+the pairs are
+\bda{c|lllllll}
+i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
+j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
+i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
+\eda
+
+A natural way to solve this problem consists of two steps. In a first step,
+one generates the sequence of all pairs $(i, j)$ of integers such that
+$1 \leq j < i < n$. In a second step one then filters from this sequence
+all pairs $(i, j)$ such that $i + j$ is prime.
+
+Looking at the first step in more detail, a natural way to generate
+the sequence of pairs consists of three sub-steps.  First, generate
+all integers between $1$ and $n$ for $i$.  
+\item
+Second, for each integer $i$ between $1$ and $n$, generate the list of
+pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
+combination of \code{range} and \code{map}:
+\begin{lstlisting}
+  List.range(1, i) map (x => (i, x))
+\end{lstlisting}
+Finally, combine all sublists using \code{foldRight} with \code{:::}.
+Putting everything together gives the following expression:
+\begin{lstlisting}
+List.range(1, n)
+  .map(i => List.range(1, i).map(x => (i, x)))
+  .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
+  .filter(pair => isPrime(pair._1 + pair._2))
+\end{lstlisting}
+
+\paragraph{Flattening Maps}
+The combination of mapping and then concatenating sublists 
+resulting from the map
+is so common that we there is a special method 
+for it in class \code{List}:
+\begin{lstlisting}
+abstract class List[+A] { ...
+  def flatMap[B](f: A => List[B]): List[B] = this match {
+    case Nil => Nil
+    case x :: xs => f(x) ::: (xs flatMap f)
+  }
+}
+\end{lstlisting}
+With \code{flatMap}, the pairs-whose-sum-is-prime expression 
+could have been written more concisely as follows.
+\begin{lstlisting}
+List.range(1, n)
+  .flatMap(i => List.range(1, i).map(x => (i, x)))
+  .filter(pair => isPrime(pair._1 + pair._2))
+\end{lstlisting}
+
+
+
+\section{Summary}
+
+This chapter has introduced lists as a fundamental data structure in
+programming. Since lists are immutable, they are a common data type in
+functional programming languages. They have a role comparable to
+arrays in imperative languages. However, the access patterns between
+arrays and lists are quite different. Where array accessing is always
+done by indexing, this is much less common for lists.  We have seen
+that \code{scala.List} defines a method called \code{apply} for indexing
+however this operation is much more costly than in the case of arrays
+(linear as opposed to constant time). Instead of indexing, lists are
+usually traversed recursively, where recursion steps are usually based
+on a pattern match over the traversed list. There is also a rich set of
+higher-order combinators which allow one to instantiate a set of
+predefined patterns of computations over lists.
+
+\comment{
+\bsh{Reasoning About Lists}
+
+Recall the concatenation operation for lists:
+
+\begin{lstlisting}
+class List[+A] {
+  ...
+  def ::: (that: List[A]): List[A] =
+    if (isEmpty) that
+    else head :: (tail ::: that)
+}
+\end{lstlisting}
+
+We would like to verify that concatenation is associative, with the
+empty list \code{List()} as left and right identity:
+\bda{lcl}
+   (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
+   xs ::: List()          &=& xs \gap =\ List() ::: xs
+\eda
+\emph{Q}: How can we prove statements like the one above?
+
+\emph{A}: By \emph{structural induction} over lists.
+\es
+\bsh{Reminder: Natural Induction}
+
+Recall the proof principle of \emph{natural induction}:
+
+To show a property \mathtext{P(n)} for all numbers \mathtext{n \geq b}:
+\be
+\item Show that \mathtext{P(b)} holds (\emph{base case}).
+\item For arbitrary \mathtext{n \geq b} show:
+\begin{quote}
+     if \mathtext{P(n)} holds, then \mathtext{P(n+1)} holds as well
+\end{quote}
+(\emph{induction step}).
+\ee
+%\es\bs
+\emph{Example}: Given
+\begin{lstlisting}
+def factorial(n: Int): Int =
+  if (n == 0) 1
+  else n * factorial(n-1)
+\end{lstlisting}
+show that, for all \code{n >= 4},
+\begin{lstlisting}
+   factorial(n) >= 2$^n$
+\end{lstlisting}
+\es\bs
+\Case{\code{4}}
+is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
+
+\Case{\code{n+1}} 
+We have for \code{n >= 4}:
+\begin{lstlisting}
+    \= factorial(n + 1)
+ =     \> $\expl{by the second clause of factorial(*)}$
+       \> (n + 1) * factorial(n)
+ >=    \> $\expl{by calculation}$
+       \> 2 * factorial(n)
+ >=    \> $\expl{by the induction hypothesis}$
+       \> 2 * 2$^n$.
+\end{lstlisting}
+Note that in our proof we can freely apply reduction steps such as in (*)
+anywhere in a term.
+
+
+This works because purely functional programs do not have side
+effects; so a term is equivalent to the term it reduces to.
+
+The principle is called {\em\emph{referential transparency}}.
+\es
+\bsh{Structural Induction}
+
+The principle of structural induction is analogous to natural induction:
+
+In the case of lists, it is as follows:
+
+To prove a property \mathtext{P(xs)} for all lists \mathtext{xs},
+\be
+\item Show that \code{P(List())} holds (\emph{base case}).
+\item For arbitrary lists \mathtext{xs} and elements \mathtext{x} 
+      show:
+\begin{quote}
+     if \mathtext{P(xs)} holds, then \mathtext{P(x :: xs)} holds as well
+\end{quote}
+(\emph{induction step}).
+\ee
+
+\es
+\bsh{Example}
+
+We show \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} by structural induction
+on \code{xs}.
+
+\Case{\code{List()}}
+For the left-hand side, we have:
+\begin{lstlisting}
+    \= (List() ::: ys) ::: zs
+ =     \> $\expl{by first clause of \prog{:::}}$
+       \> ys ::: zs
+\end{lstlisting}
+For the right-hand side, we have:
+\begin{lstlisting}
+    \= List() ::: (ys ::: zs)
+ =     \> $\expl{by first clause of \prog{:::}}$
+       \> ys ::: zs
+\end{lstlisting}
+So the case is established.
+
+\es
+\bs
+\Case{\code{x :: xs}} 
+
+For the left-hand side, we have:
+\begin{lstlisting}
+    \= ((x :: xs) ::: ys) ::: zs
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> (x :: (xs ::: ys)) ::: zs
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> x :: ((xs ::: ys) ::: zs)
+ =     \> $\expl{by the induction hypothesis}$
+       \> x :: (xs ::: (ys ::: zs))
+\end{lstlisting}
+
+For the right-hand side, we have:
+\begin{lstlisting}
+    \= (x :: xs) ::: (ys ::: zs)
+ =     \> $\expl{by second clause of \prog{:::}}$
+       \> x :: (xs ::: (ys ::: zs))
+\end{lstlisting}
+So the case (and with it the property) is established.
+
+\begin{exercise}
 %% Show by induction on \code{xs} that \code{xs ::: List()  =  xs}.
-%% \es
-%% \bsh{Example (2)}
-%% \end{exercise}
-
-%% As a more difficult example, consider function
-%% \begin{lstlisting}
-%% abstract class List[A] { ...
-%%   def reverse: List[A] = this match {
-%%     case List() => List()
-%%     case x :: xs => xs.reverse ::: List(x)
-%%   }
-%% }
-%% \end{lstlisting}
-%% We would like to prove the proposition that
-%% \begin{lstlisting}
-%%    xs.reverse.reverse  =  xs  .
-%% \end{lstlisting}
-%% We proceed by induction over \code{xs}. The base case is easy to establish:
-%% \begin{lstlisting}
-%%     \= List().reverse.reverse
-%%  =     \> $\expl{by first clause of \prog{reverse}}$
-%%        \> List().reverse
-%%  =     \> $\expl{by first clause of \prog{reverse}}$
-%%        \> List()
-%% \end{lstlisting}
-%% \es\bs
-%% For the induction step, we try:
-%% \begin{lstlisting}
-%%     \= (x :: xs).reverse.reverse
-%%  =     \> $\expl{by second clause of \prog{reverse}}$
-%%        \> (xs.reverse ::: List(x)).reverse
-%% \end{lstlisting}
-%% There's nothing more we can do to this expression, so we turn to the right side:
-%% \begin{lstlisting}
-%%     \= x :: xs
-%%  =     \> $\expl{by induction hypothesis}$
-%%        \> x :: xs.reverse.reverse
-%% \end{lstlisting}
-%% The two sides have simplified to different expressions.
-
-%% So we still have to show that
-%% \begin{lstlisting}
-%%   (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
-%% \end{lstlisting}
-%% Trying to prove this directly by induction does not work.
-
-%% Instead we have to {\em generalize} the equation to:
-%% \begin{lstlisting}
-%%   (ys ::: List(x)).reverse  =  x :: ys.reverse
-%% \end{lstlisting}
-%% \es\bs
-%% This equation can be proved by a second induction argument over \code{ys}.
-%% (See blackboard).
-
-%% \begin{exercise}
-%% Is it the case that \code{(xs drop m) at n  =  xs at (m + n)} for all 
-%% natural numbers \code{m}, \code{n} and all lists \code{xs}?
-%% \end{exercise}
-
-%% \es
-%% \bsh{Structural Induction on Trees}
-
-%% Structural induction is not restricted to lists; it works for arbitrary
-%% trees.
-
-%% The general induction principle is as follows.
-
-%% To show that property \code{P(t)} holds for all trees of a certain type,
-%% \begin{itemize}
-%% \item Show \code{P(l)} for all leaf trees \code{$l$}.
-%% \item For every interior node \code{t} with subtrees \code{s$_1$, ..., s$_n$}, 
-%%       show that \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}.
-%% \end{itemize} 
-
-%% \example Recall our definition of \code{IntSet} with 
-%% operations \code{contains} and \code{incl}:
-
-%% \begin{lstlisting}
-%% abstract class IntSet {
-%%   abstract def incl(x: Int): IntSet
-%%   abstract def contains(x: Int): Boolean
-%% }
-%% \end{lstlisting}
-%% \es\bs
-%% \begin{lstlisting}
-%% case class Empty extends IntSet {
-%%   def contains(x: Int): Boolean = false
-%%   def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
-%% }
-%% case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
-%%   def contains(x: Int): Boolean =
-%%     if (x < elem) left contains x
-%%     else if (x > elem) right contains x
-%%     else true
-%%   def incl(x: Int): IntSet =
-%%     if (x < elem) NonEmpty(elem, left incl x, right)
-%%     else if (x > elem) NonEmpty(elem, left, right incl x)
-%%     else this
-%% }
-%% \end{lstlisting}
-%% (With \code{case} added, so that we can use factory methods instead of \code{new}).
-
-%% What does it mean to prove the correctness of this implementation?
-%% \es
-%% \bsh{Laws of IntSet}
-
-%% One way to state and prove the correctness of an implementation is
-%% to prove laws that hold for it.
-
-%% In the case of \code{IntSet}, three such laws would be:
-
-%% For all sets \code{s}, elements \code{x}, \code{y}:
-
-%% \begin{lstlisting}
-%% Empty contains x          \= =  false
-%% (s incl x) contains x     \> =  true
-%% (s incl x) contains y     \> =  s contains y         if x $\neq$ y
-%% \end{lstlisting}
-
-%% (In fact, one can show that these laws characterize the desired data
-%% type completely).
-
-%% How can we establish that these laws hold?
-
-%% \emph{Proposition 1}: \code{Empty contains x =  false}.
-
-%% \emph{Proof}: By the definition of \code{contains} in \code{Empty}.
-%% \es\bs
-%% \emph{Proposition 2}: \code{(xs incl x) contains x = true}
-
-%% \emph{Proof:}
-
-%% \Case{\code{Empty}}
-%% \begin{lstlisting}
-%%     \= (Empty incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
-%%        \> NonEmpty(x, Empty, Empty) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-%%        \> true
-%% \end{lstlisting}
-
-%% \Case{\code{NonEmpty(x, l, r)}}
-%% \begin{lstlisting}
-%%     \= (NonEmpty(x, l, r) incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-%%        \> NonEmpty(x, l, r) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
-%%        \> true
-%% \end{lstlisting}
-%% \es\bs
-%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-%% \begin{lstlisting}
-%%     \= (NonEmpty(y, l, r) incl x) contains x
-%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-%%        \> NonEmpty(y, l, r incl x) contains x
-%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-%%        \> (r incl x) contains x
-%%  =     \> $\expl{by the induction hypothesis}$
-%%        \> true
-%% \end{lstlisting}
-
-%% \Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
-
-%% \bigskip
-
-%% \emph{Proposition 3}: If \code{x $\neq$ y} then
-%% \code{xs incl y contains x  =  xs contains x}.
-
-%% \emph{Proof:} See blackboard.
-%% \es
-%% \bsh{Exercise}
-
-%% Say we add a \code{union} function to \code{IntSet}:
-
-%% \begin{lstlisting}
-%% class IntSet { ...
-%%   def union(other: IntSet): IntSet
-%% }
-%% class Expty extends IntSet { ...
-%%   def union(other: IntSet) = other
-%% }
-%% class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
-%%   def union(other: IntSet): IntSet = l union r union other incl x
-%% }
-%% \end{lstlisting}
-
-%% The correctness of \code{union} can be subsumed with the following
-%% law:
-
-%% \emph{Proposition 4}: 
-%% \code{(xs union ys) contains x  =  xs contains x || ys contains x}.
-%% Is that true ? What hypothesis is missing ? Show a counterexample.
-
-%% Show Proposition 4 using structural induction on \code{xs}.
-%% \es
-%% \comment{
-
-%% \emph{Proof:} By induction on \code{xs}.
-
-%% \Case{\code{Empty}}
-
-%% \Case{\code{NonEmpty(x, l, r)}}
-
-%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-
-%% \begin{lstlisting}
-%%     \= (Empty union ys) contains x 
-%%  =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
-%%         \> ys contains x
-%%  =      \> $\expl{Boolean algebra}$
-%%         \> false || ys contains x
-%%  =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
-%%         \> (Empty contains x) || (ys contains x)
-%% \end{lstlisting}
-
-%% \begin{lstlisting}
-%%     \= (NonEmpty(x, l, r) union ys) contains x
-%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-%%         \> (l union r union ys incl x) contains x
-%%  =      \> $\expl{by Proposition 2}$
-%%         \> true
-%%  =      \> $\expl{Boolean algebra}$
-%%         \> true || (ys contains x)
-%%  =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
-%%         \> (NonEmpty(x, l, r) contains x) || (ys contains x)
-%% \end{lstlisting}
-
-%% \begin{lstlisting}
-%%     \= (NonEmpty(y, l, r) union ys) contains x
-%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-%%         \> (l union r union ys incl y) contains x
-%%  =      \> $\expl{by Proposition 3}$
-%%         \> (l union r union ys) contains x
-%%  =      \> $\expl{by the induction hypothesis}$
-%%         \> ((l union r) contains x) || (ys contains x)
-%%  =      \> $\expl{by Proposition 3}$
-%%         \> ((l union r incl y) contains x) || (ys contains x)
-%% \end{lstlisting}
-
-%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-%%  ... is analogous.
-
-%% \es
-%% }}
-%% \chapter{\label{sec:for-notation}For-Comprehensions}
-
-%% The last chapter demonstrated that higher-order functions such as
-%% \verb@map@, \verb@flatMap@, \verb@filter@ provide powerful
-%% constructions for dealing with lists.  But sometimes the level of
-%% abstraction required by these functions makes a program hard to
-%% understand.
-
-%% To help understandability, Scala has a special notation which
-%% simplifies common patterns of applications of higher-order functions.
-%% This notation builds a bridge between set-comprehensions in
-%% mathematics and for-loops in imperative languages such as C or
-%% Java. It also closely resembles the query notation of relational
-%% databases.
-
-%% As a first example, say we are given a list \code{persons} of persons
-%% with \code{name} and \code{age} fields.  To print the names of all
-%% persons in the sequence which are aged over 20, one can write:
-%% \begin{lstlisting}
-%% for (p <- persons if p.age > 20) yield p.name
-%% \end{lstlisting}
-%% This is equivalent to the following expression , which uses
-%% higher-order functions \code{filter} and \code{map}:
-%% \begin{lstlisting}
-%% persons filter (p => p.age > 20) map (p => p.name)
-%% \end{lstlisting}
-%% The for-comprehension looks a bit like a for-loop in imperative languages,
-%% except that it constructs a list of the results of all iterations.
-
-%% Generally, a for-comprehension is of the form
-%% \begin{lstlisting}
-%% for ( $s$ ) yield $e$
-%% \end{lstlisting}
-%% Here, $s$ is a sequence of {\em generators}, {\em definitions} and
-%% {\em filters}.  A {\em generator} is of the form \code{val x <- e},
-%% where \code{e} is a list-valued expression. It binds \code{x} to
-%% successive values in the list.  A {\em definition} is of the form
-%% \code{val x = e}. It introduces \code{x} as a name for the value of
-%% \code{e} in the rest of the comprehension. A {\em filter} is an
-%% expression \code{f} of type \code{Boolean}.  It omits from
-%% consideration all bindings for which \code{f} is \code{false}.  The
-%% sequence $s$ starts in each case with a generator.  If there are
-%% several generators in a sequence, later generators vary more rapidly
-%% than earlier ones.
-
-%% The sequence $s$ may also be enclosed in braces instead of
-%% parentheses, in which case the semicolons between generators,
-%% definitions and filters can be omitted.
-
-%% Here are two examples that show how for-comprehensions are used.
-%% First, let's redo an example of the previous chapter: Given a positive
-%% integer $n$, find all pairs of positive integers $i$ and $j$, where $1
-%% \leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
-%% this problem is solved as follows:
-%% \begin{lstlisting}
-%% for { i <- List.range(1, n)
-%%       j <- List.range(1, i)
-%%       if isPrime(i+j) } yield {i, j}
-%% \end{lstlisting}
-%% This is arguably much clearer than the solution using \code{map},
-%% \code{flatMap} and \code{filter} that we have developed previously.
-
-%% As a second example, consider computing the scalar product of two
-%% vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
-%% be written as follows.
-%% \begin{lstlisting}
-%%   sum(for ((x, y) <- xs zip ys) yield x * y)
-%% \end{lstlisting}
-
-%% \section{The N-Queens Problem}
-
-%% For-comprehensions are especially useful for solving combinatorial
-%% puzzles. An example of such a puzzle is the 8-queens problem: Given a
-%% standard chess-board, place 8 queens such that no queen is in check from any
-%% other (a queen can check another piece if they are on the same
-%% column, row, or diagonal). We will now develop a solution to this
-%% problem, generalizing it to chess-boards of arbitrary size. Hence, the
-%% problem is to place $n$ queens on a chess-board of size $n \times n$.
-
-%% To solve this problem, note that we need to place a queen in each row.
-%% So we could place queens in successive rows, each time checking that a
-%% newly placed queen is not in check from any other queens that have
-%% already been placed. In the course of this search, it might arrive
-%% that a queen to be placed in row $k$ would be in check in all fields
-%% of that row from queens in row $1$ to $k-1$. In that case, we need to
-%% abort that part of the search in order to continue with a different
-%% configuration of queens in columns $1$ to $k-1$.
-
-%% This suggests a recursive algorithm.  Assume that we have already
-%% generated all solutions of placing $k-1$ queens on a board of size $n
-%% \times n$. We can represent each such solution by a list of length
-%% $k-1$ of column numbers (which can range from $1$ to $n$).  We treat
-%% these partial solution lists as stacks, where the column number of the
-%% queen in row $k-1$ comes first in the list, followed by the column
-%% number of the queen in row $k-2$, etc. The bottom of the stack is the
-%% column number of the queen placed in the first row of the board.  All
-%% solutions together are then represented as a list of lists, with one
-%% element for each solution.
-
-%% Now, to place the $k$'the queen, we generate all possible extensions
-%% of each previous solution by one more queen. This yields another list
-%% of solution lists, this time of length $k$. We continue the process
-%% until we have reached solutions of the size of the chess-board $n$.
-%% This algorithmic idea is embodied in function \code{placeQueens} below:
-%% \begin{lstlisting}
-%% def queens(n: Int): List[List[Int]] = {
-%%   def placeQueens(k: Int): List[List[Int]] =
-%%     if (k == 0) List(List())
-%%     else for { queens <- placeQueens(k - 1)
-%%                column <- List.range(1, n + 1)
-%%                if isSafe(column, queens, 1) } yield column :: queens
-%%   placeQueens(n)
-%% }
-%% \end{lstlisting}
-
-%% \begin{exercise} Write the function
-%% \begin{lstlisting}
-%%   def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
-%% \end{lstlisting}
-%% which tests whether a queen in the given column \verb@col@ is safe with 
-%% respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
-%% placed and the row of the first queen in the list.
-%% \end{exercise}
-
-%% \section{Querying with For-Comprehensions}
-
-%% The for-notation is essentially equivalent to common operations of
-%% database query languages.  For instance, say we are given a 
-%% database \code{books}, represented as a list of books, where
-%% \code{Book} is defined as follows.
-%% \begin{lstlisting}
-%% case class Book(title: String, authors: List[String])
-%% \end{lstlisting}
-%% Here is a small example database:
-%% \begin{lstlisting}
-%% val books: List[Book] = List(
-%%   Book("Structure and Interpretation of Computer Programs",
-%%        List("Abelson, Harold", "Sussman, Gerald J.")),
-%%   Book("Principles of Compiler Design",
-%%        List("Aho, Alfred", "Ullman, Jeffrey")),
-%%   Book("Programming in Modula-2",
-%%        List("Wirth, Niklaus")),
-%%   Book("Introduction to Functional Programming"),
-%%        List("Bird, Richard")),
-%%   Book("The Java Language Specification",
-%%        List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
-%% \end{lstlisting}
-%% Then, to find the titles of all books whose author's last name is ``Ullman'':
-%% \begin{lstlisting}
-%% for (b <- books; a <- b.authors if a startsWith "Ullman")
-%% yield b.title
-%% \end{lstlisting}
-%% (Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
-%% to find the titles of all books that have the string ``Program'' in
-%% their title:
-%% \begin{lstlisting}
-%% for (b <- books if (b.title indexOf "Program") >= 0)
-%% yield b.title
-%% \end{lstlisting}
-%% Or, to find the names of all authors that have written at least two
-%% books in the database.
-%% \begin{lstlisting}
-%% for (b1 <- books; b2 <- books if b1 != b2;
-%%      a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
-%% yield a1
-%% \end{lstlisting}
-%% The last solution is not yet perfect, because authors will appear
-%% several times in the list of results.  We still need to remove
-%% duplicate authors from result lists.  This can be achieved with the
-%% following function.
-%% \begin{lstlisting}
-%% def removeDuplicates[A](xs: List[A]): List[A] =
-%%   if (xs.isEmpty) xs
-%%   else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
-%% \end{lstlisting}
-%% Note that the last expression in method \code{removeDuplicates}
-%% can be equivalently expressed using a for-comprehension.
-%% \begin{lstlisting}
-%% xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
-%% \end{lstlisting}
-
-%% \section{Translation of For-Comprehensions}
-
-%% Every for-comprehension can be expressed in terms of the three
-%% higher-order functions \code{map}, \code{flatMap} and \code{filter}.
-%% Here is the translation scheme, which is also used by the Scala compiler.
-%% \begin{itemize}
-%% \item
-%% A simple for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e) yield e'
-%% \end{lstlisting}
-%% is translated to
-%% \begin{lstlisting}
-%% e.map(x => e')
-%% \end{lstlisting}
-%% \item
-%% A for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e if f; s) yield e'
-%% \end{lstlisting}
-%% where \code{f} is a filter and \code{s} is a (possibly empty)
-%% sequence of generators or filters
-%% is translated to
-%% \begin{lstlisting}
-%% for (x <- e.filter(x => f); s) yield e'
-%% \end{lstlisting}
-%% and then translation continues with the latter expression.
-%% \item
-%% A for-comprehension
-%% \begin{lstlisting}
-%% for (x <- e; y <- e'; s) yield e''
-%% \end{lstlisting}
-%% where \code{s} is a (possibly empty)
-%% sequence of generators or filters
-%% is translated to
-%% \begin{lstlisting}
-%% e.flatMap(x => for (y <- e'; s) yield e'')
-%% \end{lstlisting}
-%% and then translation continues with the latter expression.
-%% \end{itemize}
-%% For instance, taking our "pairs of integers whose sum is prime" example:
-%% \begin{lstlisting}
-%% for { i <- range(1, n)
-%%       j <- range(1, i)
-%%       if isPrime(i+j)
-%% } yield {i, j}
-%% \end{lstlisting}
-%% Here is what we get when we translate this expression:
-%% \begin{lstlisting}
-%% range(1, n)
-%%   .flatMap(i =>
-%%     range(1, i)
-%%       .filter(j => isPrime(i+j))
-%%       .map(j => (i, j)))
-%% \end{lstlisting}
-
-%% Conversely, it would also be possible to express functions \code{map},
-%% \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
-%% three functions again, this time implemented using for-comprehensions.
-%% \begin{lstlisting}
-%% object Demo {
-%%   def map[A, B](xs: List[A], f: A => B): List[B] =
-%%     for (x <- xs) yield f(x)
-
-%%   def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
-%%     for (x <- xs; y <- f(x)) yield y
-
-%%   def filter[A](xs: List[A], p: A => Boolean): List[A] =
-%%     for (x <- xs if p(x)) yield x
-%% }
-%% \end{lstlisting}
-%% Not surprisingly, the translation of the for-comprehension in the body of
-%% \code{Demo.map} will produce a call to \code{map} in class \code{List}.
-%% Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
-%% \code{flatMap} and \code{filter} in class \code{List}.
-
-%% \begin{exercise}
-%% Define the following function in terms of \code{for}.
-%% \begin{lstlisting}
-%% def flatten[A](xss: List[List[A]]): List[A] =
-%%   (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% \begin{exercise}
-%% Translate
-%% \begin{lstlisting}
-%% for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
-%% for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
-%% \end{lstlisting}
-%% to higher-order functions.
-%% \end{exercise}
-
-%% \section{For-Loops}\label{sec:for-loops}
-
-%% For-comprehensions resemble for-loops in imperative languages, except
-%% that they produce a list of results. Sometimes, a list of results is
-%% not needed but we would still like the flexibility of generators and
-%% filters in iterations over lists. This is made possible by a variant
-%% of the for-comprehension syntax, which expresses for-loops:
-%% \begin{lstlisting}
-%% for ( $s$ ) $e$
-%% \end{lstlisting}
-%% This construct is the same as the standard for-comprehension syntax
-%% except that the keyword \code{yield} is missing. The for-loop is
-%% executed by executing the expression $e$ for each element generated
-%% from the sequence of generators and filters $s$.
-
-%% As an example, the following expression prints out all elements of a
-%% matrix represented as a list of lists:
-%%  \begin{lstlisting}
-%% for (xs <- xss) {
-%%   for (x <- xs) print(x + "\t")
-%%   println()
-%% }
-%% \end{lstlisting}
-%% The translation of for-loops to higher-order methods of class
-%% \code{List} is similar to the translation of for-comprehensions, but
-%% is simpler. Where for-comprehensions translate to \code{map} and
-%% \code{flatMap}, for-loops translate in each case to \code{foreach}.
-
-%% \section{Generalizing For}
-
-%% We have seen that the translation of for-comprehensions only relies on
-%% the presence of methods \code{map}, \code{flatMap}, and
-%% \code{filter}. Therefore it is possible to apply the same notation to
-%% generators that produce objects other than lists; these objects only
-%% have to support the three key functions \code{map}, \code{flatMap},
-%% and \code{filter}.
-
-%% The standard Scala library has several other abstractions that support
-%% these three methods and with them support for-comprehensions. We will
-%% encounter some of them in the following chapters. As a programmer you
-%% can also use this principle to enable for-comprehensions for types you
-%% define -- these types just need to support methods \code{map},
-%% \code{flatMap}, and \code{filter}.
-
-%% There are many examples where this is useful: Examples are database
-%% interfaces, XML trees, or optional values. 
-
-%% One caveat: It is not assured automatically that the result
-%% translating a for-comprehension is well-typed. To ensure this, the
-%% types of \code{map}, \code{flatMap} and \code{filter} have to be
-%% essentially similar to the types of these methods in class \code{List}.
-
-%% To make this precise, assume you have a parameterized class
-%%  \code{C[A]} for which you want to enable for-comprehensions. Then
-%%  \code{C} should define \code{map}, \code{flatMap} and \code{filter}
-%%  with the following types:
-%% \begin{lstlisting}
-%% def map[B](f: A => B): C[B]
-%% def flatMap[B](f: A => C[B]): C[B]
-%% def filter(p: A => Boolean): C[A]
-%% \end{lstlisting}
-%% It would be attractive to enforce these types statically in the Scala
-%% compiler, for instance by requiring that any type supporting
-%% for-comprehensions implements a standard trait with these methods
-%% \footnote{In the programming language Haskell, which has similar
-%% constructs, this abstraction is called a ``monad with zero''}.  The
-%% problem is that such a standard trait would have to abstract over the
-%% identity of the class \code{C}, for instance by taking \code{C} as a
-%% type parameter.  Note that this parameter would be a type constructor,
-%% which gets applied to {\em several different} types in the signatures of
-%% methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
-%% system is too weak to express this construct, since it can handle only
-%% type parameters which are fully applied types.
-
-%% \chapter{Mutable State}
-
-%% Most programs we have presented so far did not have side-effects
-%% \footnote{We ignore here the fact that some of our program printed to
-%% standard output, which technically is a side effect.}.  Therefore, the
-%% notion of {\em time} did not matter.  For a program that terminates,
-%% any sequence of actions would have led to the same result!  This is
-%% also reflected by the substitution model of computation, where a
-%% rewrite step can be applied anywhere in a term, and all rewritings
-%% that terminate lead to the same solution.  In fact, this {\em
-%% confluence} property is a deep result in $\lambda$-calculus, the
-%% theory underlying functional programming. 
-
-%% In this chapter, we introduce functions with side effects and study
-%% their behavior. We will see that as a consequence we have to
-%% fundamentally modify up the substitution model of computation which we
-%% employed so far.
-
-%% \section{Stateful Objects}
-
-%% We normally view the world as a set of objects, some of which have
-%% state that {\em changes} over time.  Normally, state is associated
-%% with a set of variables that can be changed in the course of a
-%% computation.  There is also a more abstract notion of state, which
-%% does not refer to particular constructs of a programming language: An
-%% object {\em has state} (or: {\em is stateful}) if its behavior is
-%% influenced by its history.
-
-%% For instance, a bank account object has state, because the question
-%% ``can I withdraw 100 CHF?''
-%% might have different answers during the lifetime of the account.
-
-%% In Scala, all mutable state is ultimately built from variables.  A
-%% variable definition is written like a value definition, but starts
-%% with \verb@var@ instead of \verb@val@. For instance, the following two
-%% definitions introduce and initialize two variables \code{x} and
-%% \code{count}.
-%% \begin{lstlisting}
-%% var x: String = "abc"
-%% var count = 111
-%% \end{lstlisting}
-%% Like a value definition, a variable definition associates a name with
-%% a value. But in the case of a variable definition, this association
-%% may be changed later by an assignment.  Such assignments are written
-%% as in C or Java. Examples:
-%% \begin{lstlisting}
-%% x = "hello"
-%% count = count + 1
-%% \end{lstlisting}
-%% In Scala, every defined variable has to be initialized at the point of
-%% its definition. For instance, the statement ~\code{var x: Int;}~ is
-%% {\em not} regarded as a variable definition, because the initializer
-%% is missing\footnote{If a statement like this appears in a class, it is
-%% instead regarded as a variable declaration, which introduces
-%% abstract access methods for the variable, but does not associate these
-%% methods with a piece of state.}. If one does not know, or does not
-%% care about, the appropriate initializer, one can use a wildcard
-%% instead. I.e.
-%% \begin{lstlisting}
-%% val x: T = _
-%% \end{lstlisting}
-%% will initialize \code{x} to some default value (\code{null} for
-%% reference types, \code{false} for booleans, and the appropriate
-%% version of \code{0} for numeric value types).
-
-%% Real-world objects with state are represented in Scala by objects that
-%% have variables as members. For instance, here is a class that
-%% represents bank accounts.
-%% \begin{lstlisting}
-%% class BankAccount {
-%%   private var balance = 0
-%%   def deposit(amount: Int) {
-%%     if (amount > 0) balance += amount
-%%   }
-
-%%   def withdraw(amount: Int): Int =
-%%     if (0 < amount && amount <= balance) {
-%%       balance -= amount
-%%       balance
-%%     } else error("insufficient funds")
-%% }
-%% \end{lstlisting}
-%% The class defines a variable \code{balance} which contains the current
-%% balance of an account. Methods \code{deposit} and \code{withdraw}
-%% change the value of this variable through assignments.  Note that
-%% \code{balance} is \code{private} in class \code{BankAccount} -- hence
-%% it can not be accessed directly outside the class.
-
-%% To create bank-accounts, we use the usual object creation notation:
-%% \begin{lstlisting}
-%% val myAccount = new BankAccount
-%% \end{lstlisting}
-
-%% \example Here is a \code{scalaint} session that deals with bank
-%% accounts.
-
-%% \begin{lstlisting}
-%% scala> :l bankaccount.scala
-%% Loading bankaccount.scala...
-%% defined class BankAccount
-%% scala> val account = new BankAccount
-%% account: BankAccount = BankAccount$\Dollar$class@1797795
-%% scala> account deposit 50
-%% unnamed0: Unit = ()
-%% scala> account withdraw 20
-%% unnamed1: Int = 30
-%% scala> account withdraw 20
-%% unnamed2: Int = 10
-%% scala> account withdraw 15
-%% java.lang.Error: insufficient funds
-%%         at scala.Predef$\Dollar$error(Predef.scala:74)
-%%         at BankAccount$\Dollar$class.withdraw(<console>:14)
-%%         at <init>(<console>:5)
-%% scala> 
-%% \end{lstlisting}
-%% The example shows that applying the same operation (\code{withdraw
-%% 20}) twice to an account yields different results. So, clearly,
-%% accounts are stateful objects.  
-
-%% \paragraph{Sameness and Change}
-%% Assignments pose new problems in deciding when two expressions are
-%% ``the same''.
-%% If assignments are excluded, and one writes
-%% \begin{lstlisting}
-%% val x = E; val y = E
-%% \end{lstlisting}
-%% where \code{E} is some arbitrary expression,
-%% then \code{x} and \code{y} can reasonably be assumed to be the same.
-%% I.e. one could have equivalently written
-%% \begin{lstlisting}
-%% val x = E; val y = x
-%% \end{lstlisting}
-%% (This property is usually called {\em referential transparency}). But
-%% once we admit assignments, the two definition sequences are different.
-%% Consider:
-%% \begin{lstlisting}
-%% val x = new BankAccount; val y = new BankAccount
-%% \end{lstlisting}
-%% To answer the question whether \code{x} and \code{y} are the same, we
-%% need to be more precise what ``sameness'' means. This meaning is
-%% captured in the notion of {\em operational equivalence}, which,
-%% somewhat informally, is stated as follows.
-
-%% Suppose we have two definitions of \code{x} and \code{y}.
-%% To test whether \code{x} and \code{y} define the same value, proceed
-%% as follows.
-%% \begin{itemize}
-%% \item
-%% Execute the definitions followed by an
-%% arbitrary sequence \code{S} of operations that involve \code{x} and
-%% \code{y}. Observe the results (if any).
-%% \item
-%% Then, execute the definitions with another sequence \code{S'} which
-%% results from \code{S} by renaming all occurrences of \code{y} in
-%% \code{S} to \code{x}.
-%% \item
-%% If the results of running \code{S'} are different, then surely
-%% \code{x} and \code{y} are different.
-%% \item
-%% On the other hand, if all possible pairs of sequences \lstinline@{S, S'}@
-%% yield the same results, then \code{x} and \code{y} are the same.
-%% \end{itemize}
-%% In other words, operational equivalence regards two definitions
-%% \code{x} and \code{y} as defining the same value, if no possible
-%% experiment can distinguish between \code{x} and \code{y}. An
-%% experiment in this context are two version of an arbitrary program which use either
-%% \code{x} or \code{y}.
+Mostre por indu\c{c}\~{a}o que dado \code{xs} temos \code{xs ::: List() = xs}. 
+\es
+\bsh{Example (2)}
+\end{exercise}
+
+Como um exemplo mais dif\'{i}cil, considere a fun\c{c}\~{a}o
+\begin{lstlisting}
+abstract class List[A] { ...
+  def reverse: List[A] = this match {
+    case List() => List()
+    case x :: xs => xs.reverse ::: List(x)
+  }
+}
+\end{lstlisting}
+We would like to prove the proposition that
+\begin{lstlisting}
+   xs.reverse.reverse  =  xs  .
+\end{lstlisting}
+We proceed by induction over \code{xs}. The base case is easy to establish:
+\begin{lstlisting}
+    \= List().reverse.reverse
+ =     \> $\expl{by first clause of \prog{reverse}}$
+       \> List().reverse
+ =     \> $\expl{by first clause of \prog{reverse}}$
+       \> List()
+\end{lstlisting}
+\es\bs
+For the induction step, we try:
+\begin{lstlisting}
+    \= (x :: xs).reverse.reverse
+ =     \> $\expl{by second clause of \prog{reverse}}$
+       \> (xs.reverse ::: List(x)).reverse
+\end{lstlisting}
+There's nothing more we can do to this expression, so we turn to the right side:
+\begin{lstlisting}
+    \= x :: xs
+ =     \> $\expl{by induction hypothesis}$
+       \> x :: xs.reverse.reverse
+\end{lstlisting}
+The two sides have simplified to different expressions.
+
+So we still have to show that
+\begin{lstlisting}
+  (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
+\end{lstlisting}
+Trying to prove this directly by induction does not work.
+
+Instead we have to {\em generalize} the equation to:
+\begin{lstlisting}
+  (ys ::: List(x)).reverse  =  x :: ys.reverse
+\end{lstlisting}
+\es\bs
+This equation can be proved by a second induction argument over \code{ys}.
+(See blackboard).
+
+\begin{exercise}
+Is it the case that \code{(xs drop m) at n  =  xs at (m + n)} for all 
+natural numbers \code{m}, \code{n} and all lists \code{xs}?
+\end{exercise}
+
+\es
+\bsh{Structural Induction on Trees}
+
+Structural induction is not restricted to lists; it works for arbitrary
+trees.
+
+The general induction principle is as follows.
+
+To show that property \code{P(t)} holds for all trees of a certain type,
+\begin{itemize}
+\item Show \code{P(l)} for all leaf trees \code{$l$}.
+\item For every interior node \code{t} with subtrees \code{s$_1$, ..., s$_n$}, 
+      show that \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}.
+\end{itemize} 
+
+\example Recall our definition of \code{IntSet} with 
+operations \code{contains} and \code{incl}:
+
+\begin{lstlisting}
+abstract class IntSet {
+  abstract def incl(x: Int): IntSet
+  abstract def contains(x: Int): Boolean
+}
+\end{lstlisting}
+\es\bs
+\begin{lstlisting}
+case class Empty extends IntSet {
+  def contains(x: Int): Boolean = false
+  def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
+}
+case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
+  def contains(x: Int): Boolean =
+    if (x < elem) left contains x
+    else if (x > elem) right contains x
+    else true
+  def incl(x: Int): IntSet =
+    if (x < elem) NonEmpty(elem, left incl x, right)
+    else if (x > elem) NonEmpty(elem, left, right incl x)
+    else this
+}
+\end{lstlisting}
+(With \code{case} added, so that we can use factory methods instead of \code{new}).
+
+What does it mean to prove the correctness of this implementation?
+\es
+\bsh{Laws of IntSet}
+
+One way to state and prove the correctness of an implementation is
+to prove laws that hold for it.
+
+In the case of \code{IntSet}, three such laws would be:
+
+For all sets \code{s}, elements \code{x}, \code{y}:
+
+\begin{lstlisting}
+Empty contains x          \= =  false
+(s incl x) contains x     \> =  true
+(s incl x) contains y     \> =  s contains y         if x $\neq$ y
+\end{lstlisting}
+
+(In fact, one can show that these laws characterize the desired data
+type completely).
+
+How can we establish that these laws hold?
+
+\emph{Proposition 1}: \code{Empty contains x =  false}.
+
+\emph{Proof}: By the definition of \code{contains} in \code{Empty}.
+\es\bs
+\emph{Proposition 2}: \code{(xs incl x) contains x = true}
+
+\emph{Proof:}
+
+\Case{\code{Empty}}
+\begin{lstlisting}
+    \= (Empty incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
+       \> NonEmpty(x, Empty, Empty) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+       \> true
+\end{lstlisting}
+
+\Case{\code{NonEmpty(x, l, r)}}
+\begin{lstlisting}
+    \= (NonEmpty(x, l, r) incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+       \> NonEmpty(x, l, r) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
+       \> true
+\end{lstlisting}
+\es\bs
+\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+\begin{lstlisting}
+    \= (NonEmpty(y, l, r) incl x) contains x
+ =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+       \> NonEmpty(y, l, r incl x) contains x
+ =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+       \> (r incl x) contains x
+ =     \> $\expl{by the induction hypothesis}$
+       \> true
+\end{lstlisting}
+
+\Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
+
+\bigskip
+
+\emph{Proposition 3}: If \code{x $\neq$ y} then
+\code{xs incl y contains x  =  xs contains x}.
+
+\emph{Proof:} See blackboard.
+\es
+\bsh{Exercise}
+
+Say we add a \code{union} function to \code{IntSet}:
+
+\begin{lstlisting}
+class IntSet { ...
+  def union(other: IntSet): IntSet
+}
+class Expty extends IntSet { ...
+  def union(other: IntSet) = other
+}
+class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
+  def union(other: IntSet): IntSet = l union r union other incl x
+}
+\end{lstlisting}
+
+The correctness of \code{union} can be subsumed with the following
+law:
+
+\emph{Proposition 4}: 
+\code{(xs union ys) contains x  =  xs contains x || ys contains x}.
+Is that true ? What hypothesis is missing ? Show a counterexample.
+
+Show Proposition 4 using structural induction on \code{xs}.
+\es
+\comment{
+
+\emph{Proof:} By induction on \code{xs}.
+
+\Case{\code{Empty}}
+
+\Case{\code{NonEmpty(x, l, r)}}
+
+\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+
+\begin{lstlisting}
+    \= (Empty union ys) contains x 
+ =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
+        \> ys contains x
+ =      \> $\expl{Boolean algebra}$
+        \> false || ys contains x
+ =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
+        \> (Empty contains x) || (ys contains x)
+\end{lstlisting}
+
+\begin{lstlisting}
+    \= (NonEmpty(x, l, r) union ys) contains x
+ =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+        \> (l union r union ys incl x) contains x
+ =      \> $\expl{by Proposition 2}$
+        \> true
+ =      \> $\expl{Boolean algebra}$
+        \> true || (ys contains x)
+ =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
+        \> (NonEmpty(x, l, r) contains x) || (ys contains x)
+\end{lstlisting}
+
+\begin{lstlisting}
+    \= (NonEmpty(y, l, r) union ys) contains x
+ =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+        \> (l union r union ys incl y) contains x
+ =      \> $\expl{by Proposition 3}$
+        \> (l union r union ys) contains x
+ =      \> $\expl{by the induction hypothesis}$
+        \> ((l union r) contains x) || (ys contains x)
+ =      \> $\expl{by Proposition 3}$
+        \> ((l union r incl y) contains x) || (ys contains x)
+\end{lstlisting}
+
+\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+ ... is analogous.
+
+\es
+}}
+\chapter{\label{sec:for-notation}For-Comprehensions}
+
+The last chapter demonstrated that higher-order functions such as
+\verb@map@, \verb@flatMap@, \verb@filter@ provide powerful
+constructions for dealing with lists.  But sometimes the level of
+abstraction required by these functions makes a program hard to
+understand.
+
+To help understandability, Scala has a special notation which
+simplifies common patterns of applications of higher-order functions.
+This notation builds a bridge between set-comprehensions in
+mathematics and for-loops in imperative languages such as C or
+Java. It also closely resembles the query notation of relational
+databases.
+
+As a first example, say we are given a list \code{persons} of persons
+with \code{name} and \code{age} fields.  To print the names of all
+persons in the sequence which are aged over 20, one can write:
+\begin{lstlisting}
+for (p <- persons if p.age > 20) yield p.name
+\end{lstlisting}
+This is equivalent to the following expression , which uses
+higher-order functions \code{filter} and \code{map}:
+\begin{lstlisting}
+persons filter (p => p.age > 20) map (p => p.name)
+\end{lstlisting}
+The for-comprehension looks a bit like a for-loop in imperative languages,
+except that it constructs a list of the results of all iterations.
+
+Generally, a for-comprehension is of the form
+\begin{lstlisting}
+for ( $s$ ) yield $e$
+\end{lstlisting}
+Here, $s$ is a sequence of {\em generators}, {\em definitions} and
+{\em filters}.  A {\em generator} is of the form \code{val x <- e},
+where \code{e} is a list-valued expression. It binds \code{x} to
+successive values in the list.  A {\em definition} is of the form
+\code{val x = e}. It introduces \code{x} as a name for the value of
+\code{e} in the rest of the comprehension. A {\em filter} is an
+expression \code{f} of type \code{Boolean}.  It omits from
+consideration all bindings for which \code{f} is \code{false}.  The
+sequence $s$ starts in each case with a generator.  If there are
+several generators in a sequence, later generators vary more rapidly
+than earlier ones.
+
+The sequence $s$ may also be enclosed in braces instead of
+parentheses, in which case the semicolons between generators,
+definitions and filters can be omitted.
+
+Here are two examples that show how for-comprehensions are used.
+First, let's redo an example of the previous chapter: Given a positive
+integer $n$, find all pairs of positive integers $i$ and $j$, where $1
+\leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
+this problem is solved as follows:
+\begin{lstlisting}
+for { i <- List.range(1, n)
+      j <- List.range(1, i)
+      if isPrime(i+j) } yield {i, j}
+\end{lstlisting}
+This is arguably much clearer than the solution using \code{map},
+\code{flatMap} and \code{filter} that we have developed previously.
+
+As a second example, consider computing the scalar product of two
+vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
+be written as follows.
+\begin{lstlisting}
+  sum(for ((x, y) <- xs zip ys) yield x * y)
+\end{lstlisting}
+
+\section{The N-Queens Problem}
+
+For-comprehensions are especially useful for solving combinatorial
+puzzles. An example of such a puzzle is the 8-queens problem: Given a
+standard chess-board, place 8 queens such that no queen is in check from any
+other (a queen can check another piece if they are on the same
+column, row, or diagonal). We will now develop a solution to this
+problem, generalizing it to chess-boards of arbitrary size. Hence, the
+problem is to place $n$ queens on a chess-board of size $n \times n$.
+
+To solve this problem, note that we need to place a queen in each row.
+So we could place queens in successive rows, each time checking that a
+newly placed queen is not in check from any other queens that have
+already been placed. In the course of this search, it might arrive
+that a queen to be placed in row $k$ would be in check in all fields
+of that row from queens in row $1$ to $k-1$. In that case, we need to
+abort that part of the search in order to continue with a different
+configuration of queens in columns $1$ to $k-1$.
+
+This suggests a recursive algorithm.  Assume that we have already
+generated all solutions of placing $k-1$ queens on a board of size $n
+\times n$. We can represent each such solution by a list of length
+$k-1$ of column numbers (which can range from $1$ to $n$).  We treat
+these partial solution lists as stacks, where the column number of the
+queen in row $k-1$ comes first in the list, followed by the column
+number of the queen in row $k-2$, etc. The bottom of the stack is the
+column number of the queen placed in the first row of the board.  All
+solutions together are then represented as a list of lists, with one
+element for each solution.
+
+Now, to place the $k$'the queen, we generate all possible extensions
+of each previous solution by one more queen. This yields another list
+of solution lists, this time of length $k$. We continue the process
+until we have reached solutions of the size of the chess-board $n$.
+This algorithmic idea is embodied in function \code{placeQueens} below:
+\begin{lstlisting}
+def queens(n: Int): List[List[Int]] = {
+  def placeQueens(k: Int): List[List[Int]] =
+    if (k == 0) List(List())
+    else for { queens <- placeQueens(k - 1)
+               column <- List.range(1, n + 1)
+               if isSafe(column, queens, 1) } yield column :: queens
+  placeQueens(n)
+}
+\end{lstlisting}
+
+\begin{exercise} Write the function
+\begin{lstlisting}
+  def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
+\end{lstlisting}
+which tests whether a queen in the given column \verb@col@ is safe with 
+respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
+placed and the row of the first queen in the list.
+\end{exercise}
+
+\section{Querying with For-Comprehensions}
+
+The for-notation is essentially equivalent to common operations of
+database query languages.  For instance, say we are given a 
+database \code{books}, represented as a list of books, where
+\code{Book} is defined as follows.
+\begin{lstlisting}
+case class Book(title: String, authors: List[String])
+\end{lstlisting}
+Here is a small example database:
+\begin{lstlisting}
+val books: List[Book] = List(
+  Book("Structure and Interpretation of Computer Programs",
+       List("Abelson, Harold", "Sussman, Gerald J.")),
+  Book("Principles of Compiler Design",
+       List("Aho, Alfred", "Ullman, Jeffrey")),
+  Book("Programming in Modula-2",
+       List("Wirth, Niklaus")),
+  Book("Introduction to Functional Programming"),
+       List("Bird, Richard")),
+  Book("The Java Language Specification",
+       List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
+\end{lstlisting}
+Then, to find the titles of all books whose author's last name is ``Ullman'':
+\begin{lstlisting}
+for (b <- books; a <- b.authors if a startsWith "Ullman")
+yield b.title
+\end{lstlisting}
+(Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
+to find the titles of all books that have the string ``Program'' in
+their title:
+\begin{lstlisting}
+for (b <- books if (b.title indexOf "Program") >= 0)
+yield b.title
+\end{lstlisting}
+Or, to find the names of all authors that have written at least two
+books in the database.
+\begin{lstlisting}
+for (b1 <- books; b2 <- books if b1 != b2;
+     a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
+yield a1
+\end{lstlisting}
+The last solution is not yet perfect, because authors will appear
+several times in the list of results.  We still need to remove
+duplicate authors from result lists.  This can be achieved with the
+following function.
+\begin{lstlisting}
+def removeDuplicates[A](xs: List[A]): List[A] =
+  if (xs.isEmpty) xs
+  else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
+\end{lstlisting}
+Note that the last expression in method \code{removeDuplicates}
+can be equivalently expressed using a for-comprehension.
+\begin{lstlisting}
+xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
+\end{lstlisting}
+
+\section{Translation of For-Comprehensions}
+
+Every for-comprehension can be expressed in terms of the three
+higher-order functions \code{map}, \code{flatMap} and \code{filter}.
+Here is the translation scheme, which is also used by the Scala compiler.
+\begin{itemize}
+\item
+A simple for-comprehension
+\begin{lstlisting}
+for (x <- e) yield e'
+\end{lstlisting}
+is translated to
+\begin{lstlisting}
+e.map(x => e')
+\end{lstlisting}
+\item
+A for-comprehension
+\begin{lstlisting}
+for (x <- e if f; s) yield e'
+\end{lstlisting}
+where \code{f} is a filter and \code{s} is a (possibly empty)
+sequence of generators or filters
+is translated to
+\begin{lstlisting}
+for (x <- e.filter(x => f); s) yield e'
+\end{lstlisting}
+and then translation continues with the latter expression.
+\item
+A for-comprehension
+\begin{lstlisting}
+for (x <- e; y <- e'; s) yield e''
+\end{lstlisting}
+where \code{s} is a (possibly empty)
+sequence of generators or filters
+is translated to
+\begin{lstlisting}
+e.flatMap(x => for (y <- e'; s) yield e'')
+\end{lstlisting}
+and then translation continues with the latter expression.
+\end{itemize}
+For instance, taking our "pairs of integers whose sum is prime" example:
+\begin{lstlisting}
+for { i <- range(1, n)
+      j <- range(1, i)
+      if isPrime(i+j)
+} yield {i, j}
+\end{lstlisting}
+Here is what we get when we translate this expression:
+\begin{lstlisting}
+range(1, n)
+  .flatMap(i =>
+    range(1, i)
+      .filter(j => isPrime(i+j))
+      .map(j => (i, j)))
+\end{lstlisting}
+
+Conversely, it would also be possible to express functions \code{map},
+\code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
+three functions again, this time implemented using for-comprehensions.
+\begin{lstlisting}
+object Demo {
+  def map[A, B](xs: List[A], f: A => B): List[B] =
+    for (x <- xs) yield f(x)
+
+  def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
+    for (x <- xs; y <- f(x)) yield y
+
+  def filter[A](xs: List[A], p: A => Boolean): List[A] =
+    for (x <- xs if p(x)) yield x
+}
+\end{lstlisting}
+Not surprisingly, the translation of the for-comprehension in the body of
+\code{Demo.map} will produce a call to \code{map} in class \code{List}.
+Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
+\code{flatMap} and \code{filter} in class \code{List}.
+
+\begin{exercise}
+Define the following function in terms of \code{for}.
+\begin{lstlisting}
+def flatten[A](xss: List[List[A]]): List[A] =
+  (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
+\end{lstlisting}
+\end{exercise}
+
+\begin{exercise}
+Translate
+\begin{lstlisting}
+for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
+for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
+\end{lstlisting}
+to higher-order functions.
+\end{exercise}
+
+\section{For-Loops}\label{sec:for-loops}
+
+For-comprehensions resemble for-loops in imperative languages, except
+that they produce a list of results. Sometimes, a list of results is
+not needed but we would still like the flexibility of generators and
+filters in iterations over lists. This is made possible by a variant
+of the for-comprehension syntax, which expresses for-loops:
+\begin{lstlisting}
+for ( $s$ ) $e$
+\end{lstlisting}
+This construct is the same as the standard for-comprehension syntax
+except that the keyword \code{yield} is missing. The for-loop is
+executed by executing the expression $e$ for each element generated
+from the sequence of generators and filters $s$.
+
+As an example, the following expression prints out all elements of a
+matrix represented as a list of lists:
+ \begin{lstlisting}
+for (xs <- xss) {
+  for (x <- xs) print(x + "\t")
+  println()
+}
+\end{lstlisting}
+The translation of for-loops to higher-order methods of class
+\code{List} is similar to the translation of for-comprehensions, but
+is simpler. Where for-comprehensions translate to \code{map} and
+\code{flatMap}, for-loops translate in each case to \code{foreach}.
+
+\section{Generalizing For}
+
+We have seen that the translation of for-comprehensions only relies on
+the presence of methods \code{map}, \code{flatMap}, and
+\code{filter}. Therefore it is possible to apply the same notation to
+generators that produce objects other than lists; these objects only
+have to support the three key functions \code{map}, \code{flatMap},
+and \code{filter}.
+
+The standard Scala library has several other abstractions that support
+these three methods and with them support for-comprehensions. We will
+encounter some of them in the following chapters. As a programmer you
+can also use this principle to enable for-comprehensions for types you
+define -- these types just need to support methods \code{map},
+\code{flatMap}, and \code{filter}.
+
+There are many examples where this is useful: Examples are database
+interfaces, XML trees, or optional values. 
+
+One caveat: It is not assured automatically that the result
+translating a for-comprehension is well-typed. To ensure this, the
+types of \code{map}, \code{flatMap} and \code{filter} have to be
+essentially similar to the types of these methods in class \code{List}.
+
+To make this precise, assume you have a parameterized class
+ \code{C[A]} for which you want to enable for-comprehensions. Then
+ \code{C} should define \code{map}, \code{flatMap} and \code{filter}
+ with the following types:
+\begin{lstlisting}
+def map[B](f: A => B): C[B]
+def flatMap[B](f: A => C[B]): C[B]
+def filter(p: A => Boolean): C[A]
+\end{lstlisting}
+It would be attractive to enforce these types statically in the Scala
+compiler, for instance by requiring that any type supporting
+for-comprehensions implements a standard trait with these methods
+\footnote{In the programming language Haskell, which has similar
+constructs, this abstraction is called a ``monad with zero''}.  The
+problem is that such a standard trait would have to abstract over the
+identity of the class \code{C}, for instance by taking \code{C} as a
+type parameter.  Note that this parameter would be a type constructor,
+which gets applied to {\em several different} types in the signatures of
+methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
+system is too weak to express this construct, since it can handle only
+type parameters which are fully applied types.
+
+\chapter{Mutable State}
+
+Most programs we have presented so far did not have side-effects
+\footnote{We ignore here the fact that some of our program printed to
+standard output, which technically is a side effect.}.  Therefore, the
+notion of {\em time} did not matter.  For a program that terminates,
+any sequence of actions would have led to the same result!  This is
+also reflected by the substitution model of computation, where a
+rewrite step can be applied anywhere in a term, and all rewritings
+that terminate lead to the same solution.  In fact, this {\em
+confluence} property is a deep result in $\lambda$-calculus, the
+theory underlying functional programming. 
+
+In this chapter, we introduce functions with side effects and study
+their behavior. We will see that as a consequence we have to
+fundamentally modify up the substitution model of computation which we
+employed so far.
+
+\section{Stateful Objects}
+
+We normally view the world as a set of objects, some of which have
+state that {\em changes} over time.  Normally, state is associated
+with a set of variables that can be changed in the course of a
+computation.  There is also a more abstract notion of state, which
+does not refer to particular constructs of a programming language: An
+object {\em has state} (or: {\em is stateful}) if its behavior is
+influenced by its history.
+
+For instance, a bank account object has state, because the question
+``can I withdraw 100 CHF?''
+might have different answers during the lifetime of the account.
+
+In Scala, all mutable state is ultimately built from variables.  A
+variable definition is written like a value definition, but starts
+with \verb@var@ instead of \verb@val@. For instance, the following two
+definitions introduce and initialize two variables \code{x} and
+\code{count}.
+\begin{lstlisting}
+var x: String = "abc"
+var count = 111
+\end{lstlisting}
+Like a value definition, a variable definition associates a name with
+a value. But in the case of a variable definition, this association
+may be changed later by an assignment.  Such assignments are written
+as in C or Java. Examples:
+\begin{lstlisting}
+x = "hello"
+count = count + 1
+\end{lstlisting}
+In Scala, every defined variable has to be initialized at the point of
+its definition. For instance, the statement ~\code{var x: Int;}~ is
+{\em not} regarded as a variable definition, because the initializer
+is missing\footnote{If a statement like this appears in a class, it is
+instead regarded as a variable declaration, which introduces
+abstract access methods for the variable, but does not associate these
+methods with a piece of state.}. If one does not know, or does not
+care about, the appropriate initializer, one can use a wildcard
+instead. I.e.
+\begin{lstlisting}
+val x: T = _
+\end{lstlisting}
+will initialize \code{x} to some default value (\code{null} for
+reference types, \code{false} for booleans, and the appropriate
+version of \code{0} for numeric value types).
+
+Real-world objects with state are represented in Scala by objects that
+have variables as members. For instance, here is a class that
+represents bank accounts.
+\begin{lstlisting}
+class BankAccount {
+  private var balance = 0
+  def deposit(amount: Int) {
+    if (amount > 0) balance += amount
+  }
+
+  def withdraw(amount: Int): Int =
+    if (0 < amount && amount <= balance) {
+      balance -= amount
+      balance
+    } else error("insufficient funds")
+}
+\end{lstlisting}
+The class defines a variable \code{balance} which contains the current
+balance of an account. Methods \code{deposit} and \code{withdraw}
+change the value of this variable through assignments.  Note that
+\code{balance} is \code{private} in class \code{BankAccount} -- hence
+it can not be accessed directly outside the class.
+
+To create bank-accounts, we use the usual object creation notation:
+\begin{lstlisting}
+val myAccount = new BankAccount
+\end{lstlisting}
+
+\example Here is a \code{scalaint} session that deals with bank
+accounts.
+
+\begin{lstlisting}
+scala> :l bankaccount.scala
+Loading bankaccount.scala...
+defined class BankAccount
+scala> val account = new BankAccount
+account: BankAccount = BankAccount$\Dollar$class@1797795
+scala> account deposit 50
+unnamed0: Unit = ()
+scala> account withdraw 20
+unnamed1: Int = 30
+scala> account withdraw 20
+unnamed2: Int = 10
+scala> account withdraw 15
+java.lang.Error: insufficient funds
+        at scala.Predef$\Dollar$error(Predef.scala:74)
+        at BankAccount$\Dollar$class.withdraw(<console>:14)
+        at <init>(<console>:5)
+scala> 
+\end{lstlisting}
+The example shows that applying the same operation (\code{withdraw
+20}) twice to an account yields different results. So, clearly,
+accounts are stateful objects.  
+
+\paragraph{Sameness and Change}
+Assignments pose new problems in deciding when two expressions are
+``the same''.
+If assignments are excluded, and one writes
+\begin{lstlisting}
+val x = E; val y = E
+\end{lstlisting}
+where \code{E} is some arbitrary expression,
+then \code{x} and \code{y} can reasonably be assumed to be the same.
+I.e. one could have equivalently written
+\begin{lstlisting}
+val x = E; val y = x
+\end{lstlisting}
+(This property is usually called {\em referential transparency}). But
+once we admit assignments, the two definition sequences are different.
+Consider:
+\begin{lstlisting}
+val x = new BankAccount; val y = new BankAccount
+\end{lstlisting}
+To answer the question whether \code{x} and \code{y} are the same, we
+need to be more precise what ``sameness'' means. This meaning is
+captured in the notion of {\em operational equivalence}, which,
+somewhat informally, is stated as follows.
+
+Suppose we have two definitions of \code{x} and \code{y}.
+To test whether \code{x} and \code{y} define the same value, proceed
+as follows.
+\begin{itemize}
+\item
+Execute the definitions followed by an
+arbitrary sequence \code{S} of operations that involve \code{x} and
+\code{y}. Observe the results (if any).
+\item
+Then, execute the definitions with another sequence \code{S'} which
+results from \code{S} by renaming all occurrences of \code{y} in
+\code{S} to \code{x}.
+\item
+If the results of running \code{S'} are different, then surely
+\code{x} and \code{y} are different.
+\item
+On the other hand, if all possible pairs of sequences \lstinline@{S, S'}@
+yield the same results, then \code{x} and \code{y} are the same.
+\end{itemize}
+In other words, operational equivalence regards two definitions
+\code{x} and \code{y} as defining the same value, if no possible
+experiment can distinguish between \code{x} and \code{y}. An
+experiment in this context are two version of an arbitrary program which use either
+\code{x} or \code{y}.
  
-%% Given this definition, let's test whether
-%% \begin{lstlisting}
-%% val x = new BankAccount; val y = new BankAccount
-%% \end{lstlisting}
-%% defines values \code{x} and \code{y} which are the same.
-%% Here are the definitions again, followed by a test sequence:
-
-%% \begin{lstlisting}
-%% > val x = new BankAccount
-%% > val y = new BankAccount
-%% > x deposit 30
-%% 30
-%% > y withdraw 20
-%% java.lang.RuntimeException: insufficient funds
-%% \end{lstlisting}
-
-%% Now, rename all occurrences of \code{y} in that sequence to
-%% \code{x}. We get:
-%% \begin{lstlisting}
-%% > val x = new BankAccount
-%% > val y = new BankAccount
-%% > x deposit 30
-%% 30
-%% > x withdraw 20
-%% 10
-%% \end{lstlisting}
-%% Since the final results are different, we have established that
-%% \code{x} and \code{y} are not the same.
-%% On the other hand, if we define
-%% \begin{lstlisting}
-%% val x = new BankAccount; val y = x
-%% \end{lstlisting}
-%% then no sequence of operations can distinguish between \code{x} and
-%% \code{y}, so \code{x} and \code{y} are the same in this case.
-
-%% \paragraph{Assignment and the Substitution Model}
-%% These examples show that our previous substitution model of
-%% computation cannot be used anymore.  After all, under this
-%% model we could always replace a value name by its
-%% defining expression.
-%% For instance in
-%% \begin{lstlisting}
-%% val x = new BankAccount; val y = x
-%% \end{lstlisting}
-%% the \code{x} in the definition of \code{y} could
-%% be replaced by \code{new BankAccount}.
-%% But we have seen that this change leads to a different program.
-%% So the substitution model must be invalid, once we add assignments. 
-
-%% \section{Imperative Control Structures}
-
-%% Scala has the \code{while} and \code{do-while} loop constructs known
-%% from the C and Java languages. There is also a single branch \code{if}
-%% which leaves out the else-part as well as a \code{return} statement which
-%% aborts a function prematurely. This makes it possible to program in a
-%% conventional imperative style. For instance, the following function,
-%% which computes the \code{n}'th power of a given parameter \code{x}, is
-%% implemented using \code{while} and single-branch \code{if}.
-%% \begin{lstlisting}
-%% def power(x: Double, n: Int): Double = {
-%%   var r = 1.0
-%%   var i = n
-%%   var j = 0
-%%   while (j < 32) {
-%%     r = r * r
-%%     if (i < 0)
-%%       r *= x
-%%     i = i << 1
-%%     j += 1
-%%   }
-%%   r
-%% }
-%% \end{lstlisting}
-%% These imperative control constructs are in the language for
-%% convenience. They could have been left out, as the same constructs can
-%% be implemented using just functions. As an example, let's develop a
-%% functional implementation of the while loop. \code{whileLoop} should
-%% be a function that takes two parameters: a condition, of type
-%% \code{Boolean}, and a command, of type \code{Unit}. Both condition and
-%% command need to be passed by-name, so that they are evaluated
-%% repeatedly for each loop iteration.  This leads to the following
-%% definition of \code{whileLoop}.
-%% \begin{lstlisting}
-%% def whileLoop(condition: => Boolean)(command: => Unit) {
-%%   if (condition) {
-%%     command; whileLoop(condition)(command)
-%%   } else ()
-%% }
-%% \end{lstlisting}
-%% Note that \code{whileLoop} is tail recursive, so it operates in
-%% constant stack space.
-
-%% \begin{exercise} Write a function \code{repeatLoop}, which should be 
-%% applied as follows:
-%% \begin{lstlisting}
-%% repeatLoop { command } ( condition )
-%% \end{lstlisting}
-%% Is there also a way to obtain a loop syntax like the following?
-%% \begin{lstlisting}
-%% repeatLoop { command } until ( condition )
-%% \end{lstlisting}
-%% \end{exercise}
-
-%% Some other control constructs known from C and Java are missing in
-%% Scala: There are no \code{break} and \code{continue} jumps for loops.
-%% There are also no for-loops in the Java sense -- these have been
-%% replaced by the more general for-loop construct discussed in
-%% Section~\ref{sec:for-loops}.
-
-%% \section{Extended Example: Discrete Event Simulation}
-
-%% We now discuss an example that demonstrates how assignments and
-%% higher-order functions can be combined in interesting ways.  
-%% We will build a simulator for digital circuits.
-
-%% The example is taken from Abelson and Sussman's book
-%% \cite{abelson-sussman:structure}. We augment their basic (Scheme-)
-%% code by an object-oriented structure which allows code-reuse through
-%% inheritance. The example also shows how discrete event simulation programs
-%% in general are structured and built.
-
-%% We start with a little language to describe digital circuits.
-%% A digital circuit is built from {\em wires} and {\em function boxes}.
-%% Wires carry signals which are transformed by function boxes.
-%% We will represent signals by the booleans \code{true} and
-%% \code{false}.
-
-%% Basic function boxes (or: {\em gates}) are:
-%% \begin{itemize}
-%% \item An \emph{inverter}, which negates its signal
-%% \item An \emph{and-gate}, which sets its output to the conjunction of its input.
-%% \item An \emph{or-gate}, which sets its output to the disjunction of its
-%% input.
-%% \end{itemize}
-%% Other function boxes can be built by combining basic ones.
-
-%% Gates have {\em delays}, so an output of a gate will change only some
-%% time after its inputs change.
-
-%% \paragraph{A Language for Digital Circuits}
-
-%% We describe the elements of a digital circuit by the following set of
-%% Scala classes and functions.
-
-%% First, there is a class \code{Wire} for wires.
-%% We can construct wires as follows.
-%% \begin{lstlisting}
-%% val a = new Wire
-%% val b = new Wire
-%% val c = new Wire
-%% \end{lstlisting}
-%% Second, there are procedures
-%% \begin{lstlisting}
-%% def inverter(input: Wire, output: Wire)
-%% def andGate(a1: Wire, a2: Wire, output: Wire)
-%% def orGate(o1: Wire, o2: Wire, output: Wire)
-%% \end{lstlisting}
-%% which ``make'' the basic gates we need (as side-effects).
-%% More complicated function boxes can now be built from these.
-%% For instance, to construct a half-adder, we can define:
-%% \begin{lstlisting}
-%%   def halfAdder(a: Wire, b: Wire, s: Wire, c: Wire) {
-%%     val d = new Wire
-%%     val e = new Wire
-%%     orGate(a, b, d)
-%%     andGate(a, b, c)
-%%     inverter(c, e)
-%%     andGate(d, e, s)
-%%   }
-%% \end{lstlisting}
-%% This abstraction can itself be used, for instance in defining a full
-%% adder:
-%% \begin{lstlisting}
-%%   def fullAdder(a: Wire, b: Wire, cin: Wire, sum: Wire, cout: Wire) {
-%%     val s = new Wire
-%%     val c1 = new Wire
-%%     val c2 = new Wire
-%%     halfAdder(a, cin, s, c1)
-%%     halfAdder(b, s, sum, c2)
-%%     orGate(c1, c2, cout)
-%%   }
-%% \end{lstlisting}
-%% Class \code{Wire} and functions \code{inverter}, \code{andGate}, and
-%% \code{orGate} represent thus a little language in which users can
-%% define digital circuits.  We now give implementations of this class
-%% and these functions, which allow one to simulate circuits.
-%% These implementations are based on a simple and general API for
-%% discrete event simulation.
-
-%% \paragraph{The Simulation API}
-
-%% Discrete event simulation performs user-defined \emph{actions} at
-%% specified \emph{times}.  
-%% An {\em action} is represented as a function which takes no parameters and
-%% returns a \code{Unit} result:
-%% \begin{lstlisting}
-%% type Action = () => Unit
-%% \end{lstlisting}
-%% The \emph{time} is simulated; it is not the actual ``wall-clock'' time.
-
-%% A concrete simulation will be done inside an object which inherits
-%% from the abstract \code{Simulation} class. This class has the following
-%% signature:
-
-%% \begin{lstlisting}
-%% abstract class Simulation {
-%%   def currentTime: Int
-%%   def afterDelay(delay: Int, action: => Action)
-%%   def run()
-%% }
-%% \end{lstlisting}
-%% Here,
-%% \code{currentTime} returns the current simulated time as an integer
-%% number,
-%% \code{afterDelay} schedules an action to be performed at a specified
-%% delay after \code{currentTime}, and
-%% \code{run} runs the simulation until there are no further actions to be 
-%% performed.
-
-%% \paragraph{The Wire Class}
-%% A wire needs to support three basic actions.
-%% \begin{itemize}
-%% \item[]
-%% \code{getSignal: Boolean}~~ returns the current signal on the wire.
-%% \item[]
-%% \code{setSignal(sig: Boolean)}~~ sets the wire's signal to \code{sig}.
-%% \item[]
-%% \code{addAction(p: Action)}~~ attaches the specified procedure
-%% \code{p} to the {\em actions} of the wire. All attached action
-%% procedures will be executed every time the signal of a wire changes.
-%% \end{itemize}
-%% Here is an implementation of the \code{Wire} class:
-%% \begin{lstlisting}
-%% class Wire {
-%%   private var sigVal = false
-%%   private var actions: List[Action] = List()
-%%   def getSignal = sigVal
-%%   def setSignal(s: Boolean) =
-%%     if (s != sigVal) {
-%%       sigVal = s
-%%       actions.foreach(action => action())
-%%     }
-%%   def addAction(a: Action) {
-%%     actions = a :: actions; a()
-%%   }
-%% }
-%% \end{lstlisting}
-%% Two private variables make up the state of a wire.  The variable
-%% \code{sigVal} represents the current signal, and the variable
-%% \code{actions} represents the action procedures currently attached to
-%% the wire.
-
-%% \paragraph{The Inverter Class}
-%% We implement an inverter by installing an action on its input wire,
-%% namely the action which puts the negated input signal onto the output
-%% signal.  The action needs to take effect at \code{InverterDelay}
-%% simulated time units after the input changes. This suggests the 
-%% following implementation:
-%% \begin{lstlisting}
-%% def inverter(input: Wire, output: Wire) {
-%%   def invertAction() {
-%%     val inputSig = input.getSignal
-%%     afterDelay(InverterDelay) { output setSignal !inputSig }
-%%   }
-%%   input addAction invertAction
-%% }
-%% \end{lstlisting}
-
-%% \paragraph{The And-Gate Class}
-%% And-gates are implemented analogously to inverters.  The action of an
-%% \code{andGate} is to output the conjunction of its input signals.
-%% This should happen at \code{AndGateDelay} simulated time units after
-%% any one of its two inputs changes. Hence, the following implementation:
-%% \begin{lstlisting}
-%% def andGate(a1: Wire, a2: Wire, output: Wire) {
-%%   def andAction() {
-%%     val a1Sig = a1.getSignal
-%%     val a2Sig = a2.getSignal
-%%     afterDelay(AndGateDelay) { output setSignal (a1Sig & a2Sig) }
-%%   }
-%%   a1 addAction andAction
-%%   a2 addAction andAction
-%% }
-%% \end{lstlisting}
-
-%% \begin{exercise} Write the implementation of \code{orGate}.
-%% \end{exercise}
-
-%% \begin{exercise} Another way is to define an or-gate by a combination of
-%% inverters and and gates. Define a function \code{orGate} in terms of
-%% \code{andGate} and \code{inverter}. What is the delay time of this function?
-%% \end{exercise}
-
-%% \paragraph{The Simulation Class}
-
-%% Now, we just need to implement class \code{Simulation}, and we are
-%% done.  The idea is that we maintain inside a \code{Simulation} object
-%% an \emph{agenda} of actions to perform.  The agenda is represented as
-%% a list of pairs of actions and the times they need to be run.  The
-%% agenda list is sorted, so that earlier actions come before later ones.
-%% \begin{lstlisting} 
-%% abstract class Simulation {
-%%   case class WorkItem(time: Int, action: Action)
-%%   private type Agenda = List[WorkItem]
-%%   private var agenda: Agenda = List()
-%% \end{lstlisting}
-%% There is also a private variable \code{curtime} to keep track of the
-%% current simulated time.
-%% \begin{lstlisting}
-%%   private var curtime = 0
-%% \end{lstlisting}
-%% An application of the method \code{afterDelay(delay, block)} 
-%% inserts the element \lstinline@WorkItem(currentTime + delay, () => block)@
-%% into the \code{agenda} list at the appropriate place.
-%% \begin{lstlisting}
-%% private def insert(ag: Agenda, item: WorkItem): Agenda =
-%%   if (ag.isEmpty || item.time < ag.head.time) item :: ag
-%%   else ag.head :: insert(ag.tail, item)
-
-%% def afterDelay(delay: Int)(block: => Unit) {
-%%   val item = WorkItem(currentTime + delay, () => block)
-%%   agenda = insert(agenda, item)
-%% }
-%% \end{lstlisting}
-%% An application of the \code{run} method removes successive elements
-%% from the \code{agenda} and performs their actions.
-%% It continues until the agenda is empty:
-%% \begin{lstlisting}
-%% private def next() {
-%%   agenda match {
-%%     case WorkItem(time, action) :: rest =>
-%%       agenda = rest; curtime = time; action()
-%%     case List() =>
-%%   }
-%% }
-
-%% def run() {
-%%   afterDelay(0) { println("*** simulation started ***") }
-%%   while (!agenda.isEmpty) next()
-%% }
-%% \end{lstlisting}
-
-%% \paragraph{Running the Simulator}
-%% To run the simulator, we still need a way to inspect changes of
-%% signals on wires. To this purpose, we write a function \code{probe}.
-%% \begin{lstlisting}
-%% def probe(name: String, wire: Wire) {
-%%   wire addAction { () =>
-%%     println(name + " " + currentTime + " new_value = " + wire.getSignal)
-%%   }
-%% }
-%% \end{lstlisting}
-%% Now, to see the simulator in action, let's define four wires, and place
-%% probes on two of them: 
-%% \begin{lstlisting}
-%% scala> val input1, input2, sum, carry = new Wire
-
-%% scala> probe("sum", sum)
-%% sum 0 new_value = false
-
-%% scala> probe("carry", carry)
-%% carry 0 new_value = false
-%% \end{lstlisting}
-%% Now let's define a half-adder connecting the wires:
-%% \begin{lstlisting}
-%% scala> halfAdder(input1, input2, sum, carry)
-%% \end{lstlisting}
-%% Finally, set one after another the signals on the two input wires to
-%% \code{true} and run the simulation.
-%% \begin{lstlisting}
-%% scala> input1 setSignal true; run
-%% *** simulation started ***
-%% sum 8 new_value = true
-
-%% scala> input2 setSignal true; run
-%% carry 11 new_value = true
-%% sum 15 new_value = false
-%% \end{lstlisting}
-
-%% \section{Summary}
-
-%% We have seen in this chapter the constructs that let us model state in
-%% Scala -- these are variables, assignments, and imperative control
-%% structures.  State and Assignment complicate our mental model of
-%% computation.  In particular, referential transparency is lost.  On the
-%% other hand, assignment gives us new ways to formulate programs
-%% elegantly. As always, it depends on the situation whether purely
-%% functional programming or programming with assignments works best.
-
-%% \chapter{Computing with Streams}
-
-%% The previous chapters have introduced variables, assignment and
-%% stateful objects.  We have seen how real-world objects that change
-%% with time can be modeled by changing the state of variables in a
-%% computation.  Time changes in the real world thus are modeled by time
-%% changes in program execution. Of course, such time changes are usually
-%% stretched out or compressed, but their relative order is the same.
-%% This seems quite natural, but there is a also price to pay: Our simple
-%% and powerful substitution model for functional computation is no
-%% longer applicable once we introduce variables and assignment.
-
-%% Is there another way? Can we model state change in the real world
-%% using only immutable functions? Taking mathematics as a guide, the
-%% answer is clearly yes: A time-changing quantity is simply modeled by
-%% a function \code{f(t)} with a time parameter \code{t}. The same can be
-%% done in computation. Instead of overwriting a variable with successive
-%% values, we represent all these values as successive elements in a
-%% list. So, a mutable variable \code{var x: T} gets replaced by an
-%% immutable value \code{val x: List[T]}. In a sense, we trade space for
-%% time -- the different values of the variable now all exist concurrently
-%% as different elements of the list.  One advantage of the list-based
-%% view is that we can ``time-travel'', i.e. view several successive
-%% values of the variable at the same time. Another advantage is that we
-%% can make use of the powerful library of list processing functions,
-%% which often simplifies computation. For instance, consider the
-%% imperative way to compute the sum of all prime numbers in an interval:
-%% \begin{lstlisting}
-%% def sumPrimes(start: Int, end: Int): Int = {
-%%   var i = start
-%%   var acc = 0
-%%   while (i < end) {
-%%     if (isPrime(i)) acc += i
-%%     i += 1
-%%   }
-%%   acc
-%% }
-%% \end{lstlisting}
-%% Note that the variable \code{i} ``steps through'' all values of the interval
-%% \code{[start .. end-1]}.
-
-%% A more functional way is to represent the list of values of variable \code{i} directly as \code{range(start, end)}. Then the function can be rewritten as follows.
-%% \begin{lstlisting}
-%% def sumPrimes(start: Int, end: Int) =
-%%   sum(range(start, end) filter isPrime)
-%% \end{lstlisting}
-
-%% No contest which program is shorter and clearer!  However, the
-%% functional program is also considerably less efficient since it
-%% constructs a list of all numbers in the interval, and then another one
-%% for the prime numbers. Even worse from an efficiency point of view is
-%% the following example:
-
-%% To find the second prime number between \code{1000} and \code{10000}:
-%% \begin{lstlisting}
-%%   range(1000, 10000) filter isPrime at 1
-%% \end{lstlisting}
-%% Here, the list of all numbers between \code{1000} and \code{10000} is
-%% constructed.  But most of that list is never inspected!
-
-%% However, we can obtain efficient execution for examples like these by
-%% a trick:
-%% \begin{quote}
-%% %\red
-%%  Avoid computing the tail of a sequence unless that tail is actually
-%%      necessary for the computation.
-%% \end{quote}
-%% We define a new class for such sequences, which is called \code{Stream}.
-
-%% Streams are created using the constant \code{empty} and the constructor \code{cons},
-%% which are both defined in module \code{scala.Stream}. For instance, the following
-%% expression constructs a stream with elements \code{1} and \code{2}:
-%% \begin{lstlisting}
-%% Stream.cons(1, Stream.cons(2, Stream.empty))
-%% \end{lstlisting}
-%% As another example, here is the analogue of \code{List.range},
-%% but returning a stream instead of a list:
-%% \begin{lstlisting}
-%% def range(start: Int, end: Int): Stream[Int] =
-%%   if (start >= end) Stream.empty
-%%   else Stream.cons(start, range(start + 1, end))
-%% \end{lstlisting}
-%% (This function is also defined as given above in module
-%% \code{Stream}).  Even though \code{Stream.range} and \code{List.range}
-%% look similar, their execution behavior is completely different: 
-
-%% \code{Stream.range} immediately returns with a \code{Stream} object
-%% whose first element is \code{start}.  All other elements are computed
-%% only when they are \emph{demanded} by calling the \code{tail} method
-%% (which might be never at all).  
-
-%% Streams are accessed just as lists. Similarly to lists, the basic access
-%% methods are \code{isEmpty}, \code{head} and \code{tail}. For instance,
-%% we can print all elements of a stream as follows.
-%% \begin{lstlisting}
-%% def print(xs: Stream[A]) {
-%%   if (!xs.isEmpty) { Console.println(xs.head); print(xs.tail) }
-%% }
-%% \end{lstlisting}
-%% Streams also support almost all other methods defined on lists (see
-%% below for where their methods sets differ). For instance, we can find
-%% the second prime number between \code{1000} and \code{10000} by applying methods
-%% \code{filter} and \code{apply} on an interval stream:
-%% \begin{lstlisting}
-%%   Stream.range(1000, 10000) filter isPrime at 1
-%% \end{lstlisting}
-%% The difference to the previous list-based implementation is that now
-%% we do not needlessly construct and test for primality any numbers
-%% beyond 1013.
-
-%% \paragraph{Consing and appending streams} Two methods in class \code{List}
-%% which are not supported by class \code{Stream} are \code{::} and
-%% \code{:::}.  The reason is that these methods are dispatched on their
-%% right-hand side argument, which means that this argument needs to be
-%% evaluated before the method is called. For instance, in the case of
-%% \code{x :: xs} on lists, the tail \code{xs} needs to be evaluated
-%% before \code{::} can be called and the new list can be constructed.
-%% This does not work for streams, where we require that the tail of a
-%% stream should not be evaluated until it is demanded by a \code{tail} operation.
-%% The argument why list-append \code{:::} cannot be adapted to streams is analogous.
-
-%% Instead of \code{x :: xs}, one uses \code{Stream.cons(x, xs)} for
-%% constructing a stream with first element \code{x} and (unevaluated)
-%% rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
-%% \code{xs append ys}.  
-
-%% \chapter{Iterators}
-
-%% Iterators are the imperative version of streams. Like streams,
-%% iterators describe potentially infinite lists. However, there is no
-%% data-structure which contains the elements of an iterator. Instead, 
-%% iterators allow one to step through the sequence, using two abstract methods \code{next} and \code{hasNext}.
-%% \begin{lstlisting}
-%% trait Iterator[+A] {
-%%   def hasNext: Boolean
-%%   def next: A
-%% \end{lstlisting}
-%% Method \code{next} returns successive elements.  Method \code{hasNext}
-%% indicates whether there are still more elements to be returned by
-%% \code{next}. Iterators also support some other methods, which are
-%% explained later.
-
-%% As an example, here is an application which prints the squares of all
-%% numbers from 1 to 100.
-%% \begin{lstlisting}
-%% val it: Iterator[Int] = Iterator.range(1, 100)
-%% while (it.hasNext) {
-%%   val x = it.next
-%%   println(x * x)
-%% }
-%% \end{lstlisting}
-
-%% \section{Iterator Methods}
-
-%% Iterators support a rich set of methods besides \code{next} and
-%% \code{hasNext}, which is described in the following. Many of these
-%% methods mimic a corresponding functionality in lists.
-
-%% \paragraph{Append}
-%% Method \code{append} constructs an iterator which resumes with the
-%% given iterator ~\code{it}~ after the current iterator has finished.
-%% \begin{lstlisting}
-%%   def append[B >: A](that: Iterator[B]): Iterator[B] = new Iterator[B] {
-%%     def hasNext = Iterator.this.hasNext || that.hasNext
-%%     def next = if (Iterator.this.hasNext) Iterator.this.next else that.next
-%%   }    
-%% \end{lstlisting}
-%% The terms \code{Iterator.this.next} and \code{Iterator.this.hasNext}
-%% in the definition of \code{append} call the corresponding methods as
-%% they are defined in the enclosing \code{Iterator} class.  If the
-%% \code{Iterator} prefix to \code{this} would have been missing,
-%% \code{hasNext} and \code{next} would have called recursively the
-%% methods being defined in the result of \code{append}, which is not
-%% what we want.
-
-%% \paragraph{Map, FlatMap, Foreach} Method \code{map} 
-%% constructs an iterator which returns all elements of the original
-%% iterator transformed by a given function \code{f}.
-%% \begin{lstlisting}
-%%   def map[B](f: A => B): Iterator[B] = new Iterator[B] {
-%%     def hasNext = Iterator.this.hasNext
-%%     def next = f(Iterator.this.next)
-%%   }
-%% \end{lstlisting}
-%% Method \code{flatMap} is like method \code{map}, except that the
-%% transformation function \code{f} now returns an iterator.
-%% The result of \code{flatMap} is the iterator resulting from appending
-%% together all iterators returned from successive calls of \code{f}.
-%% \begin{lstlisting}
-%%   def flatMap[B](f: A => Iterator[B]): Iterator[B] = new Iterator[B] {
-%%     private var cur: Iterator[B] = Iterator.empty
-%%     def hasNext: Boolean =
-%%       if (cur.hasNext) true
-%%       else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); hasNext }
-%%       else false
-%%     def next: B =
-%%       if (cur.hasNext) cur.next
-%%       else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); next }
-%%       else error("next on empty iterator")
-%%   }
-%% \end{lstlisting}
-%% Closely related to \code{map} is the \code{foreach} method, which
-%% applies a given function to all elements of an iterator, but does not
-%% construct a list of results
-%% \begin{lstlisting}
-%%   def foreach(f: A => Unit): Unit =
-%%     while (hasNext) { f(next) }
-%% \end{lstlisting}
-
-%% \paragraph{Filter} Method \code{filter} constructs an iterator which
-%% returns all elements of the original iterator that satisfy a criterion
-%% \code{p}.
-%% \begin{lstlisting}
-%%   def filter(p: A => Boolean) = new BufferedIterator[A] {
-%%     private val source =
-%%       Iterator.this.buffered
-%%     private def skip =
-%%       { while (source.hasNext && !p(source.head)) { source.next } }
-%%     def hasNext: Boolean =
-%%       { skip; source.hasNext }
-%%     def next: A =
-%%       { skip; source.next }
-%%     def head: A =
-%%       { skip; source.head }
-%%   }
-%% \end{lstlisting}
-%% In fact, \code{filter} returns instances of a subclass of iterators
-%% which are ``buffered''.  A \code{BufferedIterator} object is an
-%% iterator which has in addition a method \code{head}. This method
-%% returns the element which would otherwise have been returned by
-%% \code{head}, but does not advance beyond that element. Hence, the
-%% element returned by \code{head} is returned again by the next call to
-%% \code{head} or \code{next}. Here is the definition of the
-%% \code{BufferedIterator} trait.
-%% \begin{lstlisting}
-%% trait BufferedIterator[+A] extends Iterator[A] {
-%%   def head: A
-%% }
-%% \end{lstlisting}
-%% Since \code{map}, \code{flatMap}, \code{filter}, and \code{foreach}
-%% exist for iterators, it follows that for-comprehensions and for-loops
-%% can also be used on iterators. For instance, the application which prints the squares of numbers between 1 and 100 could have equivalently been expressed as follows.
-%% \begin{lstlisting}
-%% for (i <- Iterator.range(1, 100))
-%%   println(i * i)
-%% \end{lstlisting}
-
-%% \paragraph{Zip} Method \code{zip} takes another iterator and
-%% returns an iterator consisting of pairs of corresponding elements
-%% returned by the two iterators.
-%% \begin{lstlisting}
-%%   def zip[B](that: Iterator[B]) = new Iterator[(A, B)] {
-%%     def hasNext = Iterator.this.hasNext && that.hasNext
-%%     def next = (Iterator.this.next, that.next)
-%%   }
-%% }
-%% \end{lstlisting}
-
-%% \section{Constructing Iterators}
-
-%% Concrete iterators need to provide implementations for the two
-%% abstract methods \code{next} and \code{hasNext} in class
-%% \code{Iterator}. The simplest iterator is \code{Iterator.empty} which
-%% always returns an empty sequence:
-%% \begin{lstlisting}
-%% object Iterator {
-%%   object empty extends Iterator[Nothing] {
-%%     def hasNext = false
-%%     def next = error("next on empty iterator")
-%%   }
-%% \end{lstlisting}
-%% A more interesting iterator enumerates all elements of an array. This
-%% iterator is constructed by the \code{fromArray} method, which is also defined in the object \code{Iterator}
-%% \begin{lstlisting}
-%%   def fromArray[A](xs: Array[A]) = new Iterator[A] {
-%%     private var i = 0
-%%     def hasNext: Boolean =
-%%       i < xs.length
-%%     def next: A =
-%%       if (i < xs.length) { val x = xs(i); i += 1; x }
-%%       else error("next on empty iterator")
-%%   }
-%% \end{lstlisting}
-%% Another iterator enumerates an integer interval.  The
-%% \code{Iterator.range} function returns an iterator which traverses a
-%% given interval of integer values. It is defined as follows.
-%% \begin{lstlisting}
-%% object Iterator {
-%%   def range(start: Int, end: Int) = new Iterator[Int] {
-%%     private var current = start
-%%     def hasNext = current < end
-%%     def next = {
-%%       val r = current
-%%       if (current < end) current += 1
-%%       else error("end of iterator")
-%%       r
-%%     }
-%%   }
-%% }
-%% \end{lstlisting}
-%% All iterators seen so far terminate eventually. It is also possible to
-%% define iterators that go on forever. For instance, the following
-%% iterator returns successive integers from some start
-%% value\footnote{Due to the finite representation of type \prog{int},
-%% numbers will wrap around at $2^{31}$.}.
-%% \begin{lstlisting}
-%% def from(start: Int) = new Iterator[Int] {
-%%   private var last = start - 1
-%%   def hasNext = true
-%%   def next = { last += 1; last }
-%% }
-%% \end{lstlisting}
-
-%% \section{Using Iterators}
-
-%% Here are two more examples how iterators are used. First, to print all
-%% elements of an array \code{xs: Array[Int]}, one can write:
-%% \begin{lstlisting}
-%%   Iterator.fromArray(xs) foreach (x => println(x))
-%% \end{lstlisting}
-%% Or, using a for-comprehension:
-%% \begin{lstlisting}
-%%   for (x <- Iterator.fromArray(xs))
-%%     println(x)
-%% \end{lstlisting}
-%% As a second example, consider the problem of finding the indices of
-%% all the elements in an array of \code{double}s greater than some
-%% \code{limit}. The indices should be returned as an iterator.
-%% This is achieved by the following expression.
-%% \begin{lstlisting}
-%% import Iterator._
-%% fromArray(xs)
-%% .zip(from(0))
-%% .filter(case (x, i) => x > limit)
-%% .map(case (x, i) => i)
-%% \end{lstlisting}
-%% Or, using a for-comprehension:
-%% \begin{lstlisting}
-%% import Iterator._
-%% for ((x, i) <- fromArray(xs) zip from(0); x > limit)
-%% yield i
-%% \end{lstlisting}
-
-%% \chapter{Lazy Values}
-
-%% Lazy values provide a way to delay initialization of a value until the
-%% first time it is accessed. This may be useful when dealing with
-%% values that might not be needed during execution, and whose
-%% computational cost is signifficant. As a first example, let's consider
-%% a database of employees, containing for each employee its manager and
-%% its team.
-%% \begin{lstlisting}
-%% case class Employee(id: Int, 
-%%                     name: String, 
-%%                     managerId: Int) {
-%%   val manager: Employee = Db.get(managerId)
-%%   val team: List[Employee] = Db.team(id)
-%% }
-%% \end{lstlisting}
-
-%% The \lstinline@Employee@ class given above will eagerly initialize
-%% all its fields, loading the whole employee table in memory. This is
-%% certainly not optimal, and it can be easily  improved my making the
-%% fields lazy. This way we delay the database access until it is really
-%% needed, if it is ever needed.
-%% \begin{lstlisting}
-%% case class Employee(id: Int, 
-%%                     name: String, 
-%%                     managerId: Int) {
-%%   lazy val manager: Employee = Db.get(managerId)
-%%   lazy val team: List[Employee] = Db.team(id)
-%% }
-%% \end{lstlisting}
-
-%% To see what is really happening, we can use this mockup
-%% database which shows when records are fetched:
-%% \begin{lstlisting}
-%% object Db {
-%%   val table = Map(1 -> (1, "Haruki Murakami", -1),
-%%                   2 -> (2, "Milan Kundera", 1),
-%%                   3 -> (3, "Jeffrey Eugenides", 1),
-%%                   4 -> (4, "Mario Vargas Llosa", 1),
-%%                   5 -> (5, "Julian Barnes", 2))
-
-%%   def team(id: Int) = {
-%%     for (rec <- table.values.toList; if rec._3 == id)
-%%       yield recToEmployee(rec)
-%%   }
-
-%%   def get(id: Int) = recToEmployee(table(id))
-
-%%   private def recToEmployee(rec: (Int, String, Int)) = {
-%%     println("[db] fetching " + rec._1)
-%%     Employee(rec._1, rec._2, rec._3)
-%%   }
-%% }
-%% \end{lstlisting}
-%% The output when running a program that retrieves one employee 
-%% confirms that the database is only accessed when referring  the lazy
-%% values.
-
-%% Another use of lazy values is to resolve the
-%% initialization order of applications composed of several
-%% modules. Before lazy values were introduced, the same effect was
-%% achieved by using \lstinline@object@ definitions. As a second example,
-%% we consider a compiler composed of several modules. We look first at a
-%% simple symbol table that defines a class for symbols and two
-%% predefined functions.
-%% \begin{lstlisting}
-%% class Symbols(val compiler: Compiler) {
-%%   import compiler.types._
-
-%%   val Add = new Symbol("+", FunType(List(IntType, IntType), IntType))
-%%   val Sub = new Symbol("-", FunType(List(IntType, IntType), IntType))
-
-%%   class Symbol(name: String, tpe: Type) {
-%%     override def toString = name + ": " + tpe
-%%   }
-%% }
-%% \end{lstlisting}
-%% The \lstinline@symbols@ module is parameterized with a \lstinline@Compiler@
-%% instance, which provides access to other services, such as the types
-%% module. In our example there are only two predefined functions,
-%% addition and subtraction, and their definitions depend on the \lstinline@types@
-%% module.
-%% \begin{lstlisting}
-%% class Types(val compiler: Compiler) {
-%%   import compiler.symtab._
-
-%%   abstract class Type
-%%   case class FunType(args: List[Type], res: Type) extends Type
-%%   case class NamedType(sym: Symbol) extends Type
-%%   case object IntType extends Type
-%% }
-%% \end{lstlisting}
-%% In order to hook the two components together a compiler object is
-%% created and passed as an argument to the two components. 
-%% \begin{lstlisting}
-%% class Compiler {
-%%   val symtab = new Symbols(this)
-%%   val types  = new Types(this)
-%% }
-%% \end{lstlisting}
-%% Unfortunately, the straight-forward approach fails at runtime because
-%% the \lstinline@symtab@ module needs the \lstinline@types@
-%% module. In general, the dependency between modules can be complicated
-%% and getting the right initialization order is difficult, or even
-%% impossible when there are cycles. The easy fix is to make such fields
-%% \lstinline@lazy@ and let the compiler figure out the right order.
-%% \begin{lstlisting}
-%% class Compiler {
-%%   lazy val symtab = new Symbols(this)
-%%   lazy val types  = new Types(this)
-%% }
-%% \end{lstlisting}
-%% Now the two modules are initialized on first access, and the compiler
-%% may run as expected. 
-
-%% \subsection*{Syntax}
-%% The \lstinline@lazy@ modifier is allowed only on concrete value
-%% definitions. All typing rules for value definitions apply for
-%% \lstinline@lazy@ values as well, with one restriction removed:
-%% recursive local values are allowed.
-
-%% \chapter{Implicit Parameters and Conversions}\label{sec:implicits}
-
-%% Implicit parameters and conversions are powerful tools for
-%% custimizing existing libraries and for creating high-level
-%% abstractions. As an example, let's start with an abstract class of
-%% semi-groups that support an unspecified \lstinline@add@ operation.
-%% \begin{lstlisting}
-%% abstract class SemiGroup[A] {
-%%   def add(x: A, y: A): A
-%% }
-%% \end{lstlisting}
-%% Here's a subclass \lstinline@Monoid@ of \lstinline@SemiGroup@ which adds a
-%% \lstinline@unit@ element.
-%% \begin{lstlisting}
-%% abstract class Monoid[A] extends SemiGroup[A] {
-%%   def unit: A
-%% }
-%% \end{lstlisting}
-%% Here are two implementations of monoids:
-%% \begin{lstlisting}
-%% object stringMonoid extends Monoid[String] {
-%%   def add(x: String, y: String): String = x.concat(y)
-%%   def unit: String = ""
-%% }
-
-%% object intMonoid extends Monoid[Int] {
-%%   def add(x: Int, y: Int): Int = x + y
-%%   def unit: Int = 0
-%% }
-%% \end{lstlisting}
-%% A \lstinline@sum@ method, which works over arbitrary
-%% monoids, can be written in plain Scala as follows.
-%% \begin{lstlisting}
-%% def sum[A](xs: List[A])(m: Monoid[A]): A =
-%%   if (xs.isEmpty) m.unit
-%%   else m.add(xs.head, sum(m)(xs.tail)
-%% \end{lstlisting}
-%% This \lstinline@sum@ method can be called as follows:
-%% \begin{lstlisting}
-%% sum(List("a", "bc", "def"))(stringMonoid)
-%% sum(List(1, 2, 3))(intMonoid)
-%% \end{lstlisting}
-%% All this works, but it is not very nice. The problem is that the
-%% monoid implementations have to be passed into all code that uses them.
-%% We would sometimes wish that the system could figure out the correct
-%% arguments automatically, similar to what is done when type arguments
-%% are inferred. This is what implicit parameters provide.
-
-%% \subsection*{Implicit Parameters: The Basics}
-
-%% In Scala 2 there is a new \lstinline@implicit@ keyword that can be
-%% used at the beginning of a parameter list. Syntax:
-%% \begin{lstlisting}
-%% ParamClauses ::= {`(' [Param {`,' Param}] ')'} 
-%%                  [`(' implicit Param {`,' Param} `)']
-%% \end{lstlisting}
-%% If the keyword is present, it makes all parameters in the list
-%% implicit.  
-%% For instance, the following version of \lstinline@sum@ has
-%% \lstinline@m@ as an implicit parameter.
-%% \begin{lstlisting}
-%% def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
-%%   if (xs.isEmpty) m.unit
-%%   else m.add(xs.head, sum(xs.tail))
-%% \end{lstlisting}
-%% As can be seen from the example, it is possible to combine normal and
-%% implicit parameters. However, there may only be one implicit parameter
-%% list for a method or constructor, and it must come last.
-
-%% \lstinline@implicit@ can also be used as a modifier for definitions
-%% and declarations. Examples:
-
-%% \begin{lstlisting}
-%% implicit object stringMonoid extends Monoid[String] {
-%%   def add(x: String, y: String): String = x.concat(y)
-%%   def unit: String = ""
-%% }
-%% implicit object intMonoid extends Monoid[Int] {
-%%   def add(x: Int, y: Int): Int = x + y
-%%   def unit: Int = 0
-%% }
-%% \end{lstlisting}
-
-%% The principal idea behind implicit parameters is that arguments for
-%% them can be left out from a method call. If the arguments
-%% corresponding to an implicit parameter section are missing, they are
-%% inferred by the Scala compiler.
-
-%% The actual arguments that are eligible to be passed to an implicit
-%% parameter are all identifiers X that can be accessed at the point
-%% of the method call without a prefix and that denote an implicit
-%% definition or parameter.
-
-%% If there are several eligible arguments which match the implicit
-%% parameter's type, the Scala compiler will chose a most specific one,
-%% using the standard rules of static overloading resolution.
-%% For instance, assume the call
-%% \begin{lstlisting}
-%%   sum(List(1, 2, 3))
-%% \end{lstlisting}
-%% in a context where \lstinline@stringMonoid@ and \lstinline@intMonoid@
-%% are visible.  We know that the formal type parameter \lstinline@a@ of
-%% \lstinline@sum@ needs to be instantiated to \lstinline@int@. The only
-%% eligible value which matches the implicit formal parameter type
-%% \lstinline@Monoid[Int]@ is \lstinline@intMonoid@ so this object will %
-%% be passed as implicit parameter.
-
-%% This discussion also shows that implicit parameters are inferred after
-%% any type arguments are inferred. 
-
-%% \subsection*{Implicit Conversions}
-
-%% Say you have an expression $E$ of type $T$ which is expected to type
-%% $S$. $T$ does not conform to $S$ and is not convertible to $S$ by
-%% some other predefined conversion. Then the Scala compiler will try to
-%% apply as last resort an implicit conversion $I(E)$. Here, $I$ is an
-%% identifier denoting an implicit definition or parameter that is
-%% accessible without a prefix at the point of the conversion, that can
-%% be applied to arguments of type $T$ and whose result type conforms to the
-%% expected type $S$.
-
-%% Implicit conversions can also be applied in member
-%% selections. Given a selection $E.x$ where $x$ is not a member of the
-%% type $E$, the Scala compiler will try to insert an implicit conversion
-%% $I(E).x$, so that $x$ is a member of $I(E)$.
-
-%% Here is an example of an implicit conversion function that converts
-%% integers into instances of class \lstinline@scala.Ordered@:
-%% \begin{lstlisting}
-%% implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
-%%   def compare(y: Int): Int =
-%%     if (x < y) -1
-%%     else if (x > y) 1
-%%     else 0
-%% }
-%% \end{lstlisting}
-
-%% \subsection*{View Bounds}
-
-%% View bounds are convenient syntactic sugar for implicit
-%% parameters. Consider for instance a generic sort method:
-%% \begin{lstlisting}
-%% def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
-%%   if (xs.isEmpty || xs.tail.isEmpty) xs
-%%   else {
-%%     val {ys, zs} = xs.splitAt(xs.length / 2)
-%%     merge(ys, zs)
-%%   }
-%% \end{lstlisting}
-%% The view bounded type parameter \lstinline@[a <$\mbox{\%}$ Ordered[a]]@
-%% expresses that \lstinline@sort@ is applicable to lists of type
-%% \lstinline@a@ such that there exists an implicit conversion from
-%% \lstinline@a@ to \lstinline@Ordered[a]@. The definition is treated as
-%% a shorthand for the following method signature with an implicit
-%% parameter:
-%% \begin{lstlisting}
-%% def sort[A](xs: List[A])(implicit $c$: A => Ordered[A]): List[A] = ...
-%% \end{lstlisting}
-%% (Here, the parameter name $c$ is chosen arbitrarily in a way
-%% that does not collide with other names in the program.)
-
-%% As a more detailed example, consider the \lstinline@merge@ method that
-%% comes with the \lstinline@sort@ method above:
-%% \begin{lstlisting}
-%% def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
-%%   if (xs.isEmpty) ys
-%%   else if (ys.isEmpty) xs
-%%   else if (xs.head < ys.head) xs.head :: merge(xs.tail, ys)
-%%   else if ys.head :: merge(xs, ys.tail)
-%% \end{lstlisting}
-%% After expanding view bounds and inserting implicit conversions, this
-%% method implementation becomes:
-%% \begin{lstlisting}
-%% def merge[A](xs: List[A], ys: List[A])
-%%             (implicit $c$: A => Ordered[A]): List[A] =
-%%   if (xs.isEmpty) ys
-%%   else if (ys.isEmpty) xs
-%%   else if (c(xs.head) < ys.head) xs.head :: merge(xs.tail, ys)
-%%   else if ys.head :: merge(xs, ys.tail)(c)
-%% \end{lstlisting}
-%% The last two lines of this method definition illustrate two different
-%% uses of the implicit parameter $c$. It is applied in a conversion in
-%% the condition of the second to last line, and it is passed as implicit
-%% argument in the recursive call to \lstinline@merge@ on the last line.
-
-%% \comment{
-%% \chapter{Combinator Parsing}\label{sec:combinator-parsing}
-
-%% In this chapter we describe how to write combinator parsers in
-%% Scala. Such parsers are constructed from predefined higher-order
-%% functions, so called {\em parser combinators}, that closely model the
-%% constructions of an EBNF grammar \cite{wirth:ebnf}.
-
-%% As running example, we consider parsers for possibly nested
-%% lists of identifiers and numbers, which
-%% are described by the following context-free grammar.
-%% \bda{p{3cm}cp{10cm}}
-%% letter &::=& /* all letters */ \\
-%% digit  &::=& /* all digits */ \\[0.5em]
-%% ident  &::=& letter \{letter $|$ digit \}\\
-%% number &::=& digit \{digit\}\\[0.5em]
-%% list   &::=& `(' [listElems] `)' \\
-%% listElems &::=& expr [`,' listElems] \\
-%% expr   &::=& ident | number | list
-
-%% \eda
-
-%% \section{Simple Combinator Parsing}
-
-%% In this section we will only be concerned with the task of recognizing
-%% input strings, not with processing them. So we can describe parsers
-%% by the sets of input strings they accept.  There are two
-%% fundamental operators over parsers:
-%% \code{&} expresses the sequential composition of a parser with
-%% another, while \code{|} expresses an alternative. These operations
-%% will both be defined as methods of a \code{Parser} class.  We will
-%% also define constructors for the following primitive parsers:
-
-%% \begin{tabular}{ll}
-%% \code{empty}    & The parser that accepts the empty string
-%% \\
-%% \code{failure(msg: String)}  & The parser that accepts no string (\verb@msg@ 
-%%                                stands for an error message)
-
-%% \\
-%% \code{chr(c: char)}
-%%                 & The parser that accepts the single-character string ``$c$''.
-%% \\
-%% \code{chrSuchThat(p: Char => Boolean)}
-%%                 & The parser that accepts single-character strings
-%%                   ``$c$'' \\
-%%                 & for which $p(c)$ is true.
-%% \end{tabular}
-
-%% There are also the two higher-order parser combinators \code{opt},
-%% expressing optionality and \code{rep}, expressing repetition.
-%% For any parser $p$, \code{opt(}$p$\code{)} yields a parser that
-%% accepts the strings accepted by $p$ or else the empty string, while
-%% \code{rep(}$p$\code{)} accepts arbitrary sequences of the strings accepted by
-%% $p$. In EBNF, \code{opt(}$p$\code{)} corresponds to $[p]$ and
-%% \code{rep(}$p$\code{)} corresponds to $\{p\}$.
-
-%% The central idea of parser combinators is that parsers can be produced
-%% by a straightforward rewrite of the grammar, replacing \code{::=} with
-%% \code{=}, sequencing with
-%% \code{&}, repetition \code{\{...\}} with
-%% \code{rep(...)} and optional occurrence \code{[...]} with \code{opt(...)}.
-%% Applying this process to the grammar of lists
-%% yields the following trait.
-%% \begin{lstlisting}
-%% trait ListParsers extends Parsers {
-%%   def chrSuchThat(p: Char => Boolean): Parser
-%%   def chr(c: Char): Parser = chrSuchThat(d ==)
-
-%%   def letter    : Parser = chr(Character.isLetter)
-%%   def digit     : Parser = chr(Character.isDigit)
-
-%%   def ident     : Parser = letter &&& rep(letter ||| digit)
-%%   def number    : Parser = digit &&& rep(digit)
-%%   def list      : Parser = chr('(') &&& opt(listElems) &&& chr(')')
-%%   def listElems : Parser = expr &&& (chr(',') &&& listElems ||| empty)
-%%   def expr      : Parser = ident ||| number ||| list
-%% }
-%% \end{lstlisting}
-%% This class isolates the grammar from other aspects of parsing. It
-%% abstracts over the type of input 
-%% and over the method used to parse a single character
-%% (represented by the abstract method \code{chr(p: char =>
-%% boolean))}. The missing bits of information need to be supplied by code
-%% applying the parser class.
-
-%% It remains to explain how to implement a library with the combinators
-%% described above. We will pack combinators and their underlying
-%% implementation in a base class \code{Parsers}, which is inherited by
-%% \code{ListParsers}.  The first question to decide is which underlying
-%% representation type to use for a parser. We treat parsers here
-%% essentially as functions that take a datum of the input type
-%% \code{InType} and that yield a parse result of type
-%% \code{Option[InType]}.  The \code{Option} type is predefined as
-%% follows.
-%% \begin{lstlisting}
-%% abstract class Option[+a]
-%% case object None extends Option[Nothing]
-%% case class Some[a](x: a) extends Option[a]
-%% \end{lstlisting}
-%% A parser applied to some input either succeeds or fails. If it fails,
-%% it returns the constant \code{None}. If it succeeds, it returns a
-%% value of the form \code{Some(in1)} where \code{in1} represents the
-%% input that remains to be parsed.
-%% \begin{lstlisting}
-%% trait Parsers {
-%%   type InType
-%%   abstract class Parser {
-%%     type Result = Option[InType]
-%%     def apply(in: InType): Result
-%% \end{lstlisting}
-%% A parser also implements the combinators
-%% for sequence and alternative:
-%% \begin{lstlisting}
-%%   /*** p &&& q applies first p, and if that succeeds, then q
-%%    */
-%%   def &&& (q: => Parser) = new Parser {
-%%     def apply(in: InType): Result = Parser.this.apply(in) match {
-%%       case None => None
-%%       case Some(in1)  => q(in1)
-%%     }
-%%   }
-
-%%   /*** p ||| q applies first p, and, if that fails, then q.
-%%    */
-%%   def ||| (q: => Parser) = new Parser {
-%%     def apply(in: InType): Result = Parser.this.apply(in) match {
-%%       case None => q(in)
-%%       case s => s
-%%     }
-%%   }
-%% \end{lstlisting}
-%% The implementations of the primitive parsers \code{empty} and \code{fail}
-%% are trivial:
-%% \begin{lstlisting}
-%%   val empty = new Parser { def apply(in: InType): Result = Some(in) }
-%%   val fail  = new Parser { def apply(in: InType): Result = None }
-%% \end{lstlisting}
-%% The higher-order parser combinators \code{opt} and \code{rep} can be
-%% defined in terms of the combinators for sequence and alternative:
-%% \begin{lstlisting}
-%%   def opt(p: Parser): Parser = p ||| empty;    // p? = (p | <empty>)
-%%   def rep(p: Parser): Parser = opt(rep1(p));   // p* = [p+]
-%%   def rep1(p: Parser): Parser = p &&& rep(p);  // p+ = p p*
-%% } // end Parser
-%% \end{lstlisting}
-%% To run combinator parsers, we still need to decide on a way to handle
-%% parser input. Several possibilities exist: The input could be
-%% represented as a list, as an array, or as a random access file.  Note
-%% that the presented combinator parsers use backtracking to change from
-%% one alternative to another.  Therefore, it must be possible to reset
-%% input to a point that was previously parsed. If one restricted the
-%% focus to LL(1) grammars, a non-backtracking implementation of the
-%% parser combinators in class \code{Parsers} would also be possible. In
-%% that case sequential input methods based on (say) iterators or
-%% sequential files would also be possible.
-
-%% In our example, we represent the input by a pair of a string, which
-%% contains the input phrase as a whole, and an index, which represents
-%% the portion of the input which has not yet been parsed. Since the
-%% input string does not change, just the index needs to be passed around
-%% as a result of individual parse steps.  This leads to the following
-%% class of parsers that read strings:
-%% \begin{lstlisting}
-%% class ParseString(s: String) extends Parsers {
-%%   type InType = Int
-%%   def chrSuchThat(p: Char => Boolean) = new Parser {
-%%     def apply(in: Int): Parser#Result =
-%%       if (in < s.length() && p(s charAt in)) Some(in + 1)
-%%       else None
-%%   }
-%%   val input = 0
-%% }
-%% \end{lstlisting}
-%% This class implements a method \code{chr(p: Char => Boolean)} and a
-%% value \code{input}. The \code{chr} method builds a parser that either
-%% reads a single character satisfying the given predicate \code{p} or
-%% fails.  All other parsers over strings are ultimately implemented in
-%% terms of that method. The \code{input} value represents the input as a
-%% whole. In out case, it is simply value \code{0}, the start index of
-%% the string to be read.
-
-%% Note \code{apply}'s result type, \code{Parser#Result}. This syntax
-%% selects the type element \code{Result} of the type \code{Parser}. It
-%% thus corresponds roughly to selecting a static inner class from some
-%% outer class in Java. Note that we could {\em not} have written
-%% \code{Parser.Result}, as the latter would express selection of the
-%% \code{Result} element from a {\em value} named \code{Parser}.
-
-%% We have now extended the root class \code{Parsers} in two different
-%% directions: Class \code{ListParsers} defines a grammar of phrases to
-%% be parsed, whereas class \code{ParseString} defines a method by which
-%% such phrases are input. To write a concrete parsing application, we
-%% need to define both grammar and input method. We do this by combining
-%% two extensions of \code{Parsers} using a {\em mixin composition}.
-%% Here is the start of a sample application:
-%% \begin{lstlisting}
-%% object Test {
-%%   def main(args: Array[String]) {
-%%     val ps = new ParseString(args(0)) with ListParsers
-%%   }
-%% \end{lstlisting}
-%% The last line above creates a new family of parsers by composing class
-%% \code{ListParsers} with class \code{ParseString}. The two classes
-%% share the common superclass \code{Parsers}. The abstract method
-%% \code{chr} in \code{ListParsers} is implemented by class \code{ParseString}.
-
-%% To run the parser, we apply the start symbol of the grammar
-%% \code{expr} the argument code{input} and observe the result:
-%% \begin{lstlisting}
-%%     ps.expr(ps.input) match {
-%%       case Some(n) =>
-%%         println("parsed: " + args(0).substring(0, n))
-%%       case None =>
-%%         println("nothing parsed")
-%%     }
-%%   }
-%% }// end Test
-%% \end{lstlisting}
-%% Note the syntax ~\code{ps.expr(input)}, which treats the \code{expr}
-%% parser as if it was a function. In Scala, objects with \code{apply}
-%% methods can be applied directly to arguments as if they were functions.
-
-%% Here is an example run of the program above:
-%% \begin{lstlisting}
-%% > java examples.Test "(x,1,(y,z))"
-%% parsed: (x,1,(y,z))
-%% > java examples.Test "(x,,1,(y,z))"
-%% nothing parsed
-%% \end{lstlisting}
-
-%% \section{\label{sec:parsers-results}Parsers that Produce Results}
-
-%% The combinator library of the previous section does not support the
-%% generation of output from parsing. But usually one does not just want
-%% to check whether a given string belongs to the defined language, one
-%% also wants to convert the input string into some internal
-%% representation such as an abstract syntax tree.
-
-%% In this section, we modify our parser library to build parsers that
-%% produce results. We will make use of the for-comprehensions introduced
-%% in Chapter~\ref{sec:for-notation}.  The basic combinator of sequential
-%% composition, formerly ~\code{p &&& q}, now becomes
-%% \begin{lstlisting}
-%% for (x <- p; y <- q) yield e .
-%% \end{lstlisting}
-%% Here, the names \code{x} and \code{y} are bound to the results of
-%% executing the parsers \code{p} and \code{q}. \code{e} is an expression
-%% that uses these results to build the tree returned by the composed
-%% parser.
-
-%% Before describing the implementation of the new parser combinators, we
-%% explain how the new building blocks are used. Say we want to modify
-%% our list parser so that it returns an abstract syntax tree of the
-%% parsed expression. Syntax trees are given by the following class hierarchy:
-%% \begin{lstlisting}
-%% abstract class Tree
-%% case class Id (s: String)         extends Tree
-%% case class Num(n: Int)            extends Tree
-%% case class Lst(elems: List[Tree]) extends Tree
-%% \end{lstlisting}
-%% That is, a syntax tree is an identifier, an integer number, or a
-%% \code{Lst} node with a list of trees as descendants.
-
-%% As a first step towards parsers that produce results we define three
-%% little parsers that return a single read character as result.
-%% \begin{lstlisting}
-%% trait CharParsers extends Parsers {
-%%   def any: Parser[Char]
-%%   def chr(ch: Char): Parser[Char] =
-%%     for (c <- any if c == ch) yield c
-%%   def chrSuchThat(p: Char => Boolean): Parser[Char] =
-%%     for (c <- any if p(c)) yield c
-%% }
-%% \end{lstlisting}
-%% The \code{any} parser succeeds with the first character of remaining
-%% input as long as input is nonempty. It is abstract in class
-%% \code{ListParsers} since we want to abstract in this class from the
-%% concrete input method used.  The two \code{chr} parsers return as before
-%% the first input character if it equals a given character or matches a
-%% given predicate. They are now implemented in terms of \code{any}.
-
-%% The next level is represented by parsers reading identifiers, numbers
-%% and lists. Here is a parser for identifiers.
-%% \begin{lstlisting}
-%% trait ListParsers extends CharParsers {
-%%   def ident: Parser[Tree] = 
-%%     for {
-%%       c: Char <- chrSuchThat(Character.isLetter)
-%%       cs: List[Char] <- rep(chrSuchThat(Character.isLetterOrDigit))
-%%     } yield Id((c :: cs).mkString("", "", ""))
-%% \end{lstlisting}
-%% Remark: Because \code{chrSuchThat(...)} returns a single character, its
-%% repetition \code{rep(chrSuchThat(...))} returns a list of characters. The
-%% \code{yield} part of the for-comprehension converts all intermediate
-%% results into an \code{Id} node with a string as element.  To convert
-%% the read characters into a string, it conses them into a single list,
-%% and invokes the \code{mkString} method on the result.
-
-%% Here is a parser for numbers:
-%% \begin{lstlisting}
-%%   def number: Parser[Tree] =
-%%     for {
-%%       d: Char <- chrSuchThat(Character.isDigit)
-%%       ds: List[Char] <- rep(chrSuchThat(Character.isDigit))
-%%     } yield Num(((d - '0') /: ds) ((x, digit) => x * 10 + digit - '0'))
-%% \end{lstlisting}
-%% Intermediate results are in this case the leading digit of
-%% the read number, followed by a list of remaining digits.  The
-%% \code{yield} part of the for-comprehension reduces these to a number
-%% by a fold-left operation.
-
-%% Here is a parser for lists:
-%% \begin{lstlisting}
-%%   def list: Parser[Tree] = 
-%%     for {
-%%       _ <- chr('(')
-%%       es <- listElems ||| succeed(List())
-%%       _ <- chr(')')
-%%     } yield Lst(es)
-
-%%   def listElems: Parser[List[Tree]] = 
-%%     for {
-%%       x <- expr
-%%       xs <- chr(',') &&& listElems ||| succeed(List())
-%%     } yield x :: xs
-%% \end{lstlisting}
-%% The \code{list} parser returns a \code{Lst} node with a list of trees
-%% as elements.  That list is either the result of \code{listElems}, or,
-%% if that fails, the empty list (expressed here as: the result of a
-%% parser which always succeeds with the empty list as result).
-
-%% The highest level of our grammar is represented by function
-%% \code{expr}:
-%% \begin{lstlisting}
-%%   def expr: Parser[Tree] = 
-%%     ident ||| number ||| list
-%% }// end ListParsers.
-%% \end{lstlisting}
-%% We now present the parser combinators that support the new
-%% scheme. Parsers that succeed now return a parse result besides the
-%% un-consumed input.
-%% \begin{lstlisting}
-%% trait Parsers {
-%%   type InType
-%%   abstract class Parser[A] {
-%%     type Result = Option[(A, InType)]
-%%     def apply(in: InType): Result
-%% \end{lstlisting}
-%% Parsers are parameterized with the type of their result. The class
-%% \code{Parser[a]} now defines new methods \code{map}, \code{flatMap}
-%% and \code{filter}. The \code{for} expressions are mapped by the
-%% compiler to calls of these functions using the scheme described in
-%% Chapter~\ref{sec:for-notation}. For parsers, these methods are
-%% implemented as follows.
-%% \begin{lstlisting}
-%%     def filter(pred: A => Boolean) = new Parser[A] {
-%%       def apply(in: InType): Result = Parser.this.apply(in) match {
-%%         case None => None
-%%         case Some(x, in1) => if (pred(x)) Some(x, in1) else None
-%%       }
-%%     }
-%%     def map[B](f: A => B) = new Parser[B] {
-%%       def apply(in: InType): Result = Parser.this.apply(in) match {
-%%         case None => None
-%%         case Some(x, in1) => Some(f(x), in1)
-%%       }
-%%     }
-%%     def flatMap[b](f: A => Parser[B]) = new Parser[B] {
-%%       def apply(in: InType): Result = Parser.this.apply(in) match {
-%%         case None => None
-%%         case Some(x, in1) => f(x).apply(in1)
-%%       }
-%%     }
-%% \end{lstlisting}
-%% The \code{filter} method takes as parameter a predicate $p$ which it
-%% applies to the results of the current parser. If the predicate is
-%% false, the parser fails by returning \code{None}; otherwise it returns
-%% the result of the current parser.  The \code{map} method takes as
-%% parameter a function $f$ which it applies to the results of the
-%% current parser. The \code{flatMap} takes as parameter a function
-%% \code{f} which returns a parser.  It applies \code{f} to the result of
-%% the current parser and then continues with the resulting parser.  The
-%% \code{|||} method is essentially defined as before.  The
-%% \code{&&&} method can now be defined in terms of \code{for}.
-%% \begin{lstlisting}
-%%     def ||| (p: => Parser[A]) = new Parser[A] {
-%%       def apply(in: InType): Result = Parser.this.apply(in) match {
-%%         case None => p(in)
-%%         case s => s
-%%       }
-%%     }
-
-%%     def &&& [B](p: => Parser[B]): Parser[B] =
-%%       for (_ <- this; x <- p) yield x
-%%   }// end Parser
-%% \end{lstlisting}
-
-%% The primitive parser \code{succeed} replaces \code{empty}. It consumes
-%% no input and returns its parameter as result.
-%% \begin{lstlisting}
-%%   def succeed[A](x: A) = new Parser[A] {
-%%     def apply(in: InType) = Some(x, in)
-%%   }
-%% \end{lstlisting}
-
-%% The parser combinators \code{rep} and \code{opt} now also return
-%% results. \code{rep} returns a list which contains as elements the
-%% results of each iteration of its sub-parser. \code{opt} returns a list
-%% which is either empty or returns as single element the result of the
-%% optional parser.
-%% \begin{lstlisting}
-%%   def rep[A](p: Parser[A]): Parser[List[A]] =
-%%     rep1(p) ||| succeed(List())
-
-%%   def rep1[A](p: Parser[A]): Parser[List[A]] =
-%%     for (x <- p; xs <- rep(p)) yield x :: xs
-
-%%   def opt[A](p: Parser[A]): Parser[List[A]] =
-%%     (for (x <- p) yield List(x)) ||| succeed(List())
-%% } // end Parsers
-%% \end{lstlisting}
-%% The root class \code{Parsers} abstracts over which kind of
-%% input is parsed.  As before, we determine the input method by a separate class.
-%% Here is \code{ParseString}, this time adapted to parsers that return results.
-%% It defines now the method \code{any}, which returns the first input character.
-%% \begin{lstlisting}
-%% class ParseString(s: String) extends Parsers {
-%%   type InType = Int
-%%   val input = 0
-%%   def any = new Parser[Char] {
-%%     def apply(in: Int): Parser[Char]#Result =
-%%       if (in < s.length()) Some(s charAt in, in + 1) else None
-%%   }
-%% }
-%% \end{lstlisting}
-%% The rest of the application is as before. Here is a test program which
-%% constructs a list parser over strings and prints out the result of
-%% applying it to the command line argument.
-%% \begin{lstlisting}
-%% object Test {
-%%   def main(args: Array[String]) {
-%%     val ps = new ParseString(args(0)) with ListParsers
-%%     ps.expr(ps.input) match {
-%%       case Some(list, _) => println("parsed: " + list)
-%%       case None => println("nothing parsed")
-%%     }
-%%   }
-%% }
-%% \end{lstlisting}
-
-%% \begin{exercise}\label{exercise:end-marker} The parsers we have defined so
-%% far can succeed even if there is some input beyond the parsed text. To
-%% prevent this, one needs a parser which recognizes the end of input.
-%% Redesign the parser library so that such a parser can be introduced.
-%% Which classes need to be modified?
-%% \end{exercise}
-%% }
-
-%% \chapter{\label{sec:hm}Hindley/Milner Type Inference}
-
-%% This chapter demonstrates Scala's data types and pattern matching by
-%% developing a type inference system in the Hindley/Milner style
-%% \cite{milner:polymorphism}. The source language for the type inferencer is
-%% lambda calculus with a let construct called Mini-ML. Abstract syntax
-%% trees for the Mini-ML are represented by the following data type of
-%% \code{Terms}.
-%% \begin{lstlisting}
-%% abstract class Term {}
-%% case class Var(x: String) extends Term {
-%%   override def toString = x
-%% }
-%% case class Lam(x: String, e: Term) extends Term {
-%%   override def toString = "(\\" + x + "." + e + ")"
-%% }
-%% case class App(f: Term, e: Term) extends Term {
-%%   override def toString = "(" + f + " " + e + ")"
-%% }
-%% case class Let(x: String, e: Term, f: Term) extends Term {
-%%   override def toString = "let " + x + " = " + e + " in " + f
-%% }
-%% \end{lstlisting}
-%% There are four tree constructors: \code{Var} for variables, \code{Lam}
-%% for function abstractions, \code{App} for function applications, and
-%% \code{Let} for let expressions. Each case class overrides the
-%% \code{toString} method of class \code{Any}, so that terms can be
-%% printed in legible form.
-
-%% We next define the types that are
-%% computed by the inference system.
-%% \begin{lstlisting}
-%% sealed abstract class Type {}
-%% case class Tyvar(a: String) extends Type {
-%%   override def toString = a
-%% }
-%% case class Arrow(t1: Type, t2: Type) extends Type {
-%%   override def toString = "(" + t1 + "->" + t2 + ")"
-%% }
-%% case class Tycon(k: String, ts: List[Type]) extends Type {
-%%   override def toString = 
-%%     k + (if (ts.isEmpty) "" else ts.mkString("[", ",", "]"))
-%% }
-%% \end{lstlisting}
-%% There are three type constructors: \code{Tyvar} for type variables,
-%% \code{Arrow} for function types and \code{Tycon} for type constructors
-%% such as \code{Boolean} or \code{List}. Type constructors have as
-%% component a list of their type parameters. This list is empty for type
-%% constants such as \code{Boolean}. Again, the type constructors
-%% implement the \code{toString} method in order to display types legibly.
-
-%% Note that \code{Type} is a \code{sealed} class. This means that no
-%% subclasses or data constructors that extend \code{Type} can be formed
-%% outside the sequence of definitions in which \code{Type} is defined.
-%% This makes \code{Type} a {\em closed} algebraic data type with exactly
-%% three alternatives. By contrast, type \code{Term} is an {\em open}
-%% algebraic type for which further alternatives can be defined.
-
-%% The main parts of the type inferencer are contained in object
-%% \code{typeInfer}. We start with a utility function which creates
-%% fresh type variables:
-%% \begin{lstlisting}
-%% object typeInfer {
-%%   private var n: Int = 0
-%%   def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
-%% \end{lstlisting}
-%% We next define a class for substitutions. A substitution is an
-%% idempotent function from type variables to types. It maps a finite
-%% number of type variables to some types, and leaves all other type
-%% variables unchanged. The meaning of a substitution is extended
-%% point-wise to a mapping from types to types. We also extend
-%% the meaning of substitution to environments, which are defined
-%% later.
-%% \begin{lstlisting}
-%%   abstract class Subst extends Function1[Type,Type] {
-
-%%     def lookup(x: Tyvar): Type
-
-%%     def apply(t: Type): Type = t match {
-%%       case tv @ Tyvar(a) => val u = lookup(tv); if (t == u) t else apply(u)
-%%       case Arrow(t1, t2) => Arrow(apply(t1), apply(t2))
-%%       case Tycon(k, ts) => Tycon(k, ts map apply)
-%%     }
-
-%%     def apply(env: Env): Env = env.map({ case (x, TypeScheme(tyvars, tpe)) =>
-%%       // assumes tyvars don't occur in this substitution
-%%       (x, TypeScheme(tyvars, apply(tpe)))
-%%     })
-
-%%     def extend(x: Tyvar, t: Type) = new Subst {
-%%       def lookup(y: Tyvar): Type = if (x == y) t else Subst.this.lookup(y)
-%%     }
-%%   }
-%%   val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
-%% \end{lstlisting}
-%% We represent substitutions as functions, of type \code{Type =>
-%% Type}. This is achieved by making class \code{Subst} inherit from the
-%% unary function type \code{Function1[Type, Type]}\footnote{
-%% The class inherits the function type as a mixin rather than as a direct 
-%% superclass. This is because in the current Scala implementation, the
-%% \code{Function1} type is a Java interface, which cannot be used as a direct
-%% superclass of some other class.}.
-%% To be an instance
-%% of this type, a substitution \code{s} has to implement an \code{apply}
-%% method that takes a \code{Type} as argument and yields another
-%% \code{Type} as result. A function application \code{s(t)} is then
-%% interpreted as \code{s.apply(t)}.
-
-%% The \code{lookup} method is abstract in class \code{Subst}.  There are
-%% two concrete forms of substitutions which differ in how they
-%% implement this method.  One form is defined by the \code{emptySubst} value,
-%% the other is defined by the \code{extend} method in class
-%% \code{Subst}.
-
-%% The next data type describes type schemes, which consist of a type and
-%% a list of names of type variables which appear universally quantified
-%% in the type scheme. 
-%% For instance, the type scheme $\forall a\forall b.a \!\arrow\! b$ would be represented in the type checker as:
-%% \begin{lstlisting}
-%% TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
-%% \end{lstlisting}
-%% The class definition of type schemes does not carry an extends
-%% clause; this means that type schemes extend directly class
-%% \code{AnyRef}.  Even though there is only one possible way to
-%% construct a type scheme, a case class representation was chosen
-%% since it offers convenient ways to decompose an instance of this type into its
-%% parts.
-%% \begin{lstlisting}
-%%   case class TypeScheme(tyvars: List[Tyvar], tpe: Type) {
-%%     def newInstance: Type = {
-%%       (emptySubst /: tyvars) ((s, tv) => s.extend(tv, newTyvar())) (tpe)
-%%     }
-%%   }
-%% \end{lstlisting}
-%% Type scheme objects come with a method \code{newInstance}, which
-%% returns the type contained in the scheme after all universally type
-%% variables have been renamed to fresh variables. The implementation of
-%% this method folds (with \code{/:}) the type scheme's type variables
-%% with an operation which extends a given substitution \code{s} by
-%% renaming a given type variable \code{tv} to a fresh type
-%% variable. The resulting substitution renames all type variables of the
-%% scheme to fresh ones. This substitution is then applied to the type
-%% part of the type scheme.
-
-%% The last type we need in the type inferencer is
-%% \code{Env}, a type for environments, which associate variable names
-%% with type schemes. They are represented by a type alias \code{Env} in
-%% module \code{typeInfer}:
-%% \begin{lstlisting}
-%%   type Env = List[(String, TypeScheme)]
-%% \end{lstlisting}
-%% There are two operations on environments. The \code{lookup} function
-%% returns the type scheme associated with a given name, or \code{null}
-%% if the name is not recorded in the environment.
-%% \begin{lstlisting}
-%%   def lookup(env: Env, x: String): TypeScheme = env match {
-%%     case List() => null
-%%     case (y, t) :: env1 => if (x == y) t else lookup(env1, x)
-%%   }
-%% \end{lstlisting}
-%% The \code{gen} function turns a given type into a type scheme,
-%% quantifying over all type variables that are free in the type, but
-%% not in the environment.
-%% \begin{lstlisting}
-%%   def gen(env: Env, t: Type): TypeScheme = 
-%%     TypeScheme(tyvars(t) diff tyvars(env), t)
-%% \end{lstlisting}
-%% The set of free type variables of a type is simply the set of all type
-%% variables which occur in the type. It is represented here as a list of
-%% type variables, which is constructed as follows.
-%% \begin{lstlisting}
-%%   def tyvars(t: Type): List[Tyvar] = t match {
-%%     case tv @ Tyvar(a) => 
-%%       List(tv)
-%%     case Arrow(t1, t2) => 
-%%       tyvars(t1) union tyvars(t2)
-%%     case Tycon(k, ts) => 
-%%       (List[Tyvar]() /: ts) ((tvs, t) => tvs union tyvars(t))
-%%   }
-%% \end{lstlisting}
-%% Note that the syntax \code{tv @ ...} in the first pattern introduces a variable
-%% which is bound to the pattern that follows. Note also that the explicit type parameter \code{[Tyvar]} in the expression of the third
-%% clause is needed to make local type inference work.
-
-%% The set of free type variables of a type scheme is the set of free
-%% type variables of its type component, excluding any quantified type variables:
-%% \begin{lstlisting}
-%%   def tyvars(ts: TypeScheme): List[Tyvar] = 
-%%     tyvars(ts.tpe) diff ts.tyvars
-%% \end{lstlisting}
-%% Finally, the set of free type variables of an environment is the union
-%% of the free type variables of all type schemes recorded in it.
-%% \begin{lstlisting}
-%%   def tyvars(env: Env): List[Tyvar] =
-%%     (List[Tyvar]() /: env) ((tvs, nt) => tvs union tyvars(nt._2))
-%% \end{lstlisting}
-%% A central operation of Hindley/Milner type checking is unification,
-%% which computes a substitution to make two given types equal (such a
-%% substitution is called a {\em unifier}).  Function \code{mgu} computes
-%% the most general unifier of two given types $t$ and $u$ under a
-%% pre-existing substitution $s$.  That is, it returns the most general
-%% substitution $s'$ which extends $s$, and which makes $s'(t)$ and
-%% $s'(u)$ equal types. 
-%% \begin{lstlisting}
-%%   def mgu(t: Type, u: Type, s: Subst): Subst = (s(t), s(u)) match {
-%%     case (Tyvar(a), Tyvar(b)) if (a == b) =>
-%%       s
-%%     case (st @ Tyvar(a), su) if !(tyvars(su) contains st) =>
-%%       s.extend(st, su)
-%%     case (_, Tyvar(a)) =>
-%%       mgu(u, t, s)
-%%     case (Arrow(t1, t2), Arrow(u1, u2)) =>
-%%       mgu(t1, u1, mgu(t2, u2, s))
-%%     case (Tycon(k1, ts), Tycon(k2, us)) if (k1 == k2) =>
-%%       (s /: (ts zip us)) ((s, tu) => mgu(tu._1, tu._2, s))
-%%     case _ => 
-%%       throw new TypeError("cannot unify " + s(t) + " with " + s(u))
-%%   }
-%% \end{lstlisting}
-%% The \code{mgu} function throws a \code{TypeError} exception if no
-%% unifier substitution exists. This can happen because the two types
-%% have different type constructors at corresponding places, or because a
-%% type variable is unified with a type that contains the type variable
-%% itself. Such exceptions are modeled here as instances of case classes
-%% that inherit from the predefined \code{Exception} class.
-%% \begin{lstlisting}
-%%   case class TypeError(s: String) extends Exception(s) {}
-%% \end{lstlisting}
-%% The main task of the type checker is implemented by function
-%% \code{tp}. This function takes as parameters an environment $env$, a
-%% term $e$, a proto-type $t$, and a
-%% pre-existing substitution $s$.  The function yields a substitution
-%% $s'$ that extends $s$ and that
-%% turns $s'(env) \ts e: s'(t)$ into a derivable type judgment according
-%% to the derivation rules of the Hindley/Milner type system \cite{milner:polymorphism}.  A
-%% \code{TypeError} exception is thrown if no such substitution exists.
-%% \begin{lstlisting}
-%%   def tp(env: Env, e: Term, t: Type, s: Subst): Subst = {
-%%     current = e
-%%     e match {
-%%       case Var(x) =>
-%%         val u = lookup(env, x)
-%%         if (u == null) throw new TypeError("undefined: " + x)
-%%         else mgu(u.newInstance, t, s)
-
-%%       case Lam(x, e1) =>
-%%         val a, b = newTyvar()
-%%         val s1 = mgu(t, Arrow(a, b), s)
-%%         val env1 = {x, TypeScheme(List(), a)} :: env
-%%         tp(env1, e1, b, s1)
-
-%%       case App(e1, e2) =>
-%%         val a = newTyvar()
-%%         val s1 = tp(env, e1, Arrow(a, t), s)
-%%         tp(env, e2, a, s1)
-
-%%       case Let(x, e1, e2) =>
-%%         val a = newTyvar()
-%%         val s1 = tp(env, e1, a, s)
-%%         tp({x, gen(s1(env), s1(a))} :: env, e2, t, s1)
-%%     }
-%%   } 
-%%   var current: Term = null
-%% \end{lstlisting}
-%% To aid error diagnostics, the \code{tp} function stores the currently
-%% analyzed sub-term in variable \code{current}. Thus, if type checking
-%% is aborted with a \code{TypeError} exception, this variable will
-%% contain the subterm that caused the problem.
-
-%% The last function of the type inference module, \code{typeOf}, is a
-%% simplified facade for \code{tp}. It computes the type of a given term
-%% $e$ in a given environment $env$. It does so by creating a fresh type
-%% variable $a$, computing a typing substitution that makes $env \ts e: a$
-%% into a derivable type judgment, and returning
-%% the result of applying the substitution to $a$.
-%% \begin{lstlisting}
-%%   def typeOf(env: Env, e: Term): Type = {
-%%     val a = newTyvar()
-%%     tp(env, e, a, emptySubst)(a)
-%%   }
-%% }// end typeInfer
-%% \end{lstlisting}
-%% To apply the type inferencer, it is convenient to have a predefined
-%% environment that contains bindings for commonly used constants. The
-%% module \code{predefined} defines an environment \code{env} that
-%% contains bindings for the types of booleans, numbers and lists
-%% together with some primitive operations over them. It also
-%% defines a fixed point operator \code{fix}, which can be used to
-%% represent recursion.
+Given this definition, let's test whether
+\begin{lstlisting}
+val x = new BankAccount; val y = new BankAccount
+\end{lstlisting}
+defines values \code{x} and \code{y} which are the same.
+Here are the definitions again, followed by a test sequence:
+
+\begin{lstlisting}
+> val x = new BankAccount
+> val y = new BankAccount
+> x deposit 30
+30
+> y withdraw 20
+java.lang.RuntimeException: insufficient funds
+\end{lstlisting}
+
+Now, rename all occurrences of \code{y} in that sequence to
+\code{x}. We get:
+\begin{lstlisting}
+> val x = new BankAccount
+> val y = new BankAccount
+> x deposit 30
+30
+> x withdraw 20
+10
+\end{lstlisting}
+Since the final results are different, we have established that
+\code{x} and \code{y} are not the same.
+On the other hand, if we define
+\begin{lstlisting}
+val x = new BankAccount; val y = x
+\end{lstlisting}
+then no sequence of operations can distinguish between \code{x} and
+\code{y}, so \code{x} and \code{y} are the same in this case.
+
+\paragraph{Assignment and the Substitution Model}
+These examples show that our previous substitution model of
+computation cannot be used anymore.  After all, under this
+model we could always replace a value name by its
+defining expression.
+For instance in
+\begin{lstlisting}
+val x = new BankAccount; val y = x
+\end{lstlisting}
+the \code{x} in the definition of \code{y} could
+be replaced by \code{new BankAccount}.
+But we have seen that this change leads to a different program.
+So the substitution model must be invalid, once we add assignments. 
+
+\section{Imperative Control Structures}
+
+Scala has the \code{while} and \code{do-while} loop constructs known
+from the C and Java languages. There is also a single branch \code{if}
+which leaves out the else-part as well as a \code{return} statement which
+aborts a function prematurely. This makes it possible to program in a
+conventional imperative style. For instance, the following function,
+which computes the \code{n}'th power of a given parameter \code{x}, is
+implemented using \code{while} and single-branch \code{if}.
+\begin{lstlisting}
+def power(x: Double, n: Int): Double = {
+  var r = 1.0
+  var i = n
+  var j = 0
+  while (j < 32) {
+    r = r * r
+    if (i < 0)
+      r *= x
+    i = i << 1
+    j += 1
+  }
+  r
+}
+\end{lstlisting}
+These imperative control constructs are in the language for
+convenience. They could have been left out, as the same constructs can
+be implemented using just functions. As an example, let's develop a
+functional implementation of the while loop. \code{whileLoop} should
+be a function that takes two parameters: a condition, of type
+\code{Boolean}, and a command, of type \code{Unit}. Both condition and
+command need to be passed by-name, so that they are evaluated
+repeatedly for each loop iteration.  This leads to the following
+definition of \code{whileLoop}.
+\begin{lstlisting}
+def whileLoop(condition: => Boolean)(command: => Unit) {
+  if (condition) {
+    command; whileLoop(condition)(command)
+  } else ()
+}
+\end{lstlisting}
+Note that \code{whileLoop} is tail recursive, so it operates in
+constant stack space.
+
+\begin{exercise} Write a function \code{repeatLoop}, which should be 
+applied as follows:
+\begin{lstlisting}
+repeatLoop { command } ( condition )
+\end{lstlisting}
+Is there also a way to obtain a loop syntax like the following?
+\begin{lstlisting}
+repeatLoop { command } until ( condition )
+\end{lstlisting}
+\end{exercise}
+
+Some other control constructs known from C and Java are missing in
+Scala: There are no \code{break} and \code{continue} jumps for loops.
+There are also no for-loops in the Java sense -- these have been
+replaced by the more general for-loop construct discussed in
+Section~\ref{sec:for-loops}.
+
+\section{Extended Example: Discrete Event Simulation}
+
+We now discuss an example that demonstrates how assignments and
+higher-order functions can be combined in interesting ways.  
+We will build a simulator for digital circuits.
+
+The example is taken from Abelson and Sussman's book
+\cite{abelson-sussman:structure}. We augment their basic (Scheme-)
+code by an object-oriented structure which allows code-reuse through
+inheritance. The example also shows how discrete event simulation programs
+in general are structured and built.
+
+We start with a little language to describe digital circuits.
+A digital circuit is built from {\em wires} and {\em function boxes}.
+Wires carry signals which are transformed by function boxes.
+We will represent signals by the booleans \code{true} and
+\code{false}.
+
+Basic function boxes (or: {\em gates}) are:
+\begin{itemize}
+\item An \emph{inverter}, which negates its signal
+\item An \emph{and-gate}, which sets its output to the conjunction of its input.
+\item An \emph{or-gate}, which sets its output to the disjunction of its
+input.
+\end{itemize}
+Other function boxes can be built by combining basic ones.
+
+Gates have {\em delays}, so an output of a gate will change only some
+time after its inputs change.
+
+\paragraph{A Language for Digital Circuits}
+
+We describe the elements of a digital circuit by the following set of
+Scala classes and functions.
+
+First, there is a class \code{Wire} for wires.
+We can construct wires as follows.
+\begin{lstlisting}
+val a = new Wire
+val b = new Wire
+val c = new Wire
+\end{lstlisting}
+Second, there are procedures
+\begin{lstlisting}
+def inverter(input: Wire, output: Wire)
+def andGate(a1: Wire, a2: Wire, output: Wire)
+def orGate(o1: Wire, o2: Wire, output: Wire)
+\end{lstlisting}
+which ``make'' the basic gates we need (as side-effects).
+More complicated function boxes can now be built from these.
+For instance, to construct a half-adder, we can define:
+\begin{lstlisting}
+  def halfAdder(a: Wire, b: Wire, s: Wire, c: Wire) {
+    val d = new Wire
+    val e = new Wire
+    orGate(a, b, d)
+    andGate(a, b, c)
+    inverter(c, e)
+    andGate(d, e, s)
+  }
+\end{lstlisting}
+This abstraction can itself be used, for instance in defining a full
+adder:
+\begin{lstlisting}
+  def fullAdder(a: Wire, b: Wire, cin: Wire, sum: Wire, cout: Wire) {
+    val s = new Wire
+    val c1 = new Wire
+    val c2 = new Wire
+    halfAdder(a, cin, s, c1)
+    halfAdder(b, s, sum, c2)
+    orGate(c1, c2, cout)
+  }
+\end{lstlisting}
+Class \code{Wire} and functions \code{inverter}, \code{andGate}, and
+\code{orGate} represent thus a little language in which users can
+define digital circuits.  We now give implementations of this class
+and these functions, which allow one to simulate circuits.
+These implementations are based on a simple and general API for
+discrete event simulation.
+
+\paragraph{The Simulation API}
+
+Discrete event simulation performs user-defined \emph{actions} at
+specified \emph{times}.  
+An {\em action} is represented as a function which takes no parameters and
+returns a \code{Unit} result:
+\begin{lstlisting}
+type Action = () => Unit
+\end{lstlisting}
+The \emph{time} is simulated; it is not the actual ``wall-clock'' time.
+
+A concrete simulation will be done inside an object which inherits
+from the abstract \code{Simulation} class. This class has the following
+signature:
+
+\begin{lstlisting}
+abstract class Simulation {
+  def currentTime: Int
+  def afterDelay(delay: Int, action: => Action)
+  def run()
+}
+\end{lstlisting}
+Here,
+\code{currentTime} returns the current simulated time as an integer
+number,
+\code{afterDelay} schedules an action to be performed at a specified
+delay after \code{currentTime}, and
+\code{run} runs the simulation until there are no further actions to be 
+performed.
+
+\paragraph{The Wire Class}
+A wire needs to support three basic actions.
+\begin{itemize}
+\item[]
+\code{getSignal: Boolean}~~ returns the current signal on the wire.
+\item[]
+\code{setSignal(sig: Boolean)}~~ sets the wire's signal to \code{sig}.
+\item[]
+\code{addAction(p: Action)}~~ attaches the specified procedure
+\code{p} to the {\em actions} of the wire. All attached action
+procedures will be executed every time the signal of a wire changes.
+\end{itemize}
+Here is an implementation of the \code{Wire} class:
+\begin{lstlisting}
+class Wire {
+  private var sigVal = false
+  private var actions: List[Action] = List()
+  def getSignal = sigVal
+  def setSignal(s: Boolean) =
+    if (s != sigVal) {
+      sigVal = s
+      actions.foreach(action => action())
+    }
+  def addAction(a: Action) {
+    actions = a :: actions; a()
+  }
+}
+\end{lstlisting}
+Two private variables make up the state of a wire.  The variable
+\code{sigVal} represents the current signal, and the variable
+\code{actions} represents the action procedures currently attached to
+the wire.
+
+\paragraph{The Inverter Class}
+We implement an inverter by installing an action on its input wire,
+namely the action which puts the negated input signal onto the output
+signal.  The action needs to take effect at \code{InverterDelay}
+simulated time units after the input changes. This suggests the 
+following implementation:
+\begin{lstlisting}
+def inverter(input: Wire, output: Wire) {
+  def invertAction() {
+    val inputSig = input.getSignal
+    afterDelay(InverterDelay) { output setSignal !inputSig }
+  }
+  input addAction invertAction
+}
+\end{lstlisting}
+
+\paragraph{The And-Gate Class}
+And-gates are implemented analogously to inverters.  The action of an
+\code{andGate} is to output the conjunction of its input signals.
+This should happen at \code{AndGateDelay} simulated time units after
+any one of its two inputs changes. Hence, the following implementation:
+\begin{lstlisting}
+def andGate(a1: Wire, a2: Wire, output: Wire) {
+  def andAction() {
+    val a1Sig = a1.getSignal
+    val a2Sig = a2.getSignal
+    afterDelay(AndGateDelay) { output setSignal (a1Sig & a2Sig) }
+  }
+  a1 addAction andAction
+  a2 addAction andAction
+}
+\end{lstlisting}
+
+\begin{exercise} Write the implementation of \code{orGate}.
+\end{exercise}
+
+\begin{exercise} Another way is to define an or-gate by a combination of
+inverters and and gates. Define a function \code{orGate} in terms of
+\code{andGate} and \code{inverter}. What is the delay time of this function?
+\end{exercise}
+
+\paragraph{The Simulation Class}
+
+Now, we just need to implement class \code{Simulation}, and we are
+done.  The idea is that we maintain inside a \code{Simulation} object
+an \emph{agenda} of actions to perform.  The agenda is represented as
+a list of pairs of actions and the times they need to be run.  The
+agenda list is sorted, so that earlier actions come before later ones.
+\begin{lstlisting} 
+abstract class Simulation {
+  case class WorkItem(time: Int, action: Action)
+  private type Agenda = List[WorkItem]
+  private var agenda: Agenda = List()
+\end{lstlisting}
+There is also a private variable \code{curtime} to keep track of the
+current simulated time.
+\begin{lstlisting}
+  private var curtime = 0
+\end{lstlisting}
+An application of the method \code{afterDelay(delay, block)} 
+inserts the element \lstinline@WorkItem(currentTime + delay, () => block)@
+into the \code{agenda} list at the appropriate place.
+\begin{lstlisting}
+private def insert(ag: Agenda, item: WorkItem): Agenda =
+  if (ag.isEmpty || item.time < ag.head.time) item :: ag
+  else ag.head :: insert(ag.tail, item)
+
+def afterDelay(delay: Int)(block: => Unit) {
+  val item = WorkItem(currentTime + delay, () => block)
+  agenda = insert(agenda, item)
+}
+\end{lstlisting}
+An application of the \code{run} method removes successive elements
+from the \code{agenda} and performs their actions.
+It continues until the agenda is empty:
+\begin{lstlisting}
+private def next() {
+  agenda match {
+    case WorkItem(time, action) :: rest =>
+      agenda = rest; curtime = time; action()
+    case List() =>
+  }
+}
+
+def run() {
+  afterDelay(0) { println("*** simulation started ***") }
+  while (!agenda.isEmpty) next()
+}
+\end{lstlisting}
+
+\paragraph{Running the Simulator}
+To run the simulator, we still need a way to inspect changes of
+signals on wires. To this purpose, we write a function \code{probe}.
+\begin{lstlisting}
+def probe(name: String, wire: Wire) {
+  wire addAction { () =>
+    println(name + " " + currentTime + " new_value = " + wire.getSignal)
+  }
+}
+\end{lstlisting}
+Now, to see the simulator in action, let's define four wires, and place
+probes on two of them: 
+\begin{lstlisting}
+scala> val input1, input2, sum, carry = new Wire
+
+scala> probe("sum", sum)
+sum 0 new_value = false
+
+scala> probe("carry", carry)
+carry 0 new_value = false
+\end{lstlisting}
+Now let's define a half-adder connecting the wires:
+\begin{lstlisting}
+scala> halfAdder(input1, input2, sum, carry)
+\end{lstlisting}
+Finally, set one after another the signals on the two input wires to
+\code{true} and run the simulation.
+\begin{lstlisting}
+scala> input1 setSignal true; run
+*** simulation started ***
+sum 8 new_value = true
+
+scala> input2 setSignal true; run
+carry 11 new_value = true
+sum 15 new_value = false
+\end{lstlisting}
+
+\section{Summary}
+
+We have seen in this chapter the constructs that let us model state in
+Scala -- these are variables, assignments, and imperative control
+structures.  State and Assignment complicate our mental model of
+computation.  In particular, referential transparency is lost.  On the
+other hand, assignment gives us new ways to formulate programs
+elegantly. As always, it depends on the situation whether purely
+functional programming or programming with assignments works best.
+
+\chapter{Computing with Streams}
+
+The previous chapters have introduced variables, assignment and
+stateful objects.  We have seen how real-world objects that change
+with time can be modeled by changing the state of variables in a
+computation.  Time changes in the real world thus are modeled by time
+changes in program execution. Of course, such time changes are usually
+stretched out or compressed, but their relative order is the same.
+This seems quite natural, but there is a also price to pay: Our simple
+and powerful substitution model for functional computation is no
+longer applicable once we introduce variables and assignment.
+
+Is there another way? Can we model state change in the real world
+using only immutable functions? Taking mathematics as a guide, the
+answer is clearly yes: A time-changing quantity is simply modeled by
+a function \code{f(t)} with a time parameter \code{t}. The same can be
+done in computation. Instead of overwriting a variable with successive
+values, we represent all these values as successive elements in a
+list. So, a mutable variable \code{var x: T} gets replaced by an
+immutable value \code{val x: List[T]}. In a sense, we trade space for
+time -- the different values of the variable now all exist concurrently
+as different elements of the list.  One advantage of the list-based
+view is that we can ``time-travel'', i.e. view several successive
+values of the variable at the same time. Another advantage is that we
+can make use of the powerful library of list processing functions,
+which often simplifies computation. For instance, consider the
+imperative way to compute the sum of all prime numbers in an interval:
+\begin{lstlisting}
+def sumPrimes(start: Int, end: Int): Int = {
+  var i = start
+  var acc = 0
+  while (i < end) {
+    if (isPrime(i)) acc += i
+    i += 1
+  }
+  acc
+}
+\end{lstlisting}
+Note that the variable \code{i} ``steps through'' all values of the interval
+\code{[start .. end-1]}.
+
+A more functional way is to represent the list of values of variable \code{i} directly as \code{range(start, end)}. Then the function can be rewritten as follows.
+\begin{lstlisting}
+def sumPrimes(start: Int, end: Int) =
+  sum(range(start, end) filter isPrime)
+\end{lstlisting}
+
+No contest which program is shorter and clearer!  However, the
+functional program is also considerably less efficient since it
+constructs a list of all numbers in the interval, and then another one
+for the prime numbers. Even worse from an efficiency point of view is
+the following example:
+
+To find the second prime number between \code{1000} and \code{10000}:
+\begin{lstlisting}
+  range(1000, 10000) filter isPrime at 1
+\end{lstlisting}
+Here, the list of all numbers between \code{1000} and \code{10000} is
+constructed.  But most of that list is never inspected!
+
+However, we can obtain efficient execution for examples like these by
+a trick:
+\begin{quote}
+%\red
+ Avoid computing the tail of a sequence unless that tail is actually
+     necessary for the computation.
+\end{quote}
+We define a new class for such sequences, which is called \code{Stream}.
+
+Streams are created using the constant \code{empty} and the constructor \code{cons},
+which are both defined in module \code{scala.Stream}. For instance, the following
+expression constructs a stream with elements \code{1} and \code{2}:
+\begin{lstlisting}
+Stream.cons(1, Stream.cons(2, Stream.empty))
+\end{lstlisting}
+As another example, here is the analogue of \code{List.range},
+but returning a stream instead of a list:
+\begin{lstlisting}
+def range(start: Int, end: Int): Stream[Int] =
+  if (start >= end) Stream.empty
+  else Stream.cons(start, range(start + 1, end))
+\end{lstlisting}
+(This function is also defined as given above in module
+\code{Stream}).  Even though \code{Stream.range} and \code{List.range}
+look similar, their execution behavior is completely different: 
+
+\code{Stream.range} immediately returns with a \code{Stream} object
+whose first element is \code{start}.  All other elements are computed
+only when they are \emph{demanded} by calling the \code{tail} method
+(which might be never at all).  
+
+Streams are accessed just as lists. Similarly to lists, the basic access
+methods are \code{isEmpty}, \code{head} and \code{tail}. For instance,
+we can print all elements of a stream as follows.
+\begin{lstlisting}
+def print(xs: Stream[A]) {
+  if (!xs.isEmpty) { Console.println(xs.head); print(xs.tail) }
+}
+\end{lstlisting}
+Streams also support almost all other methods defined on lists (see
+below for where their methods sets differ). For instance, we can find
+the second prime number between \code{1000} and \code{10000} by applying methods
+\code{filter} and \code{apply} on an interval stream:
+\begin{lstlisting}
+  Stream.range(1000, 10000) filter isPrime at 1
+\end{lstlisting}
+The difference to the previous list-based implementation is that now
+we do not needlessly construct and test for primality any numbers
+beyond 1013.
+
+\paragraph{Consing and appending streams} Two methods in class \code{List}
+which are not supported by class \code{Stream} are \code{::} and
+\code{:::}.  The reason is that these methods are dispatched on their
+right-hand side argument, which means that this argument needs to be
+evaluated before the method is called. For instance, in the case of
+\code{x :: xs} on lists, the tail \code{xs} needs to be evaluated
+before \code{::} can be called and the new list can be constructed.
+This does not work for streams, where we require that the tail of a
+stream should not be evaluated until it is demanded by a \code{tail} operation.
+The argument why list-append \code{:::} cannot be adapted to streams is analogous.
+
+Instead of \code{x :: xs}, one uses \code{Stream.cons(x, xs)} for
+constructing a stream with first element \code{x} and (unevaluated)
+rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
+\code{xs append ys}.  
+
+\chapter{Iterators}
+
+Iterators are the imperative version of streams. Like streams,
+iterators describe potentially infinite lists. However, there is no
+data-structure which contains the elements of an iterator. Instead, 
+iterators allow one to step through the sequence, using two abstract methods \code{next} and \code{hasNext}.
+\begin{lstlisting}
+trait Iterator[+A] {
+  def hasNext: Boolean
+  def next: A
+\end{lstlisting}
+Method \code{next} returns successive elements.  Method \code{hasNext}
+indicates whether there are still more elements to be returned by
+\code{next}. Iterators also support some other methods, which are
+explained later.
+
+As an example, here is an application which prints the squares of all
+numbers from 1 to 100.
+\begin{lstlisting}
+val it: Iterator[Int] = Iterator.range(1, 100)
+while (it.hasNext) {
+  val x = it.next
+  println(x * x)
+}
+\end{lstlisting}
+
+\section{Iterator Methods}
+
+Iterators support a rich set of methods besides \code{next} and
+\code{hasNext}, which is described in the following. Many of these
+methods mimic a corresponding functionality in lists.
+
+\paragraph{Append}
+Method \code{append} constructs an iterator which resumes with the
+given iterator ~\code{it}~ after the current iterator has finished.
+\begin{lstlisting}
+  def append[B >: A](that: Iterator[B]): Iterator[B] = new Iterator[B] {
+    def hasNext = Iterator.this.hasNext || that.hasNext
+    def next = if (Iterator.this.hasNext) Iterator.this.next else that.next
+  }    
+\end{lstlisting}
+The terms \code{Iterator.this.next} and \code{Iterator.this.hasNext}
+in the definition of \code{append} call the corresponding methods as
+they are defined in the enclosing \code{Iterator} class.  If the
+\code{Iterator} prefix to \code{this} would have been missing,
+\code{hasNext} and \code{next} would have called recursively the
+methods being defined in the result of \code{append}, which is not
+what we want.
+
+\paragraph{Map, FlatMap, Foreach} Method \code{map} 
+constructs an iterator which returns all elements of the original
+iterator transformed by a given function \code{f}.
+\begin{lstlisting}
+  def map[B](f: A => B): Iterator[B] = new Iterator[B] {
+    def hasNext = Iterator.this.hasNext
+    def next = f(Iterator.this.next)
+  }
+\end{lstlisting}
+Method \code{flatMap} is like method \code{map}, except that the
+transformation function \code{f} now returns an iterator.
+The result of \code{flatMap} is the iterator resulting from appending
+together all iterators returned from successive calls of \code{f}.
+\begin{lstlisting}
+  def flatMap[B](f: A => Iterator[B]): Iterator[B] = new Iterator[B] {
+    private var cur: Iterator[B] = Iterator.empty
+    def hasNext: Boolean =
+      if (cur.hasNext) true
+      else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); hasNext }
+      else false
+    def next: B =
+      if (cur.hasNext) cur.next
+      else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); next }
+      else error("next on empty iterator")
+  }
+\end{lstlisting}
+Closely related to \code{map} is the \code{foreach} method, which
+applies a given function to all elements of an iterator, but does not
+construct a list of results
+\begin{lstlisting}
+  def foreach(f: A => Unit): Unit =
+    while (hasNext) { f(next) }
+\end{lstlisting}
+
+\paragraph{Filter} Method \code{filter} constructs an iterator which
+returns all elements of the original iterator that satisfy a criterion
+\code{p}.
+\begin{lstlisting}
+  def filter(p: A => Boolean) = new BufferedIterator[A] {
+    private val source =
+      Iterator.this.buffered
+    private def skip =
+      { while (source.hasNext && !p(source.head)) { source.next } }
+    def hasNext: Boolean =
+      { skip; source.hasNext }
+    def next: A =
+      { skip; source.next }
+    def head: A =
+      { skip; source.head }
+  }
+\end{lstlisting}
+In fact, \code{filter} returns instances of a subclass of iterators
+which are ``buffered''.  A \code{BufferedIterator} object is an
+iterator which has in addition a method \code{head}. This method
+returns the element which would otherwise have been returned by
+\code{head}, but does not advance beyond that element. Hence, the
+element returned by \code{head} is returned again by the next call to
+\code{head} or \code{next}. Here is the definition of the
+\code{BufferedIterator} trait.
+\begin{lstlisting}
+trait BufferedIterator[+A] extends Iterator[A] {
+  def head: A
+}
+\end{lstlisting}
+Since \code{map}, \code{flatMap}, \code{filter}, and \code{foreach}
+exist for iterators, it follows that for-comprehensions and for-loops
+can also be used on iterators. For instance, the application which prints the squares of numbers between 1 and 100 could have equivalently been expressed as follows.
+\begin{lstlisting}
+for (i <- Iterator.range(1, 100))
+  println(i * i)
+\end{lstlisting}
+
+\paragraph{Zip} Method \code{zip} takes another iterator and
+returns an iterator consisting of pairs of corresponding elements
+returned by the two iterators.
+\begin{lstlisting}
+  def zip[B](that: Iterator[B]) = new Iterator[(A, B)] {
+    def hasNext = Iterator.this.hasNext && that.hasNext
+    def next = (Iterator.this.next, that.next)
+  }
+}
+\end{lstlisting}
+
+\section{Constructing Iterators}
+
+Concrete iterators need to provide implementations for the two
+abstract methods \code{next} and \code{hasNext} in class
+\code{Iterator}. The simplest iterator is \code{Iterator.empty} which
+always returns an empty sequence:
+\begin{lstlisting}
+object Iterator {
+  object empty extends Iterator[Nothing] {
+    def hasNext = false
+    def next = error("next on empty iterator")
+  }
+\end{lstlisting}
+A more interesting iterator enumerates all elements of an array. This
+iterator is constructed by the \code{fromArray} method, which is also defined in the object \code{Iterator}
+\begin{lstlisting}
+  def fromArray[A](xs: Array[A]) = new Iterator[A] {
+    private var i = 0
+    def hasNext: Boolean =
+      i < xs.length
+    def next: A =
+      if (i < xs.length) { val x = xs(i); i += 1; x }
+      else error("next on empty iterator")
+  }
+\end{lstlisting}
+Another iterator enumerates an integer interval.  The
+\code{Iterator.range} function returns an iterator which traverses a
+given interval of integer values. It is defined as follows.
+\begin{lstlisting}
+object Iterator {
+  def range(start: Int, end: Int) = new Iterator[Int] {
+    private var current = start
+    def hasNext = current < end
+    def next = {
+      val r = current
+      if (current < end) current += 1
+      else error("end of iterator")
+      r
+    }
+  }
+}
+\end{lstlisting}
+All iterators seen so far terminate eventually. It is also possible to
+define iterators that go on forever. For instance, the following
+iterator returns successive integers from some start
+value\footnote{Due to the finite representation of type \prog{int},
+numbers will wrap around at $2^{31}$.}.
+\begin{lstlisting}
+def from(start: Int) = new Iterator[Int] {
+  private var last = start - 1
+  def hasNext = true
+  def next = { last += 1; last }
+}
+\end{lstlisting}
+
+\section{Using Iterators}
+
+Here are two more examples how iterators are used. First, to print all
+elements of an array \code{xs: Array[Int]}, one can write:
+\begin{lstlisting}
+  Iterator.fromArray(xs) foreach (x => println(x))
+\end{lstlisting}
+Or, using a for-comprehension:
+\begin{lstlisting}
+  for (x <- Iterator.fromArray(xs))
+    println(x)
+\end{lstlisting}
+As a second example, consider the problem of finding the indices of
+all the elements in an array of \code{double}s greater than some
+\code{limit}. The indices should be returned as an iterator.
+This is achieved by the following expression.
+\begin{lstlisting}
+import Iterator._
+fromArray(xs)
+.zip(from(0))
+.filter(case (x, i) => x > limit)
+.map(case (x, i) => i)
+\end{lstlisting}
+Or, using a for-comprehension:
+\begin{lstlisting}
+import Iterator._
+for ((x, i) <- fromArray(xs) zip from(0); x > limit)
+yield i
+\end{lstlisting}
+
+\chapter{Lazy Values}
+
+Lazy values provide a way to delay initialization of a value until the
+first time it is accessed. This may be useful when dealing with
+values that might not be needed during execution, and whose
+computational cost is signifficant. As a first example, let's consider
+a database of employees, containing for each employee its manager and
+its team.
+\begin{lstlisting}
+case class Employee(id: Int, 
+                    name: String, 
+                    managerId: Int) {
+  val manager: Employee = Db.get(managerId)
+  val team: List[Employee] = Db.team(id)
+}
+\end{lstlisting}
+
+The \lstinline@Employee@ class given above will eagerly initialize
+all its fields, loading the whole employee table in memory. This is
+certainly not optimal, and it can be easily  improved my making the
+fields lazy. This way we delay the database access until it is really
+needed, if it is ever needed.
+\begin{lstlisting}
+case class Employee(id: Int, 
+                    name: String, 
+                    managerId: Int) {
+  lazy val manager: Employee = Db.get(managerId)
+  lazy val team: List[Employee] = Db.team(id)
+}
+\end{lstlisting}
+
+To see what is really happening, we can use this mockup
+database which shows when records are fetched:
+\begin{lstlisting}
+object Db {
+  val table = Map(1 -> (1, "Haruki Murakami", -1),
+                  2 -> (2, "Milan Kundera", 1),
+                  3 -> (3, "Jeffrey Eugenides", 1),
+                  4 -> (4, "Mario Vargas Llosa", 1),
+                  5 -> (5, "Julian Barnes", 2))
+
+  def team(id: Int) = {
+    for (rec <- table.values.toList; if rec._3 == id)
+      yield recToEmployee(rec)
+  }
+
+  def get(id: Int) = recToEmployee(table(id))
+
+  private def recToEmployee(rec: (Int, String, Int)) = {
+    println("[db] fetching " + rec._1)
+    Employee(rec._1, rec._2, rec._3)
+  }
+}
+\end{lstlisting}
+The output when running a program that retrieves one employee 
+confirms that the database is only accessed when referring  the lazy
+values.
+
+Another use of lazy values is to resolve the
+initialization order of applications composed of several
+modules. Before lazy values were introduced, the same effect was
+achieved by using \lstinline@object@ definitions. As a second example,
+we consider a compiler composed of several modules. We look first at a
+simple symbol table that defines a class for symbols and two
+predefined functions.
+\begin{lstlisting}
+class Symbols(val compiler: Compiler) {
+  import compiler.types._
+
+  val Add = new Symbol("+", FunType(List(IntType, IntType), IntType))
+  val Sub = new Symbol("-", FunType(List(IntType, IntType), IntType))
+
+  class Symbol(name: String, tpe: Type) {
+    override def toString = name + ": " + tpe
+  }
+}
+\end{lstlisting}
+The \lstinline@symbols@ module is parameterized with a \lstinline@Compiler@
+instance, which provides access to other services, such as the types
+module. In our example there are only two predefined functions,
+addition and subtraction, and their definitions depend on the \lstinline@types@
+module.
+\begin{lstlisting}
+class Types(val compiler: Compiler) {
+  import compiler.symtab._
+
+  abstract class Type
+  case class FunType(args: List[Type], res: Type) extends Type
+  case class NamedType(sym: Symbol) extends Type
+  case object IntType extends Type
+}
+\end{lstlisting}
+In order to hook the two components together a compiler object is
+created and passed as an argument to the two components. 
+\begin{lstlisting}
+class Compiler {
+  val symtab = new Symbols(this)
+  val types  = new Types(this)
+}
+\end{lstlisting}
+Unfortunately, the straight-forward approach fails at runtime because
+the \lstinline@symtab@ module needs the \lstinline@types@
+module. In general, the dependency between modules can be complicated
+and getting the right initialization order is difficult, or even
+impossible when there are cycles. The easy fix is to make such fields
+\lstinline@lazy@ and let the compiler figure out the right order.
+\begin{lstlisting}
+class Compiler {
+  lazy val symtab = new Symbols(this)
+  lazy val types  = new Types(this)
+}
+\end{lstlisting}
+Now the two modules are initialized on first access, and the compiler
+may run as expected. 
+
+\subsection*{Syntax}
+The \lstinline@lazy@ modifier is allowed only on concrete value
+definitions. All typing rules for value definitions apply for
+\lstinline@lazy@ values as well, with one restriction removed:
+recursive local values are allowed.
+
+\chapter{Implicit Parameters and Conversions}\label{sec:implicits}
+
+Implicit parameters and conversions are powerful tools for
+custimizing existing libraries and for creating high-level
+abstractions. As an example, let's start with an abstract class of
+semi-groups that support an unspecified \lstinline@add@ operation.
+\begin{lstlisting}
+abstract class SemiGroup[A] {
+  def add(x: A, y: A): A
+}
+\end{lstlisting}
+Here's a subclass \lstinline@Monoid@ of \lstinline@SemiGroup@ which adds a
+\lstinline@unit@ element.
+\begin{lstlisting}
+abstract class Monoid[A] extends SemiGroup[A] {
+  def unit: A
+}
+\end{lstlisting}
+Here are two implementations of monoids:
+\begin{lstlisting}
+object stringMonoid extends Monoid[String] {
+  def add(x: String, y: String): String = x.concat(y)
+  def unit: String = ""
+}
+
+object intMonoid extends Monoid[Int] {
+  def add(x: Int, y: Int): Int = x + y
+  def unit: Int = 0
+}
+\end{lstlisting}
+A \lstinline@sum@ method, which works over arbitrary
+monoids, can be written in plain Scala as follows.
+\begin{lstlisting}
+def sum[A](xs: List[A])(m: Monoid[A]): A =
+  if (xs.isEmpty) m.unit
+  else m.add(xs.head, sum(m)(xs.tail)
+\end{lstlisting}
+This \lstinline@sum@ method can be called as follows:
+\begin{lstlisting}
+sum(List("a", "bc", "def"))(stringMonoid)
+sum(List(1, 2, 3))(intMonoid)
+\end{lstlisting}
+All this works, but it is not very nice. The problem is that the
+monoid implementations have to be passed into all code that uses them.
+We would sometimes wish that the system could figure out the correct
+arguments automatically, similar to what is done when type arguments
+are inferred. This is what implicit parameters provide.
+
+\subsection*{Implicit Parameters: The Basics}
+
+In Scala 2 there is a new \lstinline@implicit@ keyword that can be
+used at the beginning of a parameter list. Syntax:
+\begin{lstlisting}
+ParamClauses ::= {`(' [Param {`,' Param}] ')'} 
+                 [`(' implicit Param {`,' Param} `)']
+\end{lstlisting}
+If the keyword is present, it makes all parameters in the list
+implicit.  
+For instance, the following version of \lstinline@sum@ has
+\lstinline@m@ as an implicit parameter.
+\begin{lstlisting}
+def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
+  if (xs.isEmpty) m.unit
+  else m.add(xs.head, sum(xs.tail))
+\end{lstlisting}
+As can be seen from the example, it is possible to combine normal and
+implicit parameters. However, there may only be one implicit parameter
+list for a method or constructor, and it must come last.
+
+\lstinline@implicit@ can also be used as a modifier for definitions
+and declarations. Examples:
+
+\begin{lstlisting}
+implicit object stringMonoid extends Monoid[String] {
+  def add(x: String, y: String): String = x.concat(y)
+  def unit: String = ""
+}
+implicit object intMonoid extends Monoid[Int] {
+  def add(x: Int, y: Int): Int = x + y
+  def unit: Int = 0
+}
+\end{lstlisting}
+
+The principal idea behind implicit parameters is that arguments for
+them can be left out from a method call. If the arguments
+corresponding to an implicit parameter section are missing, they are
+inferred by the Scala compiler.
+
+The actual arguments that are eligible to be passed to an implicit
+parameter are all identifiers X that can be accessed at the point
+of the method call without a prefix and that denote an implicit
+definition or parameter.
+
+If there are several eligible arguments which match the implicit
+parameter's type, the Scala compiler will chose a most specific one,
+using the standard rules of static overloading resolution.
+For instance, assume the call
+\begin{lstlisting}
+  sum(List(1, 2, 3))
+\end{lstlisting}
+in a context where \lstinline@stringMonoid@ and \lstinline@intMonoid@
+are visible.  We know that the formal type parameter \lstinline@a@ of
+\lstinline@sum@ needs to be instantiated to \lstinline@int@. The only
+eligible value which matches the implicit formal parameter type
+\lstinline@Monoid[Int]@ is \lstinline@intMonoid@ so this object will %
+be passed as implicit parameter.
+
+This discussion also shows that implicit parameters are inferred after
+any type arguments are inferred. 
+
+\subsection*{Implicit Conversions}
+
+Say you have an expression $E$ of type $T$ which is expected to type
+$S$. $T$ does not conform to $S$ and is not convertible to $S$ by
+some other predefined conversion. Then the Scala compiler will try to
+apply as last resort an implicit conversion $I(E)$. Here, $I$ is an
+identifier denoting an implicit definition or parameter that is
+accessible without a prefix at the point of the conversion, that can
+be applied to arguments of type $T$ and whose result type conforms to the
+expected type $S$.
+
+Implicit conversions can also be applied in member
+selections. Given a selection $E.x$ where $x$ is not a member of the
+type $E$, the Scala compiler will try to insert an implicit conversion
+$I(E).x$, so that $x$ is a member of $I(E)$.
+
+Here is an example of an implicit conversion function that converts
+integers into instances of class \lstinline@scala.Ordered@:
+\begin{lstlisting}
+implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
+  def compare(y: Int): Int =
+    if (x < y) -1
+    else if (x > y) 1
+    else 0
+}
+\end{lstlisting}
+
+\subsection*{View Bounds}
+
+View bounds are convenient syntactic sugar for implicit
+parameters. Consider for instance a generic sort method:
+\begin{lstlisting}
+def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
+  if (xs.isEmpty || xs.tail.isEmpty) xs
+  else {
+    val {ys, zs} = xs.splitAt(xs.length / 2)
+    merge(ys, zs)
+  }
+\end{lstlisting}
+The view bounded type parameter \lstinline@[a <$\mbox{\%}$ Ordered[a]]@
+expresses that \lstinline@sort@ is applicable to lists of type
+\lstinline@a@ such that there exists an implicit conversion from
+\lstinline@a@ to \lstinline@Ordered[a]@. The definition is treated as
+a shorthand for the following method signature with an implicit
+parameter:
+\begin{lstlisting}
+def sort[A](xs: List[A])(implicit $c$: A => Ordered[A]): List[A] = ...
+\end{lstlisting}
+(Here, the parameter name $c$ is chosen arbitrarily in a way
+that does not collide with other names in the program.)
+
+As a more detailed example, consider the \lstinline@merge@ method that
+comes with the \lstinline@sort@ method above:
+\begin{lstlisting}
+def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
+  if (xs.isEmpty) ys
+  else if (ys.isEmpty) xs
+  else if (xs.head < ys.head) xs.head :: merge(xs.tail, ys)
+  else if ys.head :: merge(xs, ys.tail)
+\end{lstlisting}
+After expanding view bounds and inserting implicit conversions, this
+method implementation becomes:
+\begin{lstlisting}
+def merge[A](xs: List[A], ys: List[A])
+            (implicit $c$: A => Ordered[A]): List[A] =
+  if (xs.isEmpty) ys
+  else if (ys.isEmpty) xs
+  else if (c(xs.head) < ys.head) xs.head :: merge(xs.tail, ys)
+  else if ys.head :: merge(xs, ys.tail)(c)
+\end{lstlisting}
+The last two lines of this method definition illustrate two different
+uses of the implicit parameter $c$. It is applied in a conversion in
+the condition of the second to last line, and it is passed as implicit
+argument in the recursive call to \lstinline@merge@ on the last line.
+
+\comment{
+\chapter{Combinator Parsing}\label{sec:combinator-parsing}
+
+In this chapter we describe how to write combinator parsers in
+Scala. Such parsers are constructed from predefined higher-order
+functions, so called {\em parser combinators}, that closely model the
+constructions of an EBNF grammar \cite{wirth:ebnf}.
+
+As running example, we consider parsers for possibly nested
+lists of identifiers and numbers, which
+are described by the following context-free grammar.
+\bda{p{3cm}cp{10cm}}
+letter &::=& /* all letters */ \\
+digit  &::=& /* all digits */ \\[0.5em]
+ident  &::=& letter \{letter $|$ digit \}\\
+number &::=& digit \{digit\}\\[0.5em]
+list   &::=& `(' [listElems] `)' \\
+listElems &::=& expr [`,' listElems] \\
+expr   &::=& ident | number | list
+
+\eda
+
+\section{Simple Combinator Parsing}
+
+In this section we will only be concerned with the task of recognizing
+input strings, not with processing them. So we can describe parsers
+by the sets of input strings they accept.  There are two
+fundamental operators over parsers:
+\code{&} expresses the sequential composition of a parser with
+another, while \code{|} expresses an alternative. These operations
+will both be defined as methods of a \code{Parser} class.  We will
+also define constructors for the following primitive parsers:
+
+\begin{tabular}{ll}
+\code{empty}    & The parser that accepts the empty string
+\\
+\code{failure(msg: String)}  & The parser that accepts no string (\verb@msg@ 
+                               stands for an error message)
+
+\\
+\code{chr(c: char)}
+                & The parser that accepts the single-character string ``$c$''.
+\\
+\code{chrSuchThat(p: Char => Boolean)}
+                & The parser that accepts single-character strings
+                  ``$c$'' \\
+                & for which $p(c)$ is true.
+\end{tabular}
+
+There are also the two higher-order parser combinators \code{opt},
+expressing optionality and \code{rep}, expressing repetition.
+For any parser $p$, \code{opt(}$p$\code{)} yields a parser that
+accepts the strings accepted by $p$ or else the empty string, while
+\code{rep(}$p$\code{)} accepts arbitrary sequences of the strings accepted by
+$p$. In EBNF, \code{opt(}$p$\code{)} corresponds to $[p]$ and
+\code{rep(}$p$\code{)} corresponds to $\{p\}$.
+
+The central idea of parser combinators is that parsers can be produced
+by a straightforward rewrite of the grammar, replacing \code{::=} with
+\code{=}, sequencing with
+\code{&}, repetition \code{\{...\}} with
+\code{rep(...)} and optional occurrence \code{[...]} with \code{opt(...)}.
+Applying this process to the grammar of lists
+yields the following trait.
+\begin{lstlisting}
+trait ListParsers extends Parsers {
+  def chrSuchThat(p: Char => Boolean): Parser
+  def chr(c: Char): Parser = chrSuchThat(d ==)
+
+  def letter    : Parser = chr(Character.isLetter)
+  def digit     : Parser = chr(Character.isDigit)
+
+  def ident     : Parser = letter &&& rep(letter ||| digit)
+  def number    : Parser = digit &&& rep(digit)
+  def list      : Parser = chr('(') &&& opt(listElems) &&& chr(')')
+  def listElems : Parser = expr &&& (chr(',') &&& listElems ||| empty)
+  def expr      : Parser = ident ||| number ||| list
+}
+\end{lstlisting}
+This class isolates the grammar from other aspects of parsing. It
+abstracts over the type of input 
+and over the method used to parse a single character
+(represented by the abstract method \code{chr(p: char =>
+boolean))}. The missing bits of information need to be supplied by code
+applying the parser class.
+
+It remains to explain how to implement a library with the combinators
+described above. We will pack combinators and their underlying
+implementation in a base class \code{Parsers}, which is inherited by
+\code{ListParsers}.  The first question to decide is which underlying
+representation type to use for a parser. We treat parsers here
+essentially as functions that take a datum of the input type
+\code{InType} and that yield a parse result of type
+\code{Option[InType]}.  The \code{Option} type is predefined as
+follows.
+\begin{lstlisting}
+abstract class Option[+a]
+case object None extends Option[Nothing]
+case class Some[a](x: a) extends Option[a]
+\end{lstlisting}
+A parser applied to some input either succeeds or fails. If it fails,
+it returns the constant \code{None}. If it succeeds, it returns a
+value of the form \code{Some(in1)} where \code{in1} represents the
+input that remains to be parsed.
+\begin{lstlisting}
+trait Parsers {
+  type InType
+  abstract class Parser {
+    type Result = Option[InType]
+    def apply(in: InType): Result
+\end{lstlisting}
+A parser also implements the combinators
+for sequence and alternative:
+\begin{lstlisting}
+  /*** p &&& q applies first p, and if that succeeds, then q
+   */
+  def &&& (q: => Parser) = new Parser {
+    def apply(in: InType): Result = Parser.this.apply(in) match {
+      case None => None
+      case Some(in1)  => q(in1)
+    }
+  }
+
+  /*** p ||| q applies first p, and, if that fails, then q.
+   */
+  def ||| (q: => Parser) = new Parser {
+    def apply(in: InType): Result = Parser.this.apply(in) match {
+      case None => q(in)
+      case s => s
+    }
+  }
+\end{lstlisting}
+The implementations of the primitive parsers \code{empty} and \code{fail}
+are trivial:
+\begin{lstlisting}
+  val empty = new Parser { def apply(in: InType): Result = Some(in) }
+  val fail  = new Parser { def apply(in: InType): Result = None }
+\end{lstlisting}
+The higher-order parser combinators \code{opt} and \code{rep} can be
+defined in terms of the combinators for sequence and alternative:
+\begin{lstlisting}
+  def opt(p: Parser): Parser = p ||| empty;    // p? = (p | <empty>)
+  def rep(p: Parser): Parser = opt(rep1(p));   // p* = [p+]
+  def rep1(p: Parser): Parser = p &&& rep(p);  // p+ = p p*
+} // end Parser
+\end{lstlisting}
+To run combinator parsers, we still need to decide on a way to handle
+parser input. Several possibilities exist: The input could be
+represented as a list, as an array, or as a random access file.  Note
+that the presented combinator parsers use backtracking to change from
+one alternative to another.  Therefore, it must be possible to reset
+input to a point that was previously parsed. If one restricted the
+focus to LL(1) grammars, a non-backtracking implementation of the
+parser combinators in class \code{Parsers} would also be possible. In
+that case sequential input methods based on (say) iterators or
+sequential files would also be possible.
+
+In our example, we represent the input by a pair of a string, which
+contains the input phrase as a whole, and an index, which represents
+the portion of the input which has not yet been parsed. Since the
+input string does not change, just the index needs to be passed around
+as a result of individual parse steps.  This leads to the following
+class of parsers that read strings:
+\begin{lstlisting}
+class ParseString(s: String) extends Parsers {
+  type InType = Int
+  def chrSuchThat(p: Char => Boolean) = new Parser {
+    def apply(in: Int): Parser#Result =
+      if (in < s.length() && p(s charAt in)) Some(in + 1)
+      else None
+  }
+  val input = 0
+}
+\end{lstlisting}
+This class implements a method \code{chr(p: Char => Boolean)} and a
+value \code{input}. The \code{chr} method builds a parser that either
+reads a single character satisfying the given predicate \code{p} or
+fails.  All other parsers over strings are ultimately implemented in
+terms of that method. The \code{input} value represents the input as a
+whole. In out case, it is simply value \code{0}, the start index of
+the string to be read.
+
+Note \code{apply}'s result type, \code{Parser#Result}. This syntax
+selects the type element \code{Result} of the type \code{Parser}. It
+thus corresponds roughly to selecting a static inner class from some
+outer class in Java. Note that we could {\em not} have written
+\code{Parser.Result}, as the latter would express selection of the
+\code{Result} element from a {\em value} named \code{Parser}.
+
+We have now extended the root class \code{Parsers} in two different
+directions: Class \code{ListParsers} defines a grammar of phrases to
+be parsed, whereas class \code{ParseString} defines a method by which
+such phrases are input. To write a concrete parsing application, we
+need to define both grammar and input method. We do this by combining
+two extensions of \code{Parsers} using a {\em mixin composition}.
+Here is the start of a sample application:
+\begin{lstlisting}
+object Test {
+  def main(args: Array[String]) {
+    val ps = new ParseString(args(0)) with ListParsers
+  }
+\end{lstlisting}
+The last line above creates a new family of parsers by composing class
+\code{ListParsers} with class \code{ParseString}. The two classes
+share the common superclass \code{Parsers}. The abstract method
+\code{chr} in \code{ListParsers} is implemented by class \code{ParseString}.
+
+To run the parser, we apply the start symbol of the grammar
+\code{expr} the argument code{input} and observe the result:
+\begin{lstlisting}
+    ps.expr(ps.input) match {
+      case Some(n) =>
+        println("parsed: " + args(0).substring(0, n))
+      case None =>
+        println("nothing parsed")
+    }
+  }
+}// end Test
+\end{lstlisting}
+Note the syntax ~\code{ps.expr(input)}, which treats the \code{expr}
+parser as if it was a function. In Scala, objects with \code{apply}
+methods can be applied directly to arguments as if they were functions.
+
+Here is an example run of the program above:
+\begin{lstlisting}
+> java examples.Test "(x,1,(y,z))"
+parsed: (x,1,(y,z))
+> java examples.Test "(x,,1,(y,z))"
+nothing parsed
+\end{lstlisting}
+
+\section{\label{sec:parsers-results}Parsers that Produce Results}
+
+The combinator library of the previous section does not support the
+generation of output from parsing. But usually one does not just want
+to check whether a given string belongs to the defined language, one
+also wants to convert the input string into some internal
+representation such as an abstract syntax tree.
+
+In this section, we modify our parser library to build parsers that
+produce results. We will make use of the for-comprehensions introduced
+in Chapter~\ref{sec:for-notation}.  The basic combinator of sequential
+composition, formerly ~\code{p &&& q}, now becomes
+\begin{lstlisting}
+for (x <- p; y <- q) yield e .
+\end{lstlisting}
+Here, the names \code{x} and \code{y} are bound to the results of
+executing the parsers \code{p} and \code{q}. \code{e} is an expression
+that uses these results to build the tree returned by the composed
+parser.
+
+Before describing the implementation of the new parser combinators, we
+explain how the new building blocks are used. Say we want to modify
+our list parser so that it returns an abstract syntax tree of the
+parsed expression. Syntax trees are given by the following class hierarchy:
+\begin{lstlisting}
+abstract class Tree
+case class Id (s: String)         extends Tree
+case class Num(n: Int)            extends Tree
+case class Lst(elems: List[Tree]) extends Tree
+\end{lstlisting}
+That is, a syntax tree is an identifier, an integer number, or a
+\code{Lst} node with a list of trees as descendants.
+
+As a first step towards parsers that produce results we define three
+little parsers that return a single read character as result.
+\begin{lstlisting}
+trait CharParsers extends Parsers {
+  def any: Parser[Char]
+  def chr(ch: Char): Parser[Char] =
+    for (c <- any if c == ch) yield c
+  def chrSuchThat(p: Char => Boolean): Parser[Char] =
+    for (c <- any if p(c)) yield c
+}
+\end{lstlisting}
+The \code{any} parser succeeds with the first character of remaining
+input as long as input is nonempty. It is abstract in class
+\code{ListParsers} since we want to abstract in this class from the
+concrete input method used.  The two \code{chr} parsers return as before
+the first input character if it equals a given character or matches a
+given predicate. They are now implemented in terms of \code{any}.
+
+The next level is represented by parsers reading identifiers, numbers
+and lists. Here is a parser for identifiers.
+\begin{lstlisting}
+trait ListParsers extends CharParsers {
+  def ident: Parser[Tree] = 
+    for {
+      c: Char <- chrSuchThat(Character.isLetter)
+      cs: List[Char] <- rep(chrSuchThat(Character.isLetterOrDigit))
+    } yield Id((c :: cs).mkString("", "", ""))
+\end{lstlisting}
+Remark: Because \code{chrSuchThat(...)} returns a single character, its
+repetition \code{rep(chrSuchThat(...))} returns a list of characters. The
+\code{yield} part of the for-comprehension converts all intermediate
+results into an \code{Id} node with a string as element.  To convert
+the read characters into a string, it conses them into a single list,
+and invokes the \code{mkString} method on the result.
+
+Here is a parser for numbers:
+\begin{lstlisting}
+  def number: Parser[Tree] =
+    for {
+      d: Char <- chrSuchThat(Character.isDigit)
+      ds: List[Char] <- rep(chrSuchThat(Character.isDigit))
+    } yield Num(((d - '0') /: ds) ((x, digit) => x * 10 + digit - '0'))
+\end{lstlisting}
+Intermediate results are in this case the leading digit of
+the read number, followed by a list of remaining digits.  The
+\code{yield} part of the for-comprehension reduces these to a number
+by a fold-left operation.
+
+Here is a parser for lists:
+\begin{lstlisting}
+  def list: Parser[Tree] = 
+    for {
+      _ <- chr('(')
+      es <- listElems ||| succeed(List())
+      _ <- chr(')')
+    } yield Lst(es)
+
+  def listElems: Parser[List[Tree]] = 
+    for {
+      x <- expr
+      xs <- chr(',') &&& listElems ||| succeed(List())
+    } yield x :: xs
+\end{lstlisting}
+The \code{list} parser returns a \code{Lst} node with a list of trees
+as elements.  That list is either the result of \code{listElems}, or,
+if that fails, the empty list (expressed here as: the result of a
+parser which always succeeds with the empty list as result).
+
+The highest level of our grammar is represented by function
+\code{expr}:
+\begin{lstlisting}
+  def expr: Parser[Tree] = 
+    ident ||| number ||| list
+}// end ListParsers.
+\end{lstlisting}
+We now present the parser combinators that support the new
+scheme. Parsers that succeed now return a parse result besides the
+un-consumed input.
+\begin{lstlisting}
+trait Parsers {
+  type InType
+  abstract class Parser[A] {
+    type Result = Option[(A, InType)]
+    def apply(in: InType): Result
+\end{lstlisting}
+Parsers are parameterized with the type of their result. The class
+\code{Parser[a]} now defines new methods \code{map}, \code{flatMap}
+and \code{filter}. The \code{for} expressions are mapped by the
+compiler to calls of these functions using the scheme described in
+Chapter~\ref{sec:for-notation}. For parsers, these methods are
+implemented as follows.
+\begin{lstlisting}
+    def filter(pred: A => Boolean) = new Parser[A] {
+      def apply(in: InType): Result = Parser.this.apply(in) match {
+        case None => None
+        case Some(x, in1) => if (pred(x)) Some(x, in1) else None
+      }
+    }
+    def map[B](f: A => B) = new Parser[B] {
+      def apply(in: InType): Result = Parser.this.apply(in) match {
+        case None => None
+        case Some(x, in1) => Some(f(x), in1)
+      }
+    }
+    def flatMap[b](f: A => Parser[B]) = new Parser[B] {
+      def apply(in: InType): Result = Parser.this.apply(in) match {
+        case None => None
+        case Some(x, in1) => f(x).apply(in1)
+      }
+    }
+\end{lstlisting}
+The \code{filter} method takes as parameter a predicate $p$ which it
+applies to the results of the current parser. If the predicate is
+false, the parser fails by returning \code{None}; otherwise it returns
+the result of the current parser.  The \code{map} method takes as
+parameter a function $f$ which it applies to the results of the
+current parser. The \code{flatMap} takes as parameter a function
+\code{f} which returns a parser.  It applies \code{f} to the result of
+the current parser and then continues with the resulting parser.  The
+\code{|||} method is essentially defined as before.  The
+\code{&&&} method can now be defined in terms of \code{for}.
+\begin{lstlisting}
+    def ||| (p: => Parser[A]) = new Parser[A] {
+      def apply(in: InType): Result = Parser.this.apply(in) match {
+        case None => p(in)
+        case s => s
+      }
+    }
+
+    def &&& [B](p: => Parser[B]): Parser[B] =
+      for (_ <- this; x <- p) yield x
+  }// end Parser
+\end{lstlisting}
+
+The primitive parser \code{succeed} replaces \code{empty}. It consumes
+no input and returns its parameter as result.
+\begin{lstlisting}
+  def succeed[A](x: A) = new Parser[A] {
+    def apply(in: InType) = Some(x, in)
+  }
+\end{lstlisting}
+
+The parser combinators \code{rep} and \code{opt} now also return
+results. \code{rep} returns a list which contains as elements the
+results of each iteration of its sub-parser. \code{opt} returns a list
+which is either empty or returns as single element the result of the
+optional parser.
+\begin{lstlisting}
+  def rep[A](p: Parser[A]): Parser[List[A]] =
+    rep1(p) ||| succeed(List())
+
+  def rep1[A](p: Parser[A]): Parser[List[A]] =
+    for (x <- p; xs <- rep(p)) yield x :: xs
+
+  def opt[A](p: Parser[A]): Parser[List[A]] =
+    (for (x <- p) yield List(x)) ||| succeed(List())
+} // end Parsers
+\end{lstlisting}
+The root class \code{Parsers} abstracts over which kind of
+input is parsed.  As before, we determine the input method by a separate class.
+Here is \code{ParseString}, this time adapted to parsers that return results.
+It defines now the method \code{any}, which returns the first input character.
+\begin{lstlisting}
+class ParseString(s: String) extends Parsers {
+  type InType = Int
+  val input = 0
+  def any = new Parser[Char] {
+    def apply(in: Int): Parser[Char]#Result =
+      if (in < s.length()) Some(s charAt in, in + 1) else None
+  }
+}
+\end{lstlisting}
+The rest of the application is as before. Here is a test program which
+constructs a list parser over strings and prints out the result of
+applying it to the command line argument.
+\begin{lstlisting}
+object Test {
+  def main(args: Array[String]) {
+    val ps = new ParseString(args(0)) with ListParsers
+    ps.expr(ps.input) match {
+      case Some(list, _) => println("parsed: " + list)
+      case None => println("nothing parsed")
+    }
+  }
+}
+\end{lstlisting}
+
+\begin{exercise}\label{exercise:end-marker} The parsers we have defined so
+far can succeed even if there is some input beyond the parsed text. To
+prevent this, one needs a parser which recognizes the end of input.
+Redesign the parser library so that such a parser can be introduced.
+Which classes need to be modified?
+\end{exercise}
+}
+
+\chapter{\label{sec:hm}Hindley/Milner Type Inference}
+
+This chapter demonstrates Scala's data types and pattern matching by
+developing a type inference system in the Hindley/Milner style
+\cite{milner:polymorphism}. The source language for the type inferencer is
+lambda calculus with a let construct called Mini-ML. Abstract syntax
+trees for the Mini-ML are represented by the following data type of
+\code{Terms}.
+\begin{lstlisting}
+abstract class Term {}
+case class Var(x: String) extends Term {
+  override def toString = x
+}
+case class Lam(x: String, e: Term) extends Term {
+  override def toString = "(\\" + x + "." + e + ")"
+}
+case class App(f: Term, e: Term) extends Term {
+  override def toString = "(" + f + " " + e + ")"
+}
+case class Let(x: String, e: Term, f: Term) extends Term {
+  override def toString = "let " + x + " = " + e + " in " + f
+}
+\end{lstlisting}
+There are four tree constructors: \code{Var} for variables, \code{Lam}
+for function abstractions, \code{App} for function applications, and
+\code{Let} for let expressions. Each case class overrides the
+\code{toString} method of class \code{Any}, so that terms can be
+printed in legible form.
+
+We next define the types that are
+computed by the inference system.
+\begin{lstlisting}
+sealed abstract class Type {}
+case class Tyvar(a: String) extends Type {
+  override def toString = a
+}
+case class Arrow(t1: Type, t2: Type) extends Type {
+  override def toString = "(" + t1 + "->" + t2 + ")"
+}
+case class Tycon(k: String, ts: List[Type]) extends Type {
+  override def toString = 
+    k + (if (ts.isEmpty) "" else ts.mkString("[", ",", "]"))
+}
+\end{lstlisting}
+There are three type constructors: \code{Tyvar} for type variables,
+\code{Arrow} for function types and \code{Tycon} for type constructors
+such as \code{Boolean} or \code{List}. Type constructors have as
+component a list of their type parameters. This list is empty for type
+constants such as \code{Boolean}. Again, the type constructors
+implement the \code{toString} method in order to display types legibly.
+
+Note that \code{Type} is a \code{sealed} class. This means that no
+subclasses or data constructors that extend \code{Type} can be formed
+outside the sequence of definitions in which \code{Type} is defined.
+This makes \code{Type} a {\em closed} algebraic data type with exactly
+three alternatives. By contrast, type \code{Term} is an {\em open}
+algebraic type for which further alternatives can be defined.
+
+The main parts of the type inferencer are contained in object
+\code{typeInfer}. We start with a utility function which creates
+fresh type variables:
+\begin{lstlisting}
+object typeInfer {
+  private var n: Int = 0
+  def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
+\end{lstlisting}
+We next define a class for substitutions. A substitution is an
+idempotent function from type variables to types. It maps a finite
+number of type variables to some types, and leaves all other type
+variables unchanged. The meaning of a substitution is extended
+point-wise to a mapping from types to types. We also extend
+the meaning of substitution to environments, which are defined
+later.
+\begin{lstlisting}
+  abstract class Subst extends Function1[Type,Type] {
+
+    def lookup(x: Tyvar): Type
+
+    def apply(t: Type): Type = t match {
+      case tv @ Tyvar(a) => val u = lookup(tv); if (t == u) t else apply(u)
+      case Arrow(t1, t2) => Arrow(apply(t1), apply(t2))
+      case Tycon(k, ts) => Tycon(k, ts map apply)
+    }
+
+    def apply(env: Env): Env = env.map({ case (x, TypeScheme(tyvars, tpe)) =>
+      // assumes tyvars don't occur in this substitution
+      (x, TypeScheme(tyvars, apply(tpe)))
+    })
+
+    def extend(x: Tyvar, t: Type) = new Subst {
+      def lookup(y: Tyvar): Type = if (x == y) t else Subst.this.lookup(y)
+    }
+  }
+  val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
+\end{lstlisting}
+We represent substitutions as functions, of type \code{Type =>
+Type}. This is achieved by making class \code{Subst} inherit from the
+unary function type \code{Function1[Type, Type]}\footnote{
+The class inherits the function type as a mixin rather than as a direct 
+superclass. This is because in the current Scala implementation, the
+\code{Function1} type is a Java interface, which cannot be used as a direct
+superclass of some other class.}.
+To be an instance
+of this type, a substitution \code{s} has to implement an \code{apply}
+method that takes a \code{Type} as argument and yields another
+\code{Type} as result. A function application \code{s(t)} is then
+interpreted as \code{s.apply(t)}.
+
+The \code{lookup} method is abstract in class \code{Subst}.  There are
+two concrete forms of substitutions which differ in how they
+implement this method.  One form is defined by the \code{emptySubst} value,
+the other is defined by the \code{extend} method in class
+\code{Subst}.
+
+The next data type describes type schemes, which consist of a type and
+a list of names of type variables which appear universally quantified
+in the type scheme. 
+For instance, the type scheme $\forall a\forall b.a \!\arrow\! b$ would be represented in the type checker as:
+\begin{lstlisting}
+TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
+\end{lstlisting}
+The class definition of type schemes does not carry an extends
+clause; this means that type schemes extend directly class
+\code{AnyRef}.  Even though there is only one possible way to
+construct a type scheme, a case class representation was chosen
+since it offers convenient ways to decompose an instance of this type into its
+parts.
+\begin{lstlisting}
+  case class TypeScheme(tyvars: List[Tyvar], tpe: Type) {
+    def newInstance: Type = {
+      (emptySubst /: tyvars) ((s, tv) => s.extend(tv, newTyvar())) (tpe)
+    }
+  }
+\end{lstlisting}
+Type scheme objects come with a method \code{newInstance}, which
+returns the type contained in the scheme after all universally type
+variables have been renamed to fresh variables. The implementation of
+this method folds (with \code{/:}) the type scheme's type variables
+with an operation which extends a given substitution \code{s} by
+renaming a given type variable \code{tv} to a fresh type
+variable. The resulting substitution renames all type variables of the
+scheme to fresh ones. This substitution is then applied to the type
+part of the type scheme.
+
+The last type we need in the type inferencer is
+\code{Env}, a type for environments, which associate variable names
+with type schemes. They are represented by a type alias \code{Env} in
+module \code{typeInfer}:
+\begin{lstlisting}
+  type Env = List[(String, TypeScheme)]
+\end{lstlisting}
+There are two operations on environments. The \code{lookup} function
+returns the type scheme associated with a given name, or \code{null}
+if the name is not recorded in the environment.
+\begin{lstlisting}
+  def lookup(env: Env, x: String): TypeScheme = env match {
+    case List() => null
+    case (y, t) :: env1 => if (x == y) t else lookup(env1, x)
+  }
+\end{lstlisting}
+The \code{gen} function turns a given type into a type scheme,
+quantifying over all type variables that are free in the type, but
+not in the environment.
+\begin{lstlisting}
+  def gen(env: Env, t: Type): TypeScheme = 
+    TypeScheme(tyvars(t) diff tyvars(env), t)
+\end{lstlisting}
+The set of free type variables of a type is simply the set of all type
+variables which occur in the type. It is represented here as a list of
+type variables, which is constructed as follows.
+\begin{lstlisting}
+  def tyvars(t: Type): List[Tyvar] = t match {
+    case tv @ Tyvar(a) => 
+      List(tv)
+    case Arrow(t1, t2) => 
+      tyvars(t1) union tyvars(t2)
+    case Tycon(k, ts) => 
+      (List[Tyvar]() /: ts) ((tvs, t) => tvs union tyvars(t))
+  }
+\end{lstlisting}
+Note that the syntax \code{tv @ ...} in the first pattern introduces a variable
+which is bound to the pattern that follows. Note also that the explicit type parameter \code{[Tyvar]} in the expression of the third
+clause is needed to make local type inference work.
+
+The set of free type variables of a type scheme is the set of free
+type variables of its type component, excluding any quantified type variables:
+\begin{lstlisting}
+  def tyvars(ts: TypeScheme): List[Tyvar] = 
+    tyvars(ts.tpe) diff ts.tyvars
+\end{lstlisting}
+Finally, the set of free type variables of an environment is the union
+of the free type variables of all type schemes recorded in it.
+\begin{lstlisting}
+  def tyvars(env: Env): List[Tyvar] =
+    (List[Tyvar]() /: env) ((tvs, nt) => tvs union tyvars(nt._2))
+\end{lstlisting}
+A central operation of Hindley/Milner type checking is unification,
+which computes a substitution to make two given types equal (such a
+substitution is called a {\em unifier}).  Function \code{mgu} computes
+the most general unifier of two given types $t$ and $u$ under a
+pre-existing substitution $s$.  That is, it returns the most general
+substitution $s'$ which extends $s$, and which makes $s'(t)$ and
+$s'(u)$ equal types. 
+\begin{lstlisting}
+  def mgu(t: Type, u: Type, s: Subst): Subst = (s(t), s(u)) match {
+    case (Tyvar(a), Tyvar(b)) if (a == b) =>
+      s
+    case (st @ Tyvar(a), su) if !(tyvars(su) contains st) =>
+      s.extend(st, su)
+    case (_, Tyvar(a)) =>
+      mgu(u, t, s)
+    case (Arrow(t1, t2), Arrow(u1, u2)) =>
+      mgu(t1, u1, mgu(t2, u2, s))
+    case (Tycon(k1, ts), Tycon(k2, us)) if (k1 == k2) =>
+      (s /: (ts zip us)) ((s, tu) => mgu(tu._1, tu._2, s))
+    case _ => 
+      throw new TypeError("cannot unify " + s(t) + " with " + s(u))
+  }
+\end{lstlisting}
+The \code{mgu} function throws a \code{TypeError} exception if no
+unifier substitution exists. This can happen because the two types
+have different type constructors at corresponding places, or because a
+type variable is unified with a type that contains the type variable
+itself. Such exceptions are modeled here as instances of case classes
+that inherit from the predefined \code{Exception} class.
+\begin{lstlisting}
+  case class TypeError(s: String) extends Exception(s) {}
+\end{lstlisting}
+The main task of the type checker is implemented by function
+\code{tp}. This function takes as parameters an environment $env$, a
+term $e$, a proto-type $t$, and a
+pre-existing substitution $s$.  The function yields a substitution
+$s'$ that extends $s$ and that
+turns $s'(env) \ts e: s'(t)$ into a derivable type judgment according
+to the derivation rules of the Hindley/Milner type system \cite{milner:polymorphism}.  A
+\code{TypeError} exception is thrown if no such substitution exists.
+\begin{lstlisting}
+  def tp(env: Env, e: Term, t: Type, s: Subst): Subst = {
+    current = e
+    e match {
+      case Var(x) =>
+        val u = lookup(env, x)
+        if (u == null) throw new TypeError("undefined: " + x)
+        else mgu(u.newInstance, t, s)
+
+      case Lam(x, e1) =>
+        val a, b = newTyvar()
+        val s1 = mgu(t, Arrow(a, b), s)
+        val env1 = {x, TypeScheme(List(), a)} :: env
+        tp(env1, e1, b, s1)
+
+      case App(e1, e2) =>
+        val a = newTyvar()
+        val s1 = tp(env, e1, Arrow(a, t), s)
+        tp(env, e2, a, s1)
+
+      case Let(x, e1, e2) =>
+        val a = newTyvar()
+        val s1 = tp(env, e1, a, s)
+        tp({x, gen(s1(env), s1(a))} :: env, e2, t, s1)
+    }
+  } 
+  var current: Term = null
+\end{lstlisting}
+To aid error diagnostics, the \code{tp} function stores the currently
+analyzed sub-term in variable \code{current}. Thus, if type checking
+is aborted with a \code{TypeError} exception, this variable will
+contain the subterm that caused the problem.
+
+The last function of the type inference module, \code{typeOf}, is a
+simplified facade for \code{tp}. It computes the type of a given term
+$e$ in a given environment $env$. It does so by creating a fresh type
+variable $a$, computing a typing substitution that makes $env \ts e: a$
+into a derivable type judgment, and returning
+the result of applying the substitution to $a$.
+\begin{lstlisting}
+  def typeOf(env: Env, e: Term): Type = {
+    val a = newTyvar()
+    tp(env, e, a, emptySubst)(a)
+  }
+}// end typeInfer
+\end{lstlisting}
+To apply the type inferencer, it is convenient to have a predefined
+environment that contains bindings for commonly used constants. The
+module \code{predefined} defines an environment \code{env} that
+contains bindings for the types of booleans, numbers and lists
+together with some primitive operations over them. It also
+defines a fixed point operator \code{fix}, which can be used to
+represent recursion.
 \begin{lstlisting}
 object predefined {
   val booleanType = Tycon("Boolean", List())
@@ -6676,10 +7586,10 @@ object predefined {
   )
 }
 \end{lstlisting}
-%% Here's an example how the type inferencer can be used.
-%% Let's define a function \code{showType} which returns the type of
-%% a given term computed in the predefined environment
-%% \code{Predefined.env}:
+Here's an example how the type inferencer can be used.
+Let's define a function \code{showType} which returns the type of
+a given term computed in the predefined environment
+\code{Predefined.env}:
 \begin{lstlisting}
 object testInfer {
   def showType(e: Term): String =
@@ -6717,12 +7627,12 @@ command line argument.
   }
 %}// testInfer
 \end{lstlisting}
-%% To do the parsing, method \code{main} uses the combinator parser
-%% scheme of Chapter~\ref{sec:combinator-parsing}. It creates a parser
-%% family \code{ps} as a mixin composition of parsers
-%% that understand MiniML (but do not know where input comes from) and
-%% parsers that read input from a given string.  The \code{MiniMLParsers}
-%% object implements parsers for the following grammar.
+To do the parsing, method \code{main} uses the combinator parser
+scheme of Chapter~\ref{sec:combinator-parsing}. It creates a parser
+family \code{ps} as a mixin composition of parsers
+that understand MiniML (but do not know where input comes from) and
+parsers that read input from a given string.  The \code{MiniMLParsers}
+object implements parsers for the following grammar.
 \begin{lstlisting}
 term  ::= "\" ident "." term
        |  term1 {term1}
@@ -6731,13 +7641,13 @@ term1 ::= ident
        |  "(" term ")"
 all   ::= term ";"
 \end{lstlisting}
-%% Input as a whole is described by the production \code{all}; it
-%% consists of a term followed by a semicolon. We allow ``whitespace''
-%% consisting of one or more space, tabulator or newline characters
-%% between any two lexemes (this is not reflected in the grammar
-%% above). Identifiers are defined as in
-%% Chapter~\ref{sec:combinator-parsing} except that an identifier cannot
-%% be one of the two reserved words "let" and "in".
+Input as a whole is described by the production \code{all}; it
+consists of a term followed by a semicolon. We allow ``whitespace''
+consisting of one or more space, tabulator or newline characters
+between any two lexemes (this is not reflected in the grammar
+above). Identifiers are defined as in
+Chapter~\ref{sec:combinator-parsing} except that an identifier cannot
+be one of the two reserved words "let" and "in".
 \begin{lstlisting}
 trait MiniMLParsers extends CharParsers {
 
@@ -6858,17 +7768,17 @@ in ...
 \end{lstlisting}
 \end{exercise}
 
-%% \chapter{Abstractions for Concurrency}\label{sec:ex-concurrency}
+\chapter{Abstractions for Concurrency}\label{sec:ex-concurrency}
 
-%% This section reviews common concurrent programming patterns and shows
-%% how they can be implemented in Scala.
+This section reviews common concurrent programming patterns and shows
+how they can be implemented in Scala.
 
-%% \section{Signals and Monitors}
+\section{Signals and Monitors}
 
-%% \example
-%% The {\em monitor} provides the basic means for mutual exclusion
-%% of processes in Scala. Every instance of class \code{AnyRef} can be
-%% used as a monitor by calling one or more of the methods below.
+\example
+The {\em monitor} provides the basic means for mutual exclusion
+of processes in Scala. Every instance of class \code{AnyRef} can be
+used as a monitor by calling one or more of the methods below.
 \begin{lstlisting}
   def synchronized[A] (e: => A): A
   def wait()
@@ -6876,31 +7786,31 @@ in ...
   def notify()
   def notifyAll()
 \end{lstlisting}
-%% The \code{synchronized} method executes its argument computation
-%% \code{e} in mutual exclusive mode -- at any one time, only one thread
-%% can execute a \code{synchronized} argument of a given monitor.
+The \code{synchronized} method executes its argument computation
+\code{e} in mutual exclusive mode -- at any one time, only one thread
+can execute a \code{synchronized} argument of a given monitor.
 
-%% Threads can suspend inside a monitor by waiting on a signal.  Threads
-%% that call the \code{wait} method wait until a \code{notify} method of
-%% the same object is called subsequently by some other thread. Calls to
-%% \code{notify} with no threads waiting for the signal are ignored.
+Threads can suspend inside a monitor by waiting on a signal.  Threads
+that call the \code{wait} method wait until a \code{notify} method of
+the same object is called subsequently by some other thread. Calls to
+\code{notify} with no threads waiting for the signal are ignored.
 
-%% There is also a timed form of \code{wait}, which blocks only as long
-%% as no signal was received or the specified amount of time (given in
-%% milliseconds) has elapsed. Furthermore, there is a \code{notifyAll}
-%% method which unblocks all threads which wait for the signal.  These
-%% methods, as well as class \code{Monitor} are primitive in Scala; they
-%% are implemented in terms of the underlying runtime system.
+There is also a timed form of \code{wait}, which blocks only as long
+as no signal was received or the specified amount of time (given in
+milliseconds) has elapsed. Furthermore, there is a \code{notifyAll}
+method which unblocks all threads which wait for the signal.  These
+methods, as well as class \code{Monitor} are primitive in Scala; they
+are implemented in terms of the underlying runtime system.
 
-%% Typically, a thread waits for some condition to be established. If the
-%% condition does not hold at the time of the wait call, the thread
-%% blocks until some other thread has established the condition. It is
-%% the responsibility of this other thread to wake up waiting processes
-%% by issuing a \code{notify} or \code{notifyAll}. Note however, that
-%% there is no guarantee that a waiting process gets to run immediately
-%% after the call to notify is issued. It could be that other processes
-%% get to run first which invalidate the condition again. Therefore, the
-%% correct form of waiting for a condition $C$ uses a while loop:
+Typically, a thread waits for some condition to be established. If the
+condition does not hold at the time of the wait call, the thread
+blocks until some other thread has established the condition. It is
+the responsibility of this other thread to wake up waiting processes
+by issuing a \code{notify} or \code{notifyAll}. Note however, that
+there is no guarantee that a waiting process gets to run immediately
+after the call to notify is issued. It could be that other processes
+get to run first which invalidate the condition again. Therefore, the
+correct form of waiting for a condition $C$ uses a while loop:
 \begin{lstlisting}
 while (!$C$) wait()
 \end{lstlisting}
@@ -6936,9 +7846,9 @@ spawn { while (true) { val s = produceString ; buf.put(s) } }
 spawn { while (true) { val s = buf.get ; consumeString(s) } }
 }
 \end{lstlisting}
-%% The \code{spawn} method spawns a new thread which executes the
-%% expression given in the parameter. It is defined in object \code{concurrent.ops}
-%% as follows.
+The \code{spawn} method spawns a new thread which executes the
+expression given in the parameter. It is defined in object \code{concurrent.ops}
+as follows.
 \begin{lstlisting}
 def spawn(p: => Unit) {
   val t = new Thread() { override def run() = p }
@@ -6947,14 +7857,14 @@ def spawn(p: => Unit) {
 \end{lstlisting}
 
 \comment{
-%% \section{Logic Variable}
+\section{Logic Variable}
 
-%% A logic variable (or lvar for short) offers operations \code{:=}
-%% and \code{value} to define the variable and to retrieve its value.
-%% Variables can be \code{define}d only once. A call to \code{value}
-%% blocks until the variable has been defined.
+A logic variable (or lvar for short) offers operations \code{:=}
+and \code{value} to define the variable and to retrieve its value.
+Variables can be \code{define}d only once. A call to \code{value}
+blocks until the variable has been defined.
 
-%% Logic variables can be implemented as follows.
+Logic variables can be implemented as follows.
 
 \begin{lstlisting}
 class LVar[A] {
@@ -6972,14 +7882,14 @@ class LVar[A] {
 \end{lstlisting}
 }
 
-%% \section{SyncVars}
+\section{SyncVars}
 
-%% A synchronized variable (or syncvar for short) offers \code{get} and
-%% \code{put} operations to read and set the variable. \code{get} operations
-%% block until the variable has been defined. An \code{unset} operation
-%% resets the variable to undefined state.
+A synchronized variable (or syncvar for short) offers \code{get} and
+\code{put} operations to read and set the variable. \code{get} operations
+block until the variable has been defined. An \code{unset} operation
+resets the variable to undefined state.
 
-%% Here's the standard implementation of synchronized variables.
+Here's the standard implementation of synchronized variables.
 \begin{lstlisting}
 package scala.concurrent
 class SyncVar[A] {
@@ -7001,13 +7911,13 @@ class SyncVar[A] {
 }
 \end{lstlisting}
 
-%% \section{Futures}
-%% \label{sec:futures}
+\section{Futures}
+\label{sec:futures}
 
-%% A {\em future} is a value which is computed in parallel to some other
-%% client thread, to be used by the client thread at some future time.
-%% Futures are used in order to make good use of parallel processing
-%% resources.  A typical usage is:
+A {\em future} is a value which is computed in parallel to some other
+client thread, to be used by the client thread at some future time.
+Futures are used in order to make good use of parallel processing
+resources.  A typical usage is:
 
 \begin{lstlisting}
 import scala.concurrent.ops._
@@ -7017,8 +7927,8 @@ anotherLengthyComputation
 val y = f(x()) + g(x())
 \end{lstlisting}
 
-%% The \code{future} method is defined in object
-%% \code{scala.concurrent.ops} as follows.
+The \code{future} method is defined in object
+\code{scala.concurrent.ops} as follows.
 \begin{lstlisting}
 def future[A](p: => A): Unit => A = {
   val result = new SyncVar[A]
@@ -7027,28 +7937,28 @@ def future[A](p: => A): Unit => A = {
 }
 \end{lstlisting}
 
-%% The \code{future} method gets as parameter a computation \code{p} to
-%% be performed. The type of the computation is arbitrary; it is
-%% represented by \code{future}'s type parameter \code{a}.  The
-%% \code{future} method defines a guard \code{result}, which takes a
-%% parameter representing the result of the computation. It then forks
-%% off a new thread that computes the result and invokes the
-%% \code{result} guard when it is finished. In parallel to this thread,
-%% the function returns an anonymous function of type \code{a}.
-%% When called, this functions waits on the result guard to be
-%% invoked, and, once this happens returns the result argument.
-%% At the same time, the function reinvokes the \code{result} guard with
-%% the same argument, so that future invocations of the function can
-%% return the result immediately.
+The \code{future} method gets as parameter a computation \code{p} to
+be performed. The type of the computation is arbitrary; it is
+represented by \code{future}'s type parameter \code{a}.  The
+\code{future} method defines a guard \code{result}, which takes a
+parameter representing the result of the computation. It then forks
+off a new thread that computes the result and invokes the
+\code{result} guard when it is finished. In parallel to this thread,
+the function returns an anonymous function of type \code{a}.
+When called, this functions waits on the result guard to be
+invoked, and, once this happens returns the result argument.
+At the same time, the function reinvokes the \code{result} guard with
+the same argument, so that future invocations of the function can
+return the result immediately.
 
-%% \section{Parallel Computations}
+\section{Parallel Computations}
 
-%% The next example presents a function \code{par} which takes a pair of
-%% computations as parameters and which returns the results of the computations
-%% in another pair. The two computations are performed in parallel.
+The next example presents a function \code{par} which takes a pair of
+computations as parameters and which returns the results of the computations
+in another pair. The two computations are performed in parallel.
 
-%% The function is defined in object
-%% \code{scala.concurrent.ops} as follows.
+The function is defined in object
+\code{scala.concurrent.ops} as follows.
 \begin{lstlisting}
   def par[A, B](xp: => A, yp: => B): (A, B) = {
     val y = new SyncVar[B]
@@ -7056,9 +7966,9 @@ def future[A](p: => A): Unit => A = {
     (xp, y.get)
   }
 \end{lstlisting}
-%% Defined in the same place is a function \code{replicate} which performs a
-%% number of replicates of a computation in parallel. Each
-%% replication instance is passed an integer number which identifies it.
+Defined in the same place is a function \code{replicate} which performs a
+number of replicates of a computation in parallel. Each
+replication instance is passed an integer number which identifies it.
 \begin{lstlisting}
   def replicate(start: Int, end: Int)(p: Int => Unit) {
     if (start == end)
@@ -7073,8 +7983,8 @@ def future[A](p: => A): Unit => A = {
   }
 \end{lstlisting}
 
-%% The next function uses \code{replicate} to perform parallel
-%% computations on all elements of an array.
+The next function uses \code{replicate} to perform parallel
+computations on all elements of an array.
 
 \begin{lstlisting}
 def parMap[A,B](f: A => B, xs: Array[A]): Array[B] = {
@@ -7084,11 +7994,11 @@ def parMap[A,B](f: A => B, xs: Array[A]): Array[B] = {
 }
 \end{lstlisting}
 
-%% \section{Semaphores}
+\section{Semaphores}
 
-%% A common mechanism for process synchronization is a {\em lock} (or:
-%% {\em semaphore}). A lock offers two atomic actions: \prog{acquire} and
-%% \prog{release}. Here's the implementation of a lock in Scala:
+A common mechanism for process synchronization is a {\em lock} (or:
+{\em semaphore}). A lock offers two atomic actions: \prog{acquire} and
+\prog{release}. Here's the implementation of a lock in Scala:
 
 \begin{lstlisting}
 package scala.concurrent
@@ -7106,21 +8016,21 @@ class Lock {
 }
 \end{lstlisting}
 
-%% \section{Readers/Writers}
+\section{Readers/Writers}
 
-%% A more complex form of synchronization distinguishes between {\em
-%% readers} which access a common resource without modifying it and {\em
-%% writers} which can both access and modify it. To synchronize readers
-%% and writers we need to implement operations \prog{startRead}, \prog{startWrite},
-%% \prog{endRead}, \prog{endWrite}, such that:
-%% \begin{itemize}
-%% \item there can be multiple concurrent readers,
-%% \item there can only be one writer at one time,
-%% \item pending write requests have priority over pending read requests,
-%% but don't preempt ongoing read operations.
-%% \end{itemize}
-%% The following implementation of a readers/writers lock is based on the
-%% {\em mailbox} concept (see Section~\ref{sec:mailbox}).
+A more complex form of synchronization distinguishes between {\em
+readers} which access a common resource without modifying it and {\em
+writers} which can both access and modify it. To synchronize readers
+and writers we need to implement operations \prog{startRead}, \prog{startWrite},
+\prog{endRead}, \prog{endWrite}, such that:
+\begin{itemize}
+\item there can be multiple concurrent readers,
+\item there can only be one writer at one time,
+\item pending write requests have priority over pending read requests,
+but don't preempt ongoing read operations.
+\end{itemize}
+The following implementation of a readers/writers lock is based on the
+{\em mailbox} concept (see Section~\ref{sec:mailbox}).
 
 \begin{lstlisting}
 import scala.concurrent._
@@ -7148,26 +8058,26 @@ class ReadersWriters {
 }
 \end{lstlisting}
 
-%% \section{Asynchronous Channels}
+\section{Asynchronous Channels}
 
-%% A fundamental way of interprocess communication is the asynchronous
-%% channel. Its implementation makes use the following simple class for linked
-%% lists:
+A fundamental way of interprocess communication is the asynchronous
+channel. Its implementation makes use the following simple class for linked
+lists:
 \begin{lstlisting}
 class LinkedList[A] {
   var elem: A = _
   var next: LinkedList[A] = null
 }
 \end{lstlisting}
-%% To facilitate insertion and deletion of elements into linked lists,
-%% every reference into a linked list points to the node which precedes
-%% the node which conceptually forms the top of the list.
-%% Empty linked lists start with a dummy node, whose successor is \code{null}.
+To facilitate insertion and deletion of elements into linked lists,
+every reference into a linked list points to the node which precedes
+the node which conceptually forms the top of the list.
+Empty linked lists start with a dummy node, whose successor is \code{null}.
 
-%% The channel class uses a linked list to store data that has been sent
-%% but not read yet. At the opposite end, threads that
-%% wish to read from an empty channel, register their presence by
-%% incrementing the \code{nreaders} field and waiting to be notified.
+The channel class uses a linked list to store data that has been sent
+but not read yet. At the opposite end, threads that
+wish to read from an empty channel, register their presence by
+incrementing the \code{nreaders} field and waiting to be notified.
 \begin{lstlisting}
 package scala.concurrent
 
@@ -7198,12 +8108,12 @@ class Channel[A] {
 }
 \end{lstlisting}
 
-%% \section{Synchronous Channels}
+\section{Synchronous Channels}
 
-%% Here's an implementation of synchronous channels, where the sender of
-%% a message blocks until that message has been received. Synchronous
-%% channels only need a single variable to store messages in transit, but
-%% three signals are used to coordinate reader and writer processes.
+Here's an implementation of synchronous channels, where the sender of
+a message blocks until that message has been received. Synchronous
+channels only need a single variable to store messages in transit, but
+three signals are used to coordinate reader and writer processes.
 \begin{lstlisting}
 package scala.concurrent
 
@@ -7233,16 +8143,16 @@ class SyncChannel[A] {
 }
 \end{lstlisting}
 
-%% \section{Workers}
+\section{Workers}
 
-%% Here's an implementation of a {\em compute server} in Scala. The
-%% server implements a \code{future} method which evaluates a given
-%% expression in parallel with its caller. Unlike the implementation in
-%% Section~\ref{sec:futures} the server computes futures only with a
-%% predefined number of threads. A possible implementation of the server
-%% could run each thread on a separate processor, and could hence avoid
-%% the overhead inherent in context-switching several threads on a single
-%% processor.
+Here's an implementation of a {\em compute server} in Scala. The
+server implements a \code{future} method which evaluates a given
+expression in parallel with its caller. Unlike the implementation in
+Section~\ref{sec:futures} the server computes futures only with a
+predefined number of threads. A possible implementation of the server
+could run each thread on a separate processor, and could hence avoid
+the overhead inherent in context-switching several threads on a single
+processor.
 
 \begin{lstlisting}
 import scala.concurrent._, scala.concurrent.ops._
@@ -7279,39 +8189,39 @@ class ComputeServer(n: Int) {
   spawn(replicate(0, n) { processor })
 }
 \end{lstlisting}
-%% Expressions to be computed (i.e. arguments
-%% to calls of \code{future}) are written to the \code{openJobs}
-%% channel. A {\em job} is an object with
-%% \begin{itemize}
-%% \item
-%% An abstract type \code{T} which describes the result of the compute
-%% job.
-%% \item
-%% A parameterless \code{task} method of type \code{t} which denotes
-%% the expression to be computed.
-%% \item
-%% A \code{ret} method which consumes the result once it is
-%% computed.
-%% \end{itemize}
-%% The compute server creates $n$ \code{processor} processes as part of
-%% its initialization.  Every such process repeatedly consumes an open
-%% job, evaluates the job's \code{task} method and passes the result on
-%% to the job's
-%% \code{ret} method. The polymorphic \code{future} method creates
-%% a new job where the \code{ret} method is implemented by a guard
-%% named \code{reply} and inserts this job into the set of open jobs. 
-%% It then waits until the corresponding
-%% \code{reply} guard is called.
+Expressions to be computed (i.e. arguments
+to calls of \code{future}) are written to the \code{openJobs}
+channel. A {\em job} is an object with
+\begin{itemize}
+\item
+An abstract type \code{T} which describes the result of the compute
+job.
+\item
+A parameterless \code{task} method of type \code{t} which denotes
+the expression to be computed.
+\item
+A \code{ret} method which consumes the result once it is
+computed.
+\end{itemize}
+The compute server creates $n$ \code{processor} processes as part of
+its initialization.  Every such process repeatedly consumes an open
+job, evaluates the job's \code{task} method and passes the result on
+to the job's
+\code{ret} method. The polymorphic \code{future} method creates
+a new job where the \code{ret} method is implemented by a guard
+named \code{reply} and inserts this job into the set of open jobs. 
+It then waits until the corresponding
+\code{reply} guard is called.
 
-%% The example demonstrates the use of abstract types. The abstract type
-%% \code{t} keeps track of the result type of a job, which can vary
-%% between different jobs. Without abstract types it would be impossible
-%% to implement the same class to the user in a statically type-safe
-%% way, without relying on dynamic type tests and type casts.
+The example demonstrates the use of abstract types. The abstract type
+\code{t} keeps track of the result type of a job, which can vary
+between different jobs. Without abstract types it would be impossible
+to implement the same class to the user in a statically type-safe
+way, without relying on dynamic type tests and type casts.
 
 
-%% Here is some code which uses the compute server to evaluate 
-%% the expression \code{41 + 1}.
+Here is some code which uses the compute server to evaluate 
+the expression \code{41 + 1}.
 \begin{lstlisting}
 object Test with Executable {
   val server = new ComputeServer(1)
@@ -7323,11 +8233,11 @@ object Test with Executable {
 \section{Mailboxes}
 \label{sec:mailbox}
 
-%% Mailboxes are high-level, flexible constructs for process
-%% synchronization and communication. They allow sending and receiving of
-%% messages. A {\em message} in this context is an arbitrary object.
-%% There is a special message \code{TIMEOUT} which is used to signal a
-%% time-out.
+Mailboxes are high-level, flexible constructs for process
+synchronization and communication. They allow sending and receiving of
+messages. A {\em message} in this context is an arbitrary object.
+There is a special message \code{TIMEOUT} which is used to signal a
+time-out.
 \begin{lstlisting}
 case object TIMEOUT
 \end{lstlisting}
@@ -7339,23 +8249,23 @@ class MailBox {
   def receiveWithin[A](msec: Long)(f: PartialFunction[Any, A]): A
 }
 \end{lstlisting}
-%% The state of a mailbox consists of a multi-set of messages.
-%% Messages are added to the mailbox with the \code{send} method. Messages
-%% are removed using the \code{receive} method, which is passed a message
-%% processor \code{f} as argument, which is a partial function from
-%% messages to some arbitrary result type. Typically, this function is
-%% implemented as a pattern matching expression. The \code{receive}
-%% method blocks until there is a message in the mailbox for which its
-%% message processor is defined.  The matching message is then removed
-%% from the mailbox and the blocked thread is restarted by applying the
-%% message processor to the message. Both sent messages and receivers are
-%% ordered in time. A receiver $r$ is applied to a matching message $m$
-%% only if there is no other $\{$message, receiver$\}$ pair which precedes ${m,
-%% r}$ in the partial ordering on pairs that orders each component in
-%% time.
+The state of a mailbox consists of a multi-set of messages.
+Messages are added to the mailbox with the \code{send} method. Messages
+are removed using the \code{receive} method, which is passed a message
+processor \code{f} as argument, which is a partial function from
+messages to some arbitrary result type. Typically, this function is
+implemented as a pattern matching expression. The \code{receive}
+method blocks until there is a message in the mailbox for which its
+message processor is defined.  The matching message is then removed
+from the mailbox and the blocked thread is restarted by applying the
+message processor to the message. Both sent messages and receivers are
+ordered in time. A receiver $r$ is applied to a matching message $m$
+only if there is no other $\{$message, receiver$\}$ pair which precedes ${m,
+r}$ in the partial ordering on pairs that orders each component in
+time.
 
-%% As a simple example of how mailboxes are used, consider a
-%% one-place buffer:
+As a simple example of how mailboxes are used, consider a
+one-place buffer:
 \begin{lstlisting}
 class OnePlaceBuffer {
   private val m = new MailBox             // An internal mailbox
@@ -7367,7 +8277,7 @@ class OnePlaceBuffer {
     m receive { case Full(x) => m send Empty; x }
 }
 \end{lstlisting}
-%% Here's how the mailbox class can be implemented:
+Here's how the mailbox class can be implemented:
 \begin{lstlisting}
 class MailBox {
   private abstract class Receiver extends Signal {
@@ -7375,21 +8285,21 @@ class MailBox {
     var msg = null
   }
 \end{lstlisting}
-%% We define an internal class for receivers with a test method
-%% \code{isDefined}, which indicates whether the receiver is
-%% defined for a given message.  The receiver inherits from class
-%% \code{Signal} a \code{notify} method which is used to wake up a
-%% receiver thread. When the receiver thread is woken up, the message it
-%% needs to be applied to is stored in the \code{msg} variable of
-%% \code{Receiver}.
+We define an internal class for receivers with a test method
+\code{isDefined}, which indicates whether the receiver is
+defined for a given message.  The receiver inherits from class
+\code{Signal} a \code{notify} method which is used to wake up a
+receiver thread. When the receiver thread is woken up, the message it
+needs to be applied to is stored in the \code{msg} variable of
+\code{Receiver}.
 \begin{lstlisting}
   private val sent = new LinkedList[Any]
   private var lastSent = sent
   private val receivers = new LinkedList[Receiver]
   private var lastReceiver = receivers
 \end{lstlisting}
-%% The mailbox class maintains two linked lists,
-%% one for sent but unconsumed messages, the other for waiting receivers.
+The mailbox class maintains two linked lists,
+one for sent but unconsumed messages, the other for waiting receivers.
 \begin{lstlisting}
   def send(msg: Any) = synchronized {
     var r = receivers, r1 = r.next
@@ -7403,9 +8313,9 @@ class MailBox {
     }
   }
 \end{lstlisting}
-%% The \code{send} method first checks whether a waiting receiver is
-%% applicable to the sent message. If yes, the receiver is notified.
-%% Otherwise, the message is appended to the linked list of sent messages.
+The \code{send} method first checks whether a waiting receiver is
+applicable to the sent message. If yes, the receiver is notified.
+Otherwise, the message is appended to the linked list of sent messages.
 \begin{lstlisting}
   def receive[A](f: PartialFunction[Any, A]): A = {
     val msg: Any = synchronized {
@@ -7427,14 +8337,14 @@ class MailBox {
     f(msg)
   }
 \end{lstlisting}
-%% The \code{receive} method first checks whether the message processor function
-%% \code{f} can be applied to a message that has already been sent but that
-%% was not yet consumed. If yes, the thread continues immediately by
-%% applying \code{f} to the message. Otherwise, a new receiver is created
-%% and linked into the \code{receivers} list, and the thread waits for a
-%% notification on this receiver. Once the thread is woken up again, it
-%% continues by applying \code{f} to the message that was stored in the
-%% receiver. The insert method on linked lists is defined as follows.
+The \code{receive} method first checks whether the message processor function
+\code{f} can be applied to a message that has already been sent but that
+was not yet consumed. If yes, the thread continues immediately by
+applying \code{f} to the message. Otherwise, a new receiver is created
+and linked into the \code{receivers} list, and the thread waits for a
+notification on this receiver. Once the thread is woken up again, it
+continues by applying \code{f} to the message that was stored in the
+receiver. The insert method on linked lists is defined as follows.
 \begin{lstlisting}
   def insert(l: LinkedList[A], x: A): LinkedList[A] = {
     l.next = new LinkedList[A]
@@ -7443,12 +8353,12 @@ class MailBox {
     l
   }
 \end{lstlisting}
-%% The mailbox class also offers a method \code{receiveWithin}
-%% which blocks for only a specified maximal amount of time.  If no
-%% message is received within the specified time interval (given in
-%% milliseconds), the message processor argument $f$ will be unblocked
-%% with the special \code{TIMEOUT} message.  The implementation of
-%% \code{receiveWithin} is quite similar to \code{receive}:
+The mailbox class also offers a method \code{receiveWithin}
+which blocks for only a specified maximal amount of time.  If no
+message is received within the specified time interval (given in
+milliseconds), the message processor argument $f$ will be unblocked
+with the special \code{TIMEOUT} message.  The implementation of
+\code{receiveWithin} is quite similar to \code{receive}:
 \begin{lstlisting}
   def receiveWithin[A](msec: Long)(f: PartialFunction[Any, A]): A = {
     val msg: Any = synchronized {
@@ -7472,33 +8382,33 @@ class MailBox {
   }
 } // end MailBox
 \end{lstlisting}
-%% The only differences are the timed call to \code{wait}, and the
-%% statement following it.
+The only differences are the timed call to \code{wait}, and the
+statement following it.
 
-%% \section{Actors}
-%% \label{sec:actors}
+\section{Actors}
+\label{sec:actors}
 
-%% Chapter~\ref{chap:example-auction} sketched as a program example the
-%% implementation of an electronic auction service. This service was
-%% based on high-level actor processes that work by inspecting messages
-%% in their mailbox using pattern matching. A refined and optimized
-%% implementation of actors is found in the \lstinline@scala.actors@
-%% package.  We now give a sketch of a simplified version of the actors library.
+Chapter~\ref{chap:example-auction} sketched as a program example the
+implementation of an electronic auction service. This service was
+based on high-level actor processes that work by inspecting messages
+in their mailbox using pattern matching. A refined and optimized
+implementation of actors is found in the \lstinline@scala.actors@
+package.  We now give a sketch of a simplified version of the actors library.
 
-%% The code below is different from the implementation in the \lstinline@scala.actors@
-%% package, so it should be seen as an example how a simple version of
-%% actors could be implemented.  It is not a description how actors are actually defined and
-%% implemented in the standard Scala library. For the latter, please
-%% refer to the Scala API documentation.
+The code below is different from the implementation in the \lstinline@scala.actors@
+package, so it should be seen as an example how a simple version of
+actors could be implemented.  It is not a description how actors are actually defined and
+implemented in the standard Scala library. For the latter, please
+refer to the Scala API documentation.
 
-%% A simplified actor is just a thread whose communication primitives are those
-%% of a mailbox.  Such an actor can be defined as a mixin composition
-%% extension of Java's standard
-%% \code{Thread} class with the \code{MailBox} class. We also override
-%% the \code{run} method of the \code{Thread} class, so that it executes the
-%% behavior of the actor that is defined by its \code{act} method.
-%% The \code{!} method simply calls the \code{send} method of the
-%% \code{MailBox} class:
+A simplified actor is just a thread whose communication primitives are those
+of a mailbox.  Such an actor can be defined as a mixin composition
+extension of Java's standard
+\code{Thread} class with the \code{MailBox} class. We also override
+the \code{run} method of the \code{Thread} class, so that it executes the
+behavior of the actor that is defined by its \code{act} method.
+The \code{!} method simply calls the \code{send} method of the
+\code{MailBox} class:
 \begin{lstlisting}
 abstract class Actor extends Thread with MailBox {
   def act(): Unit

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7321,13 +7321,11 @@ object typeInfer {
   def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
 \end{lstlisting}
 Em seguinda, definimos uma classe para substituições.
- A substitution is an
-idempotent function from type variables to types. It maps a finite
-number of type variables to some types, and leaves all other type
-variables unchanged. The meaning of a substitution is extended
-point-wise to a mapping from types to types. We also extend
-the meaning of substitution to environments, which are defined
-later.
+A substituição é uma função idempotente de tipos variáveis para tipos.
+Ela mapeia um número finito de tipos variáveis para alguns tipos e não modifica todos 
+os outros tipos.
+O significado de uma substituição é extendido a partir de um mapeamento de tipos para tipos.
+Também extendemos o significado da substituição para ambientes que serão definidos posteriormente.
 \begin{lstlisting}
   abstract class Subst extends Function1[Type,Type] {
 
@@ -7350,6 +7348,7 @@ later.
   }
   val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
 \end{lstlisting}
+Representamos substituições como funções
 We represent substitutions as functions, of type \code{Type =>
 Type}. This is achieved by making class \code{Subst} inherit from the
 unary function type \code{Function1[Type, Type]}\footnote{
@@ -7726,20 +7725,21 @@ let id = (\x.x) in (((if (id true)) (id nil)) zero):
  reason: cannot unify Int with List[a14]
 \end{lstlisting}
 
-\begin{exercise}\label{exercise:hm-parse} Using the parser library constructed in
-Exercise~\ref{exercise:end-marker}, modify the MiniML parser library
-so that no marker ``;'' is necessary for indicating the end of input.
+\begin{exercise}\label{exercise:hm-parse} Usando a biblioteca de parser cria no
+Exercise~\ref{exercise:end-marker}, modifique a biblioteca de parser MiniML de tal forma
+que o marcador ``;'' não seja necessária para indicar o fim de uma entrada.
 \end{exercise}
 }
 
-\begin{exercise}\label{execcise:hm-extend} Extend the Mini-ML \comment{parser and} type
-inferencer with a \code{letrec} construct which allows the definition of
-recursive functions. Syntax:
+\begin{exercise}\label{execcise:hm-extend} Extenda o \comment{parser} Mini-ML e a inferência de tipos
+com uma construção \code{letrec} que permita a definição recursiva de funções. 
+Sintaxe:
 \begin{lstlisting}
 letrec ident "=" term in term .
 \end{lstlisting}
-The typing of \code{letrec} is as for \code{let}, 
-except that the defined identifier is visible in the defining expression. Using \code{letrec}, the \code{length} function for lists can now be defined as follows.
+Os tipos de \code{letrec} devem ser como os de \code{let}, 
+exceto que os identificadores definidos são visíveis na expressão que está sendo definida. Usando \code{letrec}, a função \code{length} 
+para listas seria definida da seguinte maneira.
 \begin{lstlisting}
 letrec length = \xs.
   if (isEmpty xs)
@@ -7749,12 +7749,12 @@ in ...
 \end{lstlisting}
 \end{exercise}
 
-\chapter{Abstractions for Concurrency}\label{sec:ex-concurrency}
+\chapter{Abstracões para Concorrência}\label{sec:ex-concurrency}
 
-This section reviews common concurrent programming patterns and shows
-how they can be implemented in Scala.
+Esta seção revisa padrôes comuns de concorrência e mostra como eles
+podem ser implementados em Scala.
 
-\section{Signals and Monitors}
+\section{Sinais e Monitores}
 
 \example
 The {\em monitor} provides the basic means for mutual exclusion

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5164,14 +5164,14 @@ Será verdadeiro? Que hipótese está faltando? Mostre um contra-exemplo.
 Mostre a Proposição 4 usando indução estrutural sobre \code{xs}.
 \es
 \comment{
-%----------------xpto
-\emph{Proof:} By induction on \code{xs}.
+
+\emph{Prova:} Por indução sobre \code{xs}.
 
 \Case{\code{Empty}}
 
 \Case{\code{NonEmpty(x, l, r)}}
 
-\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+\Case{\code{NonEmpty(y, l, r)} onde \code{y < x}}
 
 \begin{lstlisting}
     \= (Empty union ys) contains x 
@@ -5208,40 +5208,36 @@ Mostre a Proposição 4 usando indução estrutural sobre \code{xs}.
 \end{lstlisting}
 
 \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
- ... is analogous.
+ ... é análogo.
 
 \es
 }}
 \chapter{\label{sec:for-notation}For-Comprehensions}
 
-The last chapter demonstrated that higher-order functions such as
-\verb@map@, \verb@flatMap@, \verb@filter@ provide powerful
-constructions for dealing with lists.  But sometimes the level of
-abstraction required by these functions makes a program hard to
-understand.
+O último capítulo demonstrou que funções de alta ordem, tais como \verb@map@, \verb@flatMap@, \verb@filter@
+provém poderosas construções para lidar com listas. Mas algumas vezes o nível de abstração requerido por 
+estas funções tornam um programa difícil de entender.
 
-To help understandability, Scala has a special notation which
-simplifies common patterns of applications of higher-order functions.
-This notation builds a bridge between set-comprehensions in
-mathematics and for-loops in imperative languages such as C or
-Java. It also closely resembles the query notation of relational
-databases.
+Para ajudar a inteligibilidade, Scala tem uma notação especial que simplifica padrões comuns de aplicações 
+de funções de alta ordem. Esta notação cria uma ponte entre abrangência de conjuntos (set-comprehensions) 
+na matemática e laços for em linguagens imperativas tais como C ou Java. Também lembram de perto
+a notação de pesquisa em bases de dados relacionais.  
 
-As a first example, say we are given a list \code{persons} of persons
-with \code{name} and \code{age} fields.  To print the names of all
-persons in the sequence which are aged over 20, one can write:
+Como um primeiro exemplo, digamos que nos é dada uma lista \code{persons} de pessoas com campos \code{name} 
+e \code{age} (idade). Para imprimir os nomes de todas as pessoas na sequência para idades acima de $20$, 
+pode-se escrever:
+ 
 \begin{lstlisting}
 for (p <- persons if p.age > 20) yield p.name
 \end{lstlisting}
-This is equivalent to the following expression , which uses
-higher-order functions \code{filter} and \code{map}:
+Isto é equivalente à seguinte expressão, que usa as funções de alta ordem \code{filter} e \code{map}: 
 \begin{lstlisting}
 persons filter (p => p.age > 20) map (p => p.name)
 \end{lstlisting}
-The for-comprehension looks a bit like a for-loop in imperative languages,
-except that it constructs a list of the results of all iterations.
+A abrangência for (for-comprehension) parece um pouco com um laço for nas linguagens imperativas, 
+exceto que constrói uma lista de resultados de todas iterações.
 
-Generally, a for-comprehension is of the form
+Geralmente, um for-comprehension tem a forma
 \begin{lstlisting}
 for ( $s$ ) yield $e$
 \end{lstlisting}
@@ -5256,6 +5252,16 @@ consideration all bindings for which \code{f} is \code{false}.  The
 sequence $s$ starts in each case with a generator.  If there are
 several generators in a sequence, later generators vary more rapidly
 than earlier ones.
+
+Aqui, $s$ é uma sequência de {\em geradores}, {\em definições} e {\em filtros}. Um {\em gerador} tem a 
+forma \code{val x <- e}, onde \code{e} é uma expressão avaliada como lista. Liga \code{x} a sucessivos
+valores na lista. Uma {\em definição} tem a forma \code{val x = e}. Introduz \code{x} como um nome para 
+o valor de \code{e} no restante da abrangência. Um {\em filtro} é uma expressão \code{f} do tipo 
+\code{Boolean}. Omite da consideração todas as ligações para as quais \code{f} é \code{falso}. A
+sequência $s$
+
+%----------------xpto 
+
 
 The sequence $s$ may also be enclosed in braces instead of
 parentheses, in which case the semicolons between generators,

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3911,55 +3911,52 @@ conservadora, frequentemente sugerirá uma generalização útil do método cont
 %----------xpto
 
 
-\section{Least Types}
+\section{Tipos Minimais}
 
-Scala does not allow one to parameterize objects with types. That's
-why we originally defined a generic class \code{EmptyStack[A]}, even
-though a single value denoting empty stacks of arbitrary type would
-do. For co-variant stacks, however, one can use the following idiom:
+Scala não nos permite parametrizar objetos com tipos. Este é o motivo 
+pelo qual originalmente definimos uma classe genérica \code{EmptyStack[A]}, 
+ainda que um único valor denotando pilhas vazias de tipos arbitrários o 
+fizesse. Para pilhas covariantes, entretanto, pode-se usar o seguinte idioma:
+
+
 \begin{lstlisting}
 object EmptyStack extends Stack[Nothing] { ... }
 \end{lstlisting}
-The bottom type \code{Nothing} contains no value, so the type
-\code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
-contains no elements. Furthermore, \code{Nothing} is a subtype of all
-other types. Hence, for co-variant stacks, \code{Stack[Nothing]} is a
-subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
-possible to use a single empty stack object in user code. For
-instance:
+
+O tipo base \code{Nothing} não contém valor, portanto o tipo \code{Stack[Nothing]}
+expressa o fato que uma \code{EmptyStack} não contém elementos. Além disso, 
+\code{Nothing} é um subtipo de todos os outros tipos. Consequentemente, para 
+pilhas covariantes, \code{Stack[Nothing]} é um subtipo de \code{Stack[T]}, para 
+qualquer outro tipo \code{T}. Isso torna possível usar um único objeto pilha vazia
+no código do usuário. Por exemplo:
+
 \begin{lstlisting}
 val s = EmptyStack.push("abc").push(new AnyRef())
 \end{lstlisting}
-Let's analyze the type assignment for this expression in detail.  The
-\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
-method
+Vamos analisar a atribuição de tipo para esta expressão em detalhes. 
+O objeto \code{EmptyStack} é do tipo \code{Stack[Nothing]}, o qual tem um método 
 \begin{lstlisting}
 push[B >: Nothing](elem: B): Stack[B] .
 \end{lstlisting}
-Local type inference will determine that the type parameter \code{B}
-should be instantiated to \code{String} in the application 
-\code{EmptyStack.push("abc")}. The result type of that application is hence
-\code{Stack[String]}, which in turn has a method
+A inferência local de tipos determinará que o tipo parâmetro \code{B} deve ser
+instanciado para \code{String} na aplicação \code{EmptyStack.push("abc")}. O tipo resultado
+desta aplicação é, consequentemente, \code{Stack[String]}, que por sua vez tem um método  
 \begin{lstlisting}
 push[B >: String](elem: B): Stack[B] .
 \end{lstlisting}
-The final part of the value definition above is the application of
-this method to \code{new AnyRef()}. Local type inference will
-determine that the type parameter \code{b} should this time be
-instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
-Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
 
-Besides \code{Nothing}, which is a subtype of every other type, there
-is also the type \code{Null}, which is a subtype of
-\code{scala.AnyRef}, and every class derived from it. The \code{null}
-literal in Scala is the only value of that type. This makes
-\code{null} compatible with every reference type, but not with a value
-type such as \code{Int}.
+A parte final da definição do valor acima é a aplicação deste método a \code{new AnyRef()}.
+A inferência local de tipos determinará que o tipo parâmetro \code{b} deve desta vez
+ser instanciado para \code{AnyRef}, com tipo resultado \code{Stack[AnyRef]}. 
+Consequentemente, o tipo atribuído ao valor \code{s} é \code{Stack[AnyRef]}.
 
-We conclude this section with the complete improved definition of
-stacks. Stacks have now co-variant subtyping, the \code{push} method
-has been generalized, and the empty stack is represented by a single
-object.
+Além de \code{Nothing}, que é um subtipo para cada outro tipo, há também o tipo \code{Null},
+que é um subtipo de \code{scala.AnyRef}, e de cada classe derivada dele. O literal \code{Null}
+em Scala é o único valor deste tipo. Isto torna \code{null} compatível com cada tipo referência, 
+mas não com um valor de tipo tal como \code{Int}.  
+
+Concluímos esta seção com a definição completa melhorada de pilhas. Pilhas tem agora subtipificação
+covariante, o método \code{push} foi generalizado, e a pilha vazia é denotada por um único objeto.
 \begin{lstlisting}
 abstract class Stack[+A] {
   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1519,7 +1519,7 @@ def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% Generally, the Scala term
 %% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
 %% defines a function which maps its parameters
@@ -1528,19 +1528,30 @@ def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
 %% functions are not essential language elements of Scala, as they can
 %% always be expressed in terms of named functions. Indeed, the 
 %% anonymous function
+Em geral, o termo em Scala 
+ \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
+define uma função que mapeia seus parâmetros \code{x}$_1$\code{, ..., x}$_n$
+ao resultado da expressão \code{E} (onde \code{E} pode referir-se a   
+\code{x}$_1$\code{, ..., x}$_n$). Funções anônimas não são elementos essenciais
+da linguagem Scala, dado que sempre podem ser expressos em termos de funções
+nomeadas. De fato, a função anônima 
+
 \begin{lstlisting}
 (x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
 \end{lstlisting}
 %% is equivalent to the block
+é equivalente ao bloco
 \begin{lstlisting}
 { def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
 \end{lstlisting}
 %% where \code{f} is fresh name which is used nowhere else in the program.
 %% We also say, anonymous functions are ``syntactic sugar''.
+onde \code{f} é um novo nome que não é utilizado em qualquer outro lugar do programa.
+Também dizemos que funções anônimas são ``syntactic sugar''. 
 %----------
 
 %----------
-%% \section{Currying}
+ \section{Currying}
 
 %% The latest formulation of the summing functions is already quite
 %% compact. But we can do even better. Note that
@@ -1550,6 +1561,15 @@ def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
 
 %% Let's try to rewrite \code{sum} so that it does not take the bounds
 %% \code{a} and \code{b} as parameters:
+
+A última formulação das funções de soma já são bem compactas. Mas 
+podemos fazer ainda melhor. Observe que \code{a} e \code{b} aparecem como 
+parâmetros e argumentos de cada função, mas não parecem tomar parte de 
+combinações interessantes. Há algum modo de nos livrarmos delas?
+
+Vamos tentar reescrever \code{sum} de tal modo que não receba os limites
+\code{a} e \code{b} como parâmetros:     
+
 \begin{lstlisting}
 def sum(f: Int => Int): (Int, Int) => Int = {
   def sumF(a: Int, b: Int): Int =
@@ -1565,14 +1585,20 @@ def sum(f: Int => Int): (Int, Int) => Int = {
 %% latter function does all the work; it takes the bounds \code{a} and
 %% \code{b} as parameters, applies \code{sum}'s function parameter \code{f} to all
 %% integers between them, and sums up the results. 
-
+Nessa formulação, \code{sum} é uma função que retorna uma outra função, especificamente
+a função especializada soma \code{sumF}. Esta última função realiza todo o trabalho; 
+recebe os limites \code{a} e \code{b} como parâmetros, aplica a função \code{f}, parâmetro
+de \code{sum}, a todos os inteiros entre eles, e soma os resultados.
+      
 %% Using this new formulation of \code{sum}, we can now define:
+Usando esta nova formulação de \code{sum}, podemos agora definir:
 \begin{lstlisting}
 def sumInts  =  sum(x => x)
 def sumSquares  =  sum(x => x * x)
 def sumPowersOfTwo  =  sum(powerOfTwo)
 \end{lstlisting}
 %% Or, equivalently, with value definitions:
+Ou, equivalentemente, com definições de valores:
 \begin{lstlisting}
 val sumInts  =  sum(x => x)
 val sumSquares  =  sum(x => x * x)
@@ -1580,7 +1606,7 @@ val sumPowersOfTwo  =  sum(powerOfTwo)
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
 %% applied like any other function. For instance,
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4396,50 +4396,43 @@ Aqui está a implementação do método \code{:::}:
     case p :: ps => this.:::(ps).::(p)
   }
 \end{lstlisting}
-%----------xpto
 
-\paragraph{Reversing lists} Another useful operation
-is list reversal. There is a method \code{reverse} in \code{List} to
-that effect. Let's try to give its implementation:
+\paragraph{Invertendo listas} 
+Outra operação útil é a inversão de lista. Há um método \code{reverse} em \code{List}
+que tem esse efeito. Vamos tentar dar a implementação:
 \begin{lstlisting}
 def reverse[A](xs: List[A]): List[A] = xs match {
   case Nil => Nil
   case x :: xs => reverse(xs) ::: List(x)
 }
 \end{lstlisting}
-This implementation has the advantage of being simple, but it is not
-very efficient.  Indeed, one concatenation is executed for every
-element in the list. List concatenation takes time proportional to the
-length of its first operand. Therefore, the complexity of
-\code{reverse(xs)} is
+Esta implementação tem a vantagem de ser mais simples, mas não é muito eficiente. 
+Na verdade, uma concatenação é feita para cada elemento da lista. Concatenação de listas
+leva tempo proporcional ao tamanho do seu primeiro operando. Consequentemente, a complexidade
+de \code{reverse(xs)} é 
 \[
 n + (n - 1) + ... + 1 = n(n+1)/2
 \]
-where $n$ is the length of \code{xs}. Can \code{reverse} be
-implemented more efficiently? We will see later that there exists
-another implementation which has only linear complexity.
+onde $n$ é o tamanho de \code{xs}. Pode-se implementar \code{reverse} mais eficientemente? 
+Veremos mais tarde que há uma outra implementação que tem complexidade linear.
 
-\section{Example: Merge sort}
+\section{Exemplo: Merge sort}
 
-The insertion sort presented earlier in this chapter is simple to
-formulate, but also not very efficient. It's average complexity is
-proportional to the square of the length of the input list. We now
-design a program to sort the elements of a list which is more
-efficient than insertion sort. A good algorithm for this is {\em merge
-sort}, which works as follows.
+O insertion sort apresentado anteriormente neste capítulo é simples de formular, mas também não 
+é muito eficiente. Sua complexidade média é proporcional ao quadrado do tamanho de sua lista 
+de entrata. Agora escreveremos um programa para ordenar os elementos de uma lista que é mais 
+eficiente que o insertion sort. Um bom algoritmo para isso é {\em merge sort}, que trabalha 
+do seguinte modo.
 
-First, if the list has zero or one elements, it is already sorted, so
-one returns the list unchanged. Longer lists are split into two
-sub-lists, each containing about half the elements of the original
-list. Each sub-list is sorted by a recursive call to the sort
-function, and the resulting two sorted lists are then combined in a
-merge operation.
+Primeiro, se a lista tem zero ou um elementos, já está ordenada, logo retornamos a lista sem 
+modificações. Listas mais longas são divididas em duas sublistas, cada uma contendo por volta
+de metade dos elementos da lista original. Cada sublista é ordenada através de uma chamada 
+recursiva para a função de ordenação, e as duas listas ordenadas resultantes são então 
+combinadas em uma operação merge. 
 
-For a general implementation of merge sort, we still have to specify
-the type of list elements to be sorted, as well as the function to be
-used for the comparison of elements. We obtain a function of maximal
-generality by passing these two items as parameters. This leads to the
-following implementation.
+Para uma implementação geral do merge sort, ainda temos que especificar o tipo dos elementos da lista 
+a ser ordenada, bem como a função a ser usada na comparação dos elementos. Obtemos uma função de 
+generalidade maximal passando estes dois itens como parâmetros. Isto leva a seguinte implementação.
 \begin{lstlisting}
 def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
   def merge(xs1: List[A], xs2: List[A]): List[A] =
@@ -4452,6 +4445,9 @@ def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
   else merge(msort(less)(xs take n), msort(less)(xs drop n))
 }
 \end{lstlisting}
+
+%-------------xpto 
+
 The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
 length of the input list. To see why, note that splitting a list in
 two and merging two sorted lists each take time proportional to the

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -276,18 +276,27 @@ para gerar código inline eficiente para isso.
 %% For efficiency and better error diagnostics the \code{while} loop is a
 %% primitive construct in Scala. But in principle, it could have just as
 %% well been a predefined function. Here is a possible implementation of it:
+Por eficiência e melhor detecção de erros o laço \code{while} é um construtor 
+primitivo em Scala. Mas em princípio, poderia do mesmo modo ser uma função 
+predefinida. Aqui está uma possível implementação para ele: 
 %----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
   if (p) { s ; While(p)(s) }
 }
 \end{lstlisting}
-%----------
+
+%xpto----------
 %% The \code{While} function takes as first parameter a test function,
 %% which takes no parameters and yields a boolean value. As second
 %% parameter it takes a command function which also takes no parameters
 %% and yields a result of type \lstinline@Unit@. \code{While} invokes the
 %% command function as long as the test function yields true.
+A função \code{While} recebe como primeiro parâmetro uma função teste,
+que não recebe parâmetros e produz um valor boleano. Como segundo parâmetro 
+recebe uma função comando que também não recebe parâmetros e produz como 
+resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
+enquanto a função teste produzir verdadeiro.
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4770,41 +4770,36 @@ def lengthFun[A](xs: List[A]): int =
 \end{lstlisting}
 \end{exercise}
 
-%------------xpto
 
-\paragraph{Nested Mappings}
+\paragraph{Mapeamentos Aninhados}
 
-We can employ higher-order list processing functions to express many
-computations that are normally expressed as nested loops in imperative
-languages. 
+Podemos empregar funções de processamento de listas de alta ordem para expressar muita
+computação que, normalmente é expressa através de aninhamento de laços nas linguagens imperativas.
 
-As an example, consider the following problem: Given a positive
-integer $n$, find all pairs of positive integers $i$ and $j$, where 
-$1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
-the pairs are
+Como exemplo, considere o seguinte problema: Dado um inteiro positivo $n$, encontre todos os pares
+de inteiros positivos $i$ e $j$, onde $1 \leq j < i < n$ tal que $i + j$ seja primo. Por exemplo, 
+se $n= 7$, os pares são 
 \bda{c|lllllll}
 i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
 j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
 i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
 \eda
 
-A natural way to solve this problem consists of two steps. In a first step,
-one generates the sequence of all pairs $(i, j)$ of integers such that
-$1 \leq j < i < n$. In a second step one then filters from this sequence
-all pairs $(i, j)$ such that $i + j$ is prime.
+Um modo natural de resolver este problema consiste em dois passos. Num primeiro passo, gera-se
+a sequência de todos os pares $(i, j)$ de inteiros tal que $1 \leq j < i < n$. Num segundo passo
+filtra-se, a partir desta sequência, todos os pares $(i,j)$ tal que $i + j$ é primo.
 
-Looking at the first step in more detail, a natural way to generate
-the sequence of pairs consists of three sub-steps.  First, generate
-all integers between $1$ and $n$ for $i$.  
-\item
-Second, for each integer $i$ between $1$ and $n$, generate the list of
-pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
-combination of \code{range} and \code{map}:
+Examinando o primeiro passo em detalhe, um modo natural de gerar a sequência de pares consiste
+de três sub-passos. Primeiro, gera-se todos os inteiros entre $1$ e $n$ para $i$.
+
+Segundo, para cada inteiro $i$ entre $1$ e $n$, gera-se a lista de pares $(i, 1)$ up to $(i, i-1)$. 
+Isso pode ser conseguido através de uma combinação de \code{range} e \code{map}:
 \begin{lstlisting}
   List.range(1, i) map (x => (i, x))
 \end{lstlisting}
-Finally, combine all sublists using \code{foldRight} with \code{:::}.
-Putting everything together gives the following expression:
+
+Finalmente, combina-se todas as sublistas usando \code{foldRight} com \code{:::}. Juntando tudo
+dá a seguinte expressão:
 \begin{lstlisting}
 List.range(1, n)
   .map(i => List.range(1, i).map(x => (i, x)))
@@ -4813,10 +4808,9 @@ List.range(1, n)
 \end{lstlisting}
 
 \paragraph{Flattening Maps}
-The combination of mapping and then concatenating sublists 
-resulting from the map
-is so common that we there is a special method 
-for it in class \code{List}:
+
+A combinação entre mapeamento e a concatenação das sublistas resultantes do mapeamento é tão comum 
+que há um método especial para isto na classe \code{List}:
 \begin{lstlisting}
 abstract class List[+A] { ...
   def flatMap[B](f: A => List[B]): List[B] = this match {
@@ -4825,8 +4819,8 @@ abstract class List[+A] { ...
   }
 }
 \end{lstlisting}
-With \code{flatMap}, the pairs-whose-sum-is-prime expression 
-could have been written more concisely as follows.
+Com \code{flatMap}, os expressão dos ``pares cuja soma dá um primo'' pode ser escrita de modo mais
+sucinto como segue.
 \begin{lstlisting}
 List.range(1, n)
   .flatMap(i => List.range(1, i).map(x => (i, x)))
@@ -4835,21 +4829,19 @@ List.range(1, n)
 
 
 
-\section{Summary}
+\section{Sumário}
 
-This chapter has introduced lists as a fundamental data structure in
-programming. Since lists are immutable, they are a common data type in
-functional programming languages. They have a role comparable to
-arrays in imperative languages. However, the access patterns between
-arrays and lists are quite different. Where array accessing is always
-done by indexing, this is much less common for lists.  We have seen
-that \code{scala.List} defines a method called \code{apply} for indexing
-however this operation is much more costly than in the case of arrays
-(linear as opposed to constant time). Instead of indexing, lists are
-usually traversed recursively, where recursion steps are usually based
-on a pattern match over the traversed list. There is also a rich set of
-higher-order combinators which allow one to instantiate a set of
-predefined patterns of computations over lists.
+Este capítulo introduziu listas como uma estrutura de dados fundamental na programação. Como listas 
+são imutáveis, elas são um tipo de dado comum na programação em linguagens funcionais. Elas têm 
+importância comparável a vetores nas linguagens imperativas. Entretanto, o padrão de acesso é bem diferente 
+entre os dois. Enquanto o acesso em vetores é sempre feito através de indexação, isto é muito incomum em 
+listas. Nós vimos que \code{scala.List} define um método chamado \code{apply} para a indexação, entretanto, 
+esta operação é muito mais custosa que no caso dos vetores (linear em comparação a tempo constante). Ao
+invés da indexação, listas são geralmente percorridas recursivamente, onde passos recursivos são em geral
+baseados em casamento de padrões sobre a lista percorrida. Há também um rico conjunto de combinadores de
+alta ordem que permitem a instanciação de um conjunto de padrões pré-definidos de computações sobre listas.
+
+%---------------xpto
 
 \comment{
 \bsh{Reasoning About Lists}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -9,7 +9,7 @@
 
 \chapter{\label{chap:example-one}Um primeiro exemplo}
 
-Para comeÃ§ar, apresentamos um primeiro exemplo, a implementaÃ§Ã£o de Quicksort em Scala.
+Para começar, apresentamos um primeiro exemplo, a implementação de Quicksort em Scala.
 
 \begin{lstlisting}
 def sort(xs: Array[Int]) {
@@ -35,20 +35,20 @@ def sort(xs: Array[Int]) {
 }
 \end{lstlisting}
 
-A implementaÃ§Ã£o se parece muito com a que vocÃª faria em Java
-ou C. NÃ³s usamos os mesmos operadores e estruturas de controle.
-Existem tambÃ©m algumas pequenas diferenÃ§as sintÃ¡ticas, particularmente:
+A implementação se parece muito com a que você faria em Java
+ou C. Nós usamos os mesmos operadores e estruturas de controle.
+Existem também algumas pequenas diferenças sintáticas, particularmente:
 \begin{itemize}
 \item
-As declaraÃ§Ãµes comeÃ§am usando palavras reservadas. Particularmente, declaraÃ§Ãµes de funÃ§Ãµes sÃ£o iniciadas
-com a palavra \code{def}, declaraÃ§Ãµes de variÃ¡veis sÃ£o iniciadas com a palavra \code{var} e
-declaraÃ§Ã£o de constantes (chamadas de valores) sÃ£o iniciadas com a palavra \code{val}.
+As declarações começam usando palavras reservadas. Particularmente, declarações de funções são iniciadas
+com a palavra \code{def}, declarações de variáveis são iniciadas com a palavra \code{var} e
+declaração de constantes (chamadas de valores) são iniciadas com a palavra \code{val}.
 \item
-O tipo de um parÃ¢metro em uma funÃ§Ã£o Ã© declarado apÃ³s o nome do parÃ¢metro seguido de dois pontos(:).
+O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
 O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
-A  declaraÃ§Ã£o de vetores do tipo \code{T} Ã© feita usando a expressÃ£o \code{Array[T]} ao invÃ©s de \code{T[]}. 
-O i-Ã©simo elemento de um vetor \code{a} Ã© acessado usando \code{a(i)} ao invÃ©s de \code{a[i]}.
+A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
+O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
 %----------
 %\item
 %Functions can be nested inside other functions. Nested functions can
@@ -57,10 +57,10 @@ O i-Ã©simo elemento de um vetor \code{a} Ã© acessado usando \code{a(i)} ao invÃ©
 %\code{swap} and \code{sort1}, and therefore need not be passed as a
 %parameter to them.
 \item
-FunÃ§Ãµes podem ser aninhadas umas dentro das outras. FunÃ§Ãµes aninhadas podem
-acessar parÃ¢metros e variÃ¡veis locais de suas funÃ§Ãµes externas. Por
-exemplo, o nome do vetor \code{xs} Ã© visÃ­vel nas funÃ§Ãµes \code{swap} e 
-\code{sort1}, e portanto nÃ£o precisam ser passadas como um parÃ¢metro para elas.
+Funções podem ser aninhadas umas dentro das outras. Funções aninhadas podem
+acessar parâmetros e variáveis locais de suas funções externas. Por
+exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e 
+\code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
 %----------
 \end{itemize}
 
@@ -76,13 +76,13 @@ exemplo, o nome do vetor \code{xs} Ã© visÃ­vel nas funÃ§Ãµes \code{swap} e
 %completely different. Here is Quicksort again, this time written in
 %functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
-com algumas peculiaridades sintÃ¡ticas. De fato Ã© possÃ­vel escrever
-programas em estilo imperativo ou orientado a objetos. Isto Ã© 
-importante, porque Ã© uma das coisas que facilitam combinar componentes
+com algumas peculiaridades sintáticas. De fato é possível escrever
+programas em estilo imperativo ou orientado a objetos. Isto é 
+importante, porque é uma das coisas que facilitam combinar componentes
 Scala com componentes escritos em linguagens convencionais, tais como Java,
 C\# ou Visual Basic.
-Entretanto, tambÃ©m Ã© possÃ­vel escrever programas num estilo completamente
-diferente. Aqui estÃ¡ o Quicksort novamente, desta vez escrito em 
+Entretanto, também é possível escrever programas num estilo completamente
+diferente. Aqui está o Quicksort novamente, desta vez escrito em 
 estilo funcional.
 %----------
 \begin{lstlisting}
@@ -114,19 +114,19 @@ def sort(xs: Array[Int]): Array[Int] = {
 %% less than or greater or equal to pivot.}
 %% \item The result is obtained by appending the three sub-arrays together.
 %% \end{itemize}
-O programa funcional captura a essÃªncia do algoritmo quicksort de modo conciso:
+O programa funcional captura a essência do algoritmo quicksort de modo conciso:
 \begin{itemize}
-\item Se o vetor estÃ¡ vazio ou consiste de um Ãºnico elemento, jÃ¡ estÃ¡ ordenado,
-      entÃ£o retorne imediatamente.
-\item Se o vetor nÃ£o estÃ¡ vazio, escolha um elemento do meio do vetor como pivÃ´.
+\item Se o vetor está vazio ou consiste de um único elemento, já está ordenado,
+      então retorne imediatamente.
+\item Se o vetor não está vazio, escolha um elemento do meio do vetor como pivô.
 \item Particione o vetor em dois subvetores contendo, respectivamente os elementos
- que sÃ£o menores que o elemento pivÃ´, maiores que, e um terceiro vetor que contÃ©m
- elementos iguais ao pivÃ´.
-\item Ordene os dois primeiros subvetores por uma chamada recursiva da funÃ§Ã£o de 
-ordenaÃ§Ã£o.\footnote{Isso nÃ£o Ã© exatamente o que o algoritmo imperativo faz; este 
-Ãºltimo particiona o vetor em dois subvetores contendo elementos menores que ou 
-maiores ou iguais ao pivÃ´.}
-\item O resultado Ã© obtido pela concatenaÃ§Ã£o dos trÃªs subvetores.
+ que são menores que o elemento pivô, maiores que, e um terceiro vetor que contém
+ elementos iguais ao pivô.
+\item Ordene os dois primeiros subvetores por uma chamada recursiva da função de 
+ordenação.\footnote{Isso não é exatamente o que o algoritmo imperativo faz; este 
+último particiona o vetor em dois subvetores contendo elementos menores que ou 
+maiores ou iguais ao pivô.}
+\item O resultado é obtido pela concatenação dos três subvetores.
 \end{itemize}
 %----------
 
@@ -138,12 +138,12 @@ maiores ou iguais ao pivÃ´.}
 %% implementation returns a new sorted array and leaves the argument
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
-Tanto a implementaÃ§Ã£o imperativa quanto a funcional tem mesma complexidade
-assintÃ³tica -- $O(N;log(N))$ no caso mÃ©dio e $O(NË†2)$ no pior caso. Mas onde
-a implementaÃ§Ã£o imperativa opera localmente, modificando o vetor original,
-a implementaÃ§Ã£o funcional retorna um novo vetor ordenado e deixa o vetor
-original inalterado. A implementaÃ§Ã£o funcional, portanto, requer mais
-memÃ³ria transiente que a imperativa.
+Tanto a implementação imperativa quanto a funcional tem mesma complexidade
+assintótica -- $O(N;log(N))$ no caso médio e $O(Nœô¤æ2)$ no pior caso. Mas onde
+a implementação imperativa opera localmente, modificando o vetor original,
+a implementação funcional retorna um novo vetor ordenado e deixa o vetor
+original inalterado. A implementação funcional, portanto, requer mais
+memória transiente que a imperativa.
 %----------
 
 %----------
@@ -154,12 +154,12 @@ memÃ³ria transiente que a imperativa.
 %% standard Scala library, and which itself is implemented in
 %% Scala. Because arrays are instances of \verb@Seq@ all sequence
 %% methods are available for them.
-A implementaÃ§Ã£o funcional faz parecer que Scala Ã© uma linguagem
-especializada para operaÃ§Ãµes funcionais sobre vetores. De fato, nÃ£o Ã©;
-todas as operaÃ§Ãµes usadas no exemplo sÃ£o simples mÃ©todos de biblioteca
-de uma classe {\em sequÃªncia} \code{Seq[T]} que Ã© parte da biblioteca
-padrÃ£o Scala, e onde ela mesma Ã© implementada em Scala. Como vetores sÃ£o 
-instÃ¢ncias de \verb@Seq@, todos os mÃ©todos de sequÃªncia estÃ£o disponÃ­veis
+A implementação funcional faz parecer que Scala é uma linguagem
+especializada para operações funcionais sobre vetores. De fato, não é;
+todas as operações usadas no exemplo são simples métodos de biblioteca
+de uma classe {\em sequência} \code{Seq[T]} que é parte da biblioteca
+padrão Scala, e onde ela mesma é implementada em Scala. Como vetores são 
+instâncias de \verb@Seq@, todos os métodos de sequência estão disponíveis
 para eles.
 %----------
 
@@ -170,11 +170,11 @@ para eles.
 %% array consisting of all the elements of the original array for which the
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
-Em particular, hÃ¡ o mÃ©todo \code{filter} que recebe como argumento uma
-{\em funÃ§Ã£o predicado}. Esta funÃ§Ã£o predicado deve mapear elementos do 
-vetor para valores boleanos. O resultado de \code{filter} Ã© um vetor
-consistindo de todos os elementos do vetor original para o qual a funÃ§Ã£o
-predicado Ã© verdadeira. O mÃ©todo \code{filter} de um objeto tipo
+Em particular, há o método \code{filter} que recebe como argumento uma
+{\em função predicado}. Esta função predicado deve mapear elementos do 
+vetor para valores boleanos. O resultado de \code{filter} é um vetor
+consistindo de todos os elementos do vetor original para o qual a função
+predicado é verdadeira. O método \code{filter} de um objeto tipo
 \code{Array[T]} portanto tem a assinatura. 
 %----------
 
@@ -188,11 +188,11 @@ def filter(p: T => Boolean): Array[T]
 %% of type \code{t} and return a \code{Boolean}.  Functions like
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
-Aqui, \code{T=>Boolean} Ã© o tipo das funÃ§Ãµes que recebem um elemento 
+Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
 do tipo \code{T} e retornam um valor booleano do tipo \code{Boolean}. 
-FunÃ§Ãµes como \code{filter} 
-que recebem uma outra funÃ§Ã£o como argumento ou retornam uma funÃ§Ã£o como
-resultado sÃ£o chamadas {\em funÃ§Ãµes de alta ordem.}     
+Funções como \code{filter} 
+que recebem uma outra função como argumento ou retornam uma função como
+resultado são chamadas {\em funções de alta ordem.}     
 %----------
 
 %----------
@@ -205,15 +205,15 @@ resultado sÃ£o chamadas {\em funÃ§Ãµes de alta ordem.}
 %% for binary infix operators which start with a letter. Hence, the
 %% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
 %% method call ~\lstinline@xs.filter(pivot >)@.
-Scala nÃ£o faz distinÃ§Ã£o entre nomes de identificadores e nomes de operadores.
-um identificador pode ser ou uma sequÃªncia de letras ou digitos que comeÃ§am
-com uma letra, ou podem ser uma sequÃªncia de caracteres especiais, tais como 
+Scala não faz distinção entre nomes de identificadores e nomes de operadores.
+um identificador pode ser ou uma sequência de letras ou digitos que começam
+com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
 ``\code{+}'', ``\code{*}'', ou ``\code{:}''.  Qualquer identificador pode
-ser usado como operador infixo em Scala. A operaÃ§Ã£o binÃ¡ria $E;op;E'$ Ã© sempre
-interpretado como a chamada de mÃ©todo $E.op(E')$. Isso vale tambÃ©m para 
-operadores binÃ¡rios infixos que iniciam com uma letra. Consequentemente,
-a expressÃ£o  ~\lstinline@xs filter (pivot >)@~ Ã© equivalente Ã  chamada de
-mÃ©todo ~\lstinline@xs.filter(pivot >)@.
+ser usado como operador infixo em Scala. A operação binária $E;op;E'$ é sempre
+interpretado como a chamada de método $E.op(E')$. Isso vale também para 
+operadores binários infixos que iniciam com uma letra. Consequentemente,
+a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
+método ~\lstinline@xs.filter(pivot >)@.
 %----------
 
 
@@ -231,25 +231,25 @@ mÃ©todo ~\lstinline@xs.filter(pivot >)@.
 %% summarize, \code{xs.filter(pivot >)} returns a list consisting
 %% of all elements of the list \code{xs} that are smaller than
 %% \code{pivot}.
-No programa quicksort, \code{filter} Ã© aplicado trÃªs vezes a um argumento 
-de funÃ§Ã£o anÃ´nima. O primeiro argumento, \code{pivot >}, representa uma 
-funÃ§Ã£o que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
-Este Ã© um exemplo de uma {\em funÃ§Ã£o parcialmente aplicada}. Um outro modo, 
-equivalente de se escrever esta funÃ§Ã£o, que torna o argumento oculto explicito
-Ã© ~\lstinline@x => pivot > x@. A funÃ§Ã£o Ã© anÃ´nima, ou seja, nÃ£o Ã© definida
-com um nome. O tipo do parÃ¢metro  \code{x} Ã© omitido porque um compilador Scala 
-pode inferÃ­-lo automÃ¡ticamente a partir do contexto onde a funÃ§Ã£o Ã© usada.
+No programa quicksort, \code{filter} é aplicado três vezes a um argumento 
+de função anônima. O primeiro argumento, \code{pivot >}, representa uma 
+função que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
+Este é um exemplo de uma {\em função parcialmente aplicada}. Um outro modo, 
+equivalente de se escrever esta função, que torna o argumento oculto explicito
+é ~\lstinline@x => pivot > x@. A função é anônima, ou seja, não é definida
+com um nome. O tipo do parâmetro  \code{x} é omitido porque um compilador Scala 
+pode inferí-lo automáticamente a partir do contexto onde a função é usada.
 Resumindo, \code{xs.filter(pivot >)} retorna uma lista consistindo de todos os 
-elementos da lista \code{xs} que sÃ£o menores que \code{pivot}.  
+elementos da lista \code{xs} que são menores que \code{pivot}.  
 %----------
 
 %----------
 %% Looking again in detail at the first, imperative implementation of
 %% Quicksort, we find that many of the language constructs used in the
 %% second solution are also present, albeit in a disguised form.
-Olhando novamente em detalhes para a primeira, implementaÃ§Ã£o imperativa
+Olhando novamente em detalhes para a primeira, implementação imperativa
 do Quicksort, percebemos que muitos dos construtores da linguagem 
-usados na segunda soluÃ§Ã£o estÃ£o presentes, embora de modo distinto.
+usados na segunda solução estão presentes, embora de modo distinto.
 %----------
 
 
@@ -263,23 +263,23 @@ usados na segunda soluÃ§Ã£o estÃ£o presentes, embora de modo distinto.
 %% Of course, a compiler is free (if it is moderately smart, even expected)
 %% to recognize the special case of calling the \code{+} method over
 %% integer arguments and to generate efficient inline code for it.
-Por exemplo, operadores binÃ¡rios padrÃ£o, tais como \code{+}, \code{-},
-ou \code{<} nÃ£o sÃ£o tratados de modo especial. Assim como \code{append}, 
-sÃ£o mÃ©todos de seus operandos esquerdos. Consequentemente, a expressÃ£o 
-\code{i+1} Ã© vista como a invocaÃ§Ã£o de \code{i.+(1)} do mÃ©todo \code{+}      
-do valor inteiro de \code{i}. De fato, um compilador Ã© livre (se 
+Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
+ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
+são métodos de seus operandos esquerdos. Consequentemente, a expressão 
+\code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
+do valor inteiro de \code{i}. De fato, um compilador é livre (se 
 moderadamente esperto, ainda que  esperado) para reconhecer o caso 
-especial da chamada de mÃ©todo \code{+} sobre argumentos inteiros e 
-para gerar cÃ³digo inline eficiente para isso.  
+especial da chamada de método \code{+} sobre argumentos inteiros e 
+para gerar código inline eficiente para isso.  
 %----------
 
 %----------
 %% For efficiency and better error diagnostics the \code{while} loop is a
 %% primitive construct in Scala. But in principle, it could have just as
 %% well been a predefined function. Here is a possible implementation of it:
-Por eficiÃªncia e melhor detecÃ§Ã£o de erros o laÃ§o \code{while} Ã© um construtor 
-primitivo em Scala. Mas em princÃ­pio, poderia do mesmo modo ser uma funÃ§Ã£o 
-predefinida. Aqui estÃ¡ uma possÃ­vel implementaÃ§Ã£o para ele: 
+Por eficiência e melhor detecção de erros o laço \code{while} é um construtor 
+primitivo em Scala. Mas em princípio, poderia do mesmo modo ser uma função 
+predefinida. Aqui está uma possível implementação para ele: 
 %----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
@@ -293,11 +293,11 @@ def While (p: => Boolean) (s: => Unit) {
 %% parameter it takes a command function which also takes no parameters
 %% and yields a result of type \lstinline@Unit@. \code{While} invokes the
 %% command function as long as the test function yields true.
-A funÃ§Ã£o \code{While} recebe como primeiro parÃ¢metro uma funÃ§Ã£o teste,
-que nÃ£o recebe parÃ¢metros e produz um valor boleano. Como segundo parÃ¢metro 
-recebe uma funÃ§Ã£o comando que tambÃ©m nÃ£o recebe parÃ¢metros e produz como 
-resultado o tipo  \lstinline@Unit@. \code{While} invoca a funÃ§Ã£o comando
-enquanto a funÃ§Ã£o teste produzir verdadeiro.
+A função \code{While} recebe como primeiro parâmetro uma função teste,
+que não recebe parâmetros e produz um valor boleano. Como segundo parâmetro 
+recebe uma função comando que também não recebe parâmetros e produz como 
+resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
+enquanto a função teste produzir verdadeiro.
 %----------
 
 %----------
@@ -312,13 +312,13 @@ enquanto a funÃ§Ã£o teste produzir verdadeiro.
 %% ``expression-oriented'' formulation of the \lstinline@swap@ function
 %% in the first implementation of quicksort, which makes this explicit:
 O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
-no Java; Ã© usado sempre que uma funÃ§Ã£o nÃ£o retornar um resultado interessante.
-De fato, porque Scala Ã© uma linguagem orientada a expressÃµes, cada funÃ§Ã£o 
-retorna algum resultado. Se nenhuma expressÃ£o de retorno Ã©  explicitamente
-fornecida, o valor \lstinline@()@, que Ã© pronunciado ``unit'', Ã© assumido.
-Este valor Ã© do tipo \lstinline@Unit@. FunÃ§Ãµes que retornam ``unit'' sÃ£o 
-tambÃ©m chamadas {\em procedimentos}. Aqui estÃ¡ uma formulaÃ§Ã£o mais 
-``orientada a expressÃ£o'' da funÃ§Ã£o \lstinline@swap@ na primeira implementaÃ§Ã£o
+no Java; é usado sempre que uma função não retornar um resultado interessante.
+De fato, porque Scala é uma linguagem orientada a expressões, cada função 
+retorna algum resultado. Se nenhuma expressão de retorno é  explicitamente
+fornecida, o valor \lstinline@()@, que é pronunciado ``unit'', é assumido.
+Este valor é do tipo \lstinline@Unit@. Funções que retornam ``unit'' são 
+também chamadas {\em procedimentos}. Aqui está uma formulação mais 
+``orientada a expressão'' da função \lstinline@swap@ na primeira implementação
 do quicksort, que explicita isto:
 %----------
 
@@ -334,10 +334,10 @@ def swap(i: Int, j: Int) {
 %% \lstinline@return@ keyword is not necessary. Note that functions
 %% returning an explicit value always need an ``='' before their
 %% body or defining expression.  
-O valor resultante desta funÃ§Ã£o Ã© simplesmente sua Ãºltima expressÃ£o---uma
-palavra chave \lstinline@return@ nÃ£o Ã© necessÃ¡ria. Observe que funÃ§Ãµes 
-que retornam um valor explÃ­cito sempre precisam de um ``='' antes de
-seus corpos ou expressÃµes de definiÃ§Ã£o.
+O valor resultante desta função é simplesmente sua última expressão---uma
+palavra chave \lstinline@return@ não é necessária. Observe que funções 
+que retornam um valor explícito sempre precisam de um ``='' antes de
+seus corpos ou expressões de definição.
 %----------
 
 \chapter{Programando com Atores e Mensagens}
@@ -351,14 +351,14 @@ seus corpos ou expressÃµes de definiÃ§Ã£o.
 %% its incoming messages which is represented as a queue. It can work
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
-Aqui estÃ¡ um exemplo que mostra uma Ã¡rea de aplicaÃ§Ã£o para a qual Scala 
-Ã© particularmente indicada. Considere a tarefa de implementar um serviÃ§o
-de leilÃ£o eletrÃ´nico. Podemos usar um modelo de processo no estilo 
-actor do Erlang para implementar os participantes do leilÃ£o. Actors sÃ£o 
-objetos para os quais as mensagens sÃ£o enviadas. Cada actor tem uma caixa de correio 
-para suas mensagens de entrada que Ã© representada para uma fila. Pode
+Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
+é particularmente indicada. Considere a tarefa de implementar um serviço
+de leilão eletrônico. Podemos usar um modelo de processo no estilo 
+actor do Erlang para implementar os participantes do leilão. Actors são 
+objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
+para suas mensagens de entrada que é representada para uma fila. Pode
 trabalhar sequencialmente nas mensagens da sua caixa de correio, ou buscar 
-por mensagens que casam com algum padrÃ£o. 
+por mensagens que casam com algum padrão. 
 %----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
@@ -383,11 +383,11 @@ case object AuctionOver                      extends AuctionReply
 %% and that communicates with the seller and winning bidder to close the
 %% transaction. We present an overview of a simple implementation
 %% here.
-Para cada item negociado hÃ¡ um actor leiloeiro que publica a 
-informaÃ§Ã£o sobre o item negociado, que aceita ofertas de clientes
-e que se comunica com o vendedor e com o vencedor do leilÃ£o 
-para fechar a transaÃ§Ã£o. Apresentamos uma visÃ£o superficial de uma
- implementaÃ§Ã£o aqui.
+Para cada item negociado há um actor leiloeiro que publica a 
+informação sobre o item negociado, que aceita ofertas de clientes
+e que se comunica com o vendedor e com o vencedor do leilão 
+para fechar a transação. Apresentamos uma visão superficial de uma
+ implementação aqui.
 %----------
 
 %----------
@@ -397,10 +397,10 @@ para fechar a transaÃ§Ã£o. Apresentamos uma visÃ£o superficial de uma
 %% service, and \code{AuctionReply} for replies from the service to the
 %% clients.  For both base classes there exists a number of cases, which
 %% are defined in Figure~\ref{fig:simple-auction-msgs}.
-Como primeiro passo, definimos as mensagens que sÃ£o trocadas durante um
-leilÃ£o. HÃ¡ duas classes base abstratas \code{AuctionMessage} para mensagens 
-de clientes do serviÃ§o de leilÃ£o, e \code{AuctionReply} para respostas 
-do serviÃ§o aos clientes. Para ambas as classes base hÃ¡ um nÃºmero de casos 
+Como primeiro passo, definimos as mensagens que são trocadas durante um
+leilão. Há duas classes base abstratas \code{AuctionMessage} para mensagens 
+de clientes do serviço de leilão, e \code{AuctionReply} para respostas 
+do serviço aos clientes. Para ambas as classes base há um número de casos 
 definidos na Figura~\ref{fig:simple-auction-msgs}.
 %----------
 
@@ -446,14 +446,14 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 %% might well be ultimately mapped to small XML documents. We expect
 %% automatic tools to exist that convert between XML documents and
 %% internal data structures like the ones defined above.
-Para cada classe base, hÃ¡ um nÃºmero de {\em classes case} que definem
+Para cada classe base, há um número de {\em classes case} que definem
 o formato de mensagens particulares dentro da classe. Estas mensagens
-podem em Ãºltimo caso ser mapeadas a pequenos documentos XML. Esperamos
-que hajam ferramentas automÃ¡ticas que convertam entre documentos XML e 
+podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
+que hajam ferramentas automáticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
 % Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
 %
-% Resp: por que trata-se de um modelo de concorrÃªncia (o nome do modelo) 
+% Resp: por que trata-se de um modelo de concorrência (o nome do modelo) 
 % usado por Scala que foi inspirado no modelo do Erlang:
 %      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
@@ -473,19 +473,19 @@ estruturas de dados internas, tais como as definidas acima.
 %% message. Before finally stopping, it stays active for another period
 %% determined by the \code{timeToShutdown} constant and replies to
 %% further offers that the auction is closed.
-A Figura~\ref{fig:simple-auction} apresenta uma implementaÃ§Ã£o Scala para a classe
-\code{Auction} para actors do leilÃ£o que coordenam os lances sobre um item. Objetos
-para esta classe sÃ£o criados pela indicaÃ§Ã£o
+A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
+\code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
+para esta classe são criados pela indicação
 \begin{itemize}
-\item Um actor vendedor que precisa ser notificado quando o leilÃ£o terminou,
-\item o lance mÃ­nimo,
-\item a data de quando o leilÃ£o foi fechado.
+\item Um actor vendedor que precisa ser notificado quando o leilão terminou,
+\item o lance mínimo,
+\item a data de quando o leilão foi fechado.
 \end{itemize}  
-O comportamento do actor Ã© definido por seu mÃ©todo \code{act}. Este mÃ©todo seleciona
-repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, atÃ© que o 
-leilÃ£o seja fechado, o que Ã© sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
-finalmente parar, permanece ativo para um outro perÃ­odo determinado pela constante 
-\code{timeToShutdown} e replica para ofertas posteriores que o leilÃ£o estÃ¡ fechado.    
+O comportamento do actor é definido por seu método \code{act}. Este método seleciona
+repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, até que o 
+leilão seja fechado, o que é sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
+finalmente parar, permanece ativo para um outro período determinado pela constante 
+\code{timeToShutdown} e replica para ofertas posteriores que o leilão está fechado.    
 %----------
 
 %----------
@@ -500,14 +500,14 @@ finalmente parar, permanece ativo para um outro perÃ­odo determinado pela consta
 %% messages matching the pattern. The \code{receiveWithin} method selects
 %% the first message in the mailbox which matches one of these patterns
 %% and applies the corresponding action to it.
-Aqui estÃ£o algumas explicaÃ§Ãµes extras sobre os construtores usados neste programa:
+Aqui estão algumas explicações extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
-O mÃ©todo \code{receiveWithin} da classe \code{Actor} recebe como parÃ¢metro um prazo dado
-em milisegundos e uma funÃ§Ã£o que processa mensagens na caixa de correio. A funÃ§Ã£o Ã© dada
-por uma sequÃªncia de cases que especificam um padrÃ£o e uma aÃ§Ã£o para mensagens que 
-casam com o padrÃ£o. O mÃ©todo \code{receiveWithin} seleciona a primeira mensagem da 
-caixa de correio que casa com um destes padrÃµes e aplica a aÃ§Ã£o correspondente a ele. 
+O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um prazo dado
+em milisegundos e uma função que processa mensagens na caixa de correio. A função é dada
+por uma sequência de cases que especificam um padrão e uma ação para mensagens que 
+casam com o padrão. O método \code{receiveWithin} seleciona a primeira mensagem da 
+caixa de correio que casa com um destes padrões e aplica a ação correspondente a ele. 
 %----------
 
 
@@ -519,10 +519,10 @@ caixa de correio que casa com um destes padrÃµes e aplica a aÃ§Ã£o correspondent
 %% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
 %% special message, which is triggered by the \code{Actor} implementation itself.
 \item
-O Ãºltimo case de \code{receiveWithin} Ã© guardado por um padrÃ£o \code{TIMEOUT}.  
-Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrÃ£o Ã© disparado
-apÃ³s o prazo que foi passado como argumento para o mÃ©todo envolvente \code{receiveWithin}.
-\code{TIMEOUT} Ã© uma mensagem especial, que Ã© disparada pela prÃ³pria implementaÃ§Ã£o do 
+O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
+Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrão é disparado
+após o prazo que foi passado como argumento para o método envolvente \code{receiveWithin}.
+\code{TIMEOUT} é uma mensagem especial, que é disparada pela própria implementação do 
 \code{Actor}.    
 %----------
 
@@ -537,10 +537,10 @@ apÃ³s o prazo que foi passado como argumento para o mÃ©todo envolvente \code{rec
 %% parameter.
 %% \end{itemize}
 \item
-Mensagens de resposta sÃ£o enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
-\code{!} Ã© usado aqui como um operador binÃ¡rio com um actor e uma mensagem como argumentos.
-Isto Ã© equivalente em Scala ao chamado de mÃ©todo \code{destino.!(AlgumaMensagem)}, ou seja, 
-a invocaÃ§Ã£o do mÃ©todo \code{!} do actor destino com a mensagem dada como parÃ¢metro.
+Mensagens de resposta são enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
+\code{!} é usado aqui como um operador binário com um actor e uma mensagem como argumentos.
+Isto é equivalente em Scala ao chamado de método \code{destino.!(AlgumaMensagem)}, ou seja, 
+a invocação do método \code{!} do actor destino com a mensagem dada como parâmetro.
 \end{itemize}    
 %----------
 
@@ -554,14 +554,14 @@ a invocaÃ§Ã£o do mÃ©todo \code{!} do actor destino com a mensagem dada como parÃ
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussÃ£o precedente deu uma idÃ©ia de programaÃ§Ã£o distribuÃ­da em Scala. Isso
-dÃ¡ a sensaÃ§Ã£o que Scala tem um rico conjunto de construtores que suportam
-processos actor, envio e recebimento de mensagens, programaÃ§Ã£o com timeouts etc.
-De fato, o oposto Ã© verdadeiro. Todos os construtores discutidos acima sÃ£o 
-oferecidos como mÃ©todos na classe biblioteca \code{Actor}. Aquela classe Ã©
-ele mesma implementada em Scala, baseado no modelo thread subjacente Ã  linguagem 
-hospedeira (Java ou .NET). A implementaÃ§Ã£o de todas as caracterÃ­sticas da 
-classe \code{Actor} usada aqui Ã© dada na SeÃ§Ã£o~\ref{sec:actors}.     
+A discussão precedente deu uma idéia de programação distribuída em Scala. Isso
+dá a sensação que Scala tem um rico conjunto de construtores que suportam
+processos actor, envio e recebimento de mensagens, programação com timeouts etc.
+De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
+oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
+ele mesma implementada em Scala, baseado no modelo thread subjacente à linguagem 
+hospedeira (Java ou .NET). A implementação de todas as características da 
+classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
 %----------
 
 %----------
@@ -579,38 +579,38 @@ classe \code{Actor} usada aqui Ã© dada na SeÃ§Ã£o~\ref{sec:actors}.
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
-As vantagens da abordagem baseada em biblioteca sÃ£o a relativa simplicidade
-da linguagem nÃºcleo e a flexibilidade para os criadores de biblioteca. Como 
-a linguagem nÃºcleo nÃ£o precisa especificar detalhes da comunicaÃ§Ã£o dos 
-processos de alto nÃ­vel, pode ser mantida mais simples e geral. Como
-um modelo particular de mensagens numa caixa de correio Ã© um mÃ³dulo biblioteca, 
-pode ser modificado livremente se um diferente modelo for necessÃ¡rio em algumas 
-aplicaÃ§Ãµes. A abordagem requer, entretanto, que a linguagem nÃºcleo seja expressiva
-o suficiente para prover as abstraÃ§Ãµes linguÃ­sticas necessÃ¡rias de um modo 
+As vantagens da abordagem baseada em biblioteca são a relativa simplicidade
+da linguagem núcleo e a flexibilidade para os criadores de biblioteca. Como 
+a linguagem núcleo não precisa especificar detalhes da comunicação dos 
+processos de alto nível, pode ser mantida mais simples e geral. Como
+um modelo particular de mensagens numa caixa de correio é um módulo biblioteca, 
+pode ser modificado livremente se um diferente modelo for necessário em algumas 
+aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
+o suficiente para prover as abstrações linguísticas necessárias de um modo 
 conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
-design foi deixÃ¡-la flexÃ­vel o suficiente para atuar como uma conveniente linguagem
-hospedeira para domÃ­nios de linguagens especÃ­ficos implementados por mÃ³dulos de 
-biblioteca. Por exemplo, a construÃ§Ã£o de comunicaÃ§Ã£o actor apresentada acima
-pode ser vista como um desses domÃ­nios especÃ­ficos de linguagem, que conceitualmente
-estendem o nÃºcleo Scala.  
+design foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
+hospedeira para domínios de linguagens específicos implementados por módulos de 
+biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
+pode ser vista como um desses domínios específicos de linguagem, que conceitualmente
+estendem o núcleo Scala.  
 %----------
 
 %----------
 % Vinicius - comecei traducao aqui.
 %%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
-\chapter{\label{chap:simple-funs}ExpressÃµes e FunÃ§Ãµes Simples}
+\chapter{\label{chap:simple-funs}Expressões e Funções Simples}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
 Os exemplos anteriores deram uma ideia do que pode ser feito com Scala. Agora,
-introduzimos as suas construÃ§Ãµes de linguagem uma a uma de uma maneira mais sistemÃ¡tica.
-Vamos comeÃ§ar com os menores elementos: expressÃµes e funÃ§Ãµes.
+introduzimos as suas construções de linguagem uma a uma de uma maneira mais sistemática.
+Vamos começar com os menores elementos: expressões e funções.
 
 
 %%\section{Expressions And Simple Functions}
-\section{ExpressÃµes e FunÃ§Ãµes Simples}
+\section{Expressões e Funções Simples}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
@@ -618,8 +618,8 @@ Vamos comeÃ§ar com os menores elementos: expressÃµes e funÃ§Ãµes.
 %% types. For example:
 %----------
 Scala vem com um interpretador que pode ser visto como uma calculadora sofisticada.
-O usuÃ¡rio interage com a calculadora digitando expressÃµes. A calculadora retorna o
-resultado do cÃ¡lculo e o seu tipo de dado. Por exemplo: 
+O usuário interage com a calculadora digitando expressões. A calculadora retorna o
+resultado do cálculo e o seu tipo de dado. Por exemplo: 
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -633,8 +633,8 @@ unnamed2: java.lang.String = hello world!
 \end{lstlisting}
 %It is also possible to name a sub-expression and use the name instead
 %of the expression afterwards:
-TambÃ©m Ã© possÃ­vel dar nome a uma sub-expressÃ£o e usar o nome, ao invÃ©s da expressÃ£o, 
-nas expressÃµes seguintes:
+Também é possível dar nome a uma sub-expressão e usar o nome, ao invés da expressão, 
+nas expressões seguintes:
 \begin{lstlisting}
 scala> def scale = 5
 scale: Int
@@ -658,8 +658,8 @@ unnamed4: Double = 62.83185307179586
 %% Definitions start with the reserved word \code{def}; they introduce a
 %% name which stands for the expression following the \code{=} sign.  The
 %% interpreter will answer with the introduced name and its type.
-DefiniÃ§Ãµes comeÃ§am com a palavra reservada \code{def}. Elas introduzem um nome
-que representa a expressÃ£o que vem depois do sÃ­mbolo \code{=}. O intepretrador
+Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
+que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
 % Vinicius - parei traducao aqui.
 
@@ -673,11 +673,11 @@ responde com o nome introduzido e o seu tipo de dado.
 %% evaluation of the definition. If \code{x} is then used subsequently,
 %% it is immediately replaced by the pre-computed value of
 %% \code{e}, so that the expression need not be evaluated again.
-Executando uma definiÃ§Ã£o tal como \code{def x = e} nÃ£o avaliarÃ¡ a expressÃ£o \code{e}. 
-Ao invÃ©s \code{e} Ã© avaliado sempre que \code{x} for usado. Alternativamente, Scala 
-oferece um valor definiÃ§Ã£o \code{val x = e}, o qual avalia o lado direito de \code{e}
-como parte da avaliaÃ§Ã£o da definiÃ§Ã£o. Se \code{x} Ã© entÃ£o usado subsequentemente, Ã© 
-imediatamente substituÃ­do pelo valor prÃ©-computado de \code{e}, logo a expressÃ£o nÃ£o 
+Executando uma definição tal como \code{def x = e} não avaliará a expressão \code{e}. 
+Ao invés \code{e} é avaliado sempre que \code{x} for usado. Alternativamente, Scala 
+oferece um valor definição \code{val x = e}, o qual avalia o lado direito de \code{e}
+como parte da avaliação da definição. Se \code{x} é então usado subsequentemente, é 
+imediatamente substituído pelo valor pré-computado de \code{e}, logo a expressão não 
 precisa ser avaliada novamente.
 %----------
 
@@ -696,17 +696,17 @@ precisa ser avaliada novamente.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
-Como as expressÃµes sÃ£o avaliadas? Uma expressÃ£o consistindo de operadores e 
-operandos Ã© avaliada pela repetida aplicaÃ§Ã£o dos seguintes passos de simplificaÃ§Ã£o:
+Como as expressões são avaliadas? Uma expressão consistindo de operadores e 
+operandos é avaliada pela repetida aplicação dos seguintes passos de simplificação:
 \begin{itemize}
-\item escolha a operaÃ§Ã£o mais a esquerda.
+\item escolha a operação mais a esquerda.
 \item avalie seu operando
 \item aplique o operador aos valores do operando.
 \end{itemize}
-Um nome definido por \code{def} Ã© avaliado substituindo o nome pela definiÃ§Ã£o do lado
-direito (nÃ£o avaliada). Um nome definido por \code{val} Ã© avaliado pela substituiÃ§Ã£o do 
-nome pelo valor da definiÃ§Ã£o do lado direito. O processo de avaliaÃ§Ã£o pÃ¡ra assim que 
-encontrarmos um valor. Um valor Ã© algum dado, tal como uma cadeia de caracteres, um nÃºmero, 
+Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
+direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
+nome pelo valor da definição do lado direito. O processo de avaliação pára assim que 
+encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
 um vetor, ou uma lista.
 %----------
 
@@ -725,7 +725,7 @@ um vetor, ou uma lista.
 %% called {\em reduction}.
 
 \example
-Aqui estÃ¡ uma avaliaÃ§Ã£o de uma expressÃ£o aritmÃ©tica.
+Aqui está uma avaliação de uma expressão aritmética.
 
 \begin{lstlisting}
 $\,\,\,$   (2 * pi) * radius
@@ -734,15 +734,15 @@ $\rightarrow$  6.283185307179586 * radius
 $\rightarrow$  6.283185307179586 * 10
 $\rightarrow$  62.83185307179586
 \end{lstlisting}
-O processo de simplificar gradualmente expressÃµes para valores Ã© 
-chamado {\em reduÃ§Ã£o}.
+O processo de simplificar gradualmente expressões para valores é 
+chamado {\em redução}.
 %----------
 
 
 \section{Parameters}
 
 %% Using \code{def}, one can also define functions with parameters. For example:
-Usando \code{def}, pode-se tambÃ©m definir funÃ§Ãµes com parÃ¢metros. Por exemplo:
+Usando \code{def}, pode-se também definir funções com parâmetros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -772,9 +772,13 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
-ParÃ¢metros de funÃ§Ãµes seguem o nome da funÃ§Ã£o e sempre sÃ£o envolvidos por
-parÃªnteses. Cada parÃ¢metro vem com um tipo que segue o nome do parÃ¢metro
-e dois pontos. AtÃ© aqui, sÃ³ precisamos de tipos numÃ©ricos   
+Parâmetros de funções seguem o nome da função e sempre são envolvidos por
+parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
+e dois pontos. Até aqui, só precisamos de tipos numéricos, tal como o tipo
+\code{scala.Double} dos números de precisão dupla. Scala define {\em tipos
+aliases} para alguns tipos básicos, logo podemos escrever tipos numéricos 
+como em Java. Por exemplo, \code{double} é um tipo alias de \code{scala.Double}
+e \code{int} é um tipo alias para \code{scala.Int}.       
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -536,6 +536,8 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 %% the \code{!} method of the destination actor with the given message as
 %% parameter.
 %% \end{itemize}
+\item
+Mensagens de resposta são enviadas usando sintaxe da forma
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -77,9 +77,13 @@ exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e
 %functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
 com algumas peculiaridades sintáticas. De fato é possível escrever
-programas em estilo imperativo ou orientado a objetos. 
-
-
+programas em estilo imperativo ou orientado a objetos. Isto é 
+importante, porque é uma das coisas que facilitam combinar componentes
+Scala com componentes escritos em linguagens centrais, tais como Java,
+C\# ou Visual Basic.
+Entretanto, também é possível escrever programas num estilo completamente
+diferente. Aqui está o Quicksort novamente, desta vez escrito em 
+estilo funcional.
 %----------
 \begin{lstlisting}
 def sort(xs: Array[Int]): Array[Int] = {

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -384,8 +384,9 @@ case object AuctionOver                      extends AuctionReply
 %% here.
 Para cada item negociado há um actor leiloeiro que publica a 
 informação sobre o item negociado, que aceita ofertas de clientes
-e que comunica com o vendedor e com o vencedor para fechar a transação.
-Apresentamos uma visão superficial de uma implementação aqui.
+e que se comunica com o vendedor e com o vencedor do leilão 
+para fechar a transação. Apresentamos uma visão superficial de uma
+ implementação aqui.
 %----------
 
 %----------xpto

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5309,6 +5309,9 @@ range(1, n)
 Conversely, it would also be possible to express functions \code{map},
 \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
 three functions again, this time implemented using for-comprehensions.
+De modo inverso, também seria possível expressar as funções \code{map}, \code{flatMap} e \code{filter}
+usando for-comprehensions. Aqui estão as três funções novamente 
+
 \begin{lstlisting}
 object Demo {
   def map[A, B](xs: List[A], f: A => B): List[B] =

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -763,6 +763,7 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
+%----------xpto
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
 %% following the parameter name and a colon.  At the present time, we
@@ -771,13 +772,19 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
+Parâmetros de funções seguem o nome da função e sempre são envolvidos por
+parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
+e dois pontos. Até aqui, só precisamos de tipos numéricos   
+%----------
 
+%----------
 %% Functions with parameters are evaluated analogously to operators in
 %% expressions. First, the arguments of the function are evaluated (in
 %% left-to-right order). Then, the function application is replaced by
 %% the function's right hand side, and at the same time all formal
 %% parameters of the function are replaced by their corresponding actual
 %% arguments.
+%----------
 
 \example\ 
  
@@ -792,10 +799,13 @@ $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
 
+%----------
 %% The example shows that the interpreter reduces function arguments to
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
 %% have yielded the following reduction sequence:
+%----------
+
 \begin{lstlisting}
 $\,\,\,$   sumOfSquares(3, 2+2)
 $\rightarrow$  square(3) + square(2+2)
@@ -807,19 +817,23 @@ $\rightarrow$  9 + 4 * 4
 $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
-
+%----------
 %% The second evaluation order is known as \emph{call-by-name},
 %% whereas the first one is known as \emph{call-by-value}.  For
 %% expressions that use only pure functions and that therefore can be
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
+%----------
 
+%----------
 %% Call-by-value has the advantage that it avoids repeated evaluation of
 %% arguments. Call-by-name has the advantage that it avoids evaluation of
 %% arguments when the parameter is not used at all by the function.
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
+%----------
+
 \begin{lstlisting}
 scala> def loop: Int = loop
 loop: Int
@@ -827,15 +841,18 @@ loop: Int
 scala> def first(x: Int, y: Int) = x
 first: (Int,Int)Int
 \end{lstlisting}
+%----------
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
+%----------
 \begin{lstlisting}
 $\,\,\,$   first(1, loop)
 $\rightarrow$  first(1, loop)
 $\rightarrow$  first(1, loop)
 $\rightarrow$  ...
 \end{lstlisting}
+%----------
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
 
@@ -851,8 +868,11 @@ unnamed0: Int = 1
 scala> constOne(loop, 2)               // gives an infinite loop.
 ^C                                     // stops execution with Ctrl-C
 \end{lstlisting}
+%----------
 
-\section{Conditional Expressions}
+
+%----------
+%%\section{Conditional Expressions}
 
 %% Scala's \code{if-else} lets one choose between two alternatives.  Its
 %% syntax is like Java's \code{if-else}. But where Java's \code{if-else}
@@ -860,7 +880,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% same syntax to choose between two expressions. That's why Scala's
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
+%----------
 
+%----------
 %% \example\ 
 
 %% \begin{lstlisting}
@@ -872,7 +894,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \code{true} and
 %% \code{false}, comparison operators, boolean negation \code{!} and the
 %% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
+%----------
 
+%----------
 %% \section{\label{sec:sqrt}Example: Square Roots by Newton's Method}
 
 %% We now illustrate the language elements introduced so far in the
@@ -882,7 +906,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% def sqrt(x: Double): Double = ...
 %% \end{lstlisting}
 %% which computes the square root of \code{x}.
+%----------
 
+%----------
 %% A common way to compute square roots is by Newton's method of
 %% successive approximations. One starts with an initial guess \code{y}
 %% (say: \code{y = 1}). One then repeatedly improves the current guess
@@ -898,6 +924,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 
 %% $y$            $x/y$                   $(y + x/y)/2$
 %% \end{lstlisting}
+%----------
+
+%----------
 %% One can implement this algorithm in Scala by a set of small functions,
 %% which each represent one of the elements of the algorithm.  
 
@@ -910,7 +939,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% Note that \code{sqrtIter} calls itself recursively.  Loops in
 %% imperative programs can always be modeled by recursion in functional
 %% programs. 
+%----------
 
+%----------
 %% Note also that the definition of \code{sqrtIter} contains a return
 %% type, which follows the parameter section. Such return types are
 %% mandatory for recursive functions. For a non-recursive function, the
@@ -918,14 +949,18 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% compute it from the type of the function's right-hand side. However,
 %% even for non-recursive functions it is often a good idea to include a
 %% return type for better documentation.
+%----------
 
+%----------
 %% As a second step, we define the two functions called by
 %% \code{sqrtIter}: a function to \code{improve} the guess and a
 %% termination test \code{isGoodEnough}. Here is their definition.
 %% \begin{lstlisting}
 %% def improve(guess: Double, x: Double) =
 %%   (guess + x / guess) / 2
+%----------
 
+%----------
 %% def isGoodEnough(guess: Double, x: Double) =
 %%   abs(square(guess) - x) < 0.001
 %% \end{lstlisting}
@@ -935,7 +970,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \begin{lstlisting}
 %% def sqrt(x: Double) = sqrtIter(1.0, x)
 %% \end{lstlisting}
+%----------
 
+%----------
 %% \begin{exercise} The \code{isGoodEnough} test is not very precise for small
 %% numbers and might lead to non-termination for very large ones (why?).
 %% Design a different version of \code{isGoodEnough} which does not have
@@ -944,7 +981,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 
 %% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
 %% \end{exercise}
+%----------
 
+%----------
 %% \section{Nested Functions}
 
 %% The functional programming style encourages the construction of many
@@ -953,7 +992,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \code{improve} and \code{isGoodEnough}. The names of these functions
 %% are relevant only for the implementation of \code{sqrt}. We normally
 %% do not want users of \code{sqrt} to access these functions directly.
+%----------
 
+%----------
 %% We can enforce this (and avoid name-space pollution) by including
 %% the helper functions within the calling function itself:
 %% \begin{lstlisting}
@@ -968,17 +1009,25 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %%   sqrtIter(1.0, x)
 %% }
 %% \end{lstlisting}
+%----------
+
+%----------
 %% In this program, the braces \code{\{ ... \}} enclose a {\em block}.
 %% Blocks in Scala are themselves expressions.  Every block ends in a
 %% result expression which defines its value.  The result expression may
 %% be preceded by auxiliary definitions, which are visible only in the
 %% block itself.
+%----------
 
+%----------
 %% Every definition in a block must be followed by a semicolon, 
 %% which separates this definition from subsequent definitions or the result
 %% expression. However, a semicolon is inserted implicitly at the end of
 %% each line, unless one of the following conditions is
 %% true.
+%----------
+
+%----------
 %% \begin{enumerate}
 %% \item
 %% Either the line in question ends in a word such as a period 
@@ -989,6 +1038,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
 %% because these cannot contain multiple statements anyway.
 %% \end{enumerate}
+%----------
+
+%----------
 %% Therefore, the following are all legal:
 %% \begin{lstlisting}
 %% def f(x: Int) = x + 1;
@@ -1010,6 +1062,9 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% )
 %% h2(1) / h2(2)
 %% \end{lstlisting}
+%----------
+
+%----------
 %% Scala uses the usual block-structured scoping rules. A name defined in
 %% some outer block is visible also in some inner block, provided it is
 %% not redefined there. This rule permits us to simplify our
@@ -1028,6 +1083,8 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %%   sqrtIter(1.0)
 %% }
 %% \end{lstlisting}
+%----------
+
 
 %% \section{Tail Recursion}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -526,7 +526,7 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 \code{Actor}.    
 %----------
 
-%----------xpto
+%----------
 %% \item
 %% Reply messages are sent using syntax of the form
 %% \code{destination ! SomeMessage}. \code{!} is used here as a
@@ -537,10 +537,14 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 %% parameter.
 %% \end{itemize}
 \item
-Mensagens de resposta são enviadas usando sintaxe da forma
+Mensagens de resposta são enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
+\code{!} é usado aqui como um operador binário com um actor e uma mensagem como argumentos.
+Isto é equivalente em Scala ao chamado de método \code{destino.!(AlgumaMensagem)}, ou seja, 
+a invocação do método \code{!} do actor destino com a mensagem dada como parâmetro.
+\end{itemize}    
 %----------
 
-%----------
+%----------xpto
 %% The preceding discussion gave a flavor of distributed programming in
 %% Scala. It might seem that Scala has a rich set of language constructs
 %% that support actor processes, message sending and receiving,
@@ -550,6 +554,7 @@ Mensagens de resposta são enviadas usando sintaxe da forma
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
+A discussão precedente 
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1073,7 +1073,7 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 \end{exercise}
 %----------
 
-%----------xpto
+%----------
 %% \section{Nested Functions}
 
 %% The functional programming style encourages the construction of many
@@ -1082,23 +1082,33 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 %% \code{improve} and \code{isGoodEnough}. The names of these functions
 %% are relevant only for the implementation of \code{sqrt}. We normally
 %% do not want users of \code{sqrt} to access these functions directly.
+\section{Aninhamento de Funções}
+
+A programação funcional encoraja a construção de muitas pequenas funções
+auxiliares. Nos últimos exemplos, a implementação de \code{sqrt} faz uso da
+funções auxiliares \code{sqrtIter}, \code{improve} e \code{isGoodEnough}.
+Os nomes destas funções são relevantes somente para a implementação de 
+\code{sqrt}. Normalmente não queremos que os usuários de \code{sqrt} acessem
+estas funções diretamente.  
 %----------
 
 %----------
 %% We can enforce this (and avoid name-space pollution) by including
 %% the helper functions within the calling function itself:
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = {
-%%   def sqrtIter(guess: Double, x: Double): Double =
-%%     if (isGoodEnough(guess, x)) guess
-%%     else sqrtIter(improve(guess, x), x)
-%%   def improve(guess: Double, x: Double) =
-%%     (guess + x / guess) / 2
-%%   def isGoodEnough(guess: Double, x: Double) =
-%%     abs(square(guess) - x) < 0.001
-%%   sqrtIter(1.0, x)
-%% }
-%% \end{lstlisting}
+Nós podemos reforçar isto (e evitar poluição de nomes) incluindo
+funções auxiliares dentro das próprias funções: 
+\begin{lstlisting}
+def sqrt(x: Double) = {
+  def sqrtIter(guess: Double, x: Double): Double =
+    if (isGoodEnough(guess, x)) guess
+    else sqrtIter(improve(guess, x), x)
+  def improve(guess: Double, x: Double) =
+    (guess + x / guess) / 2
+  def isGoodEnough(guess: Double, x: Double) =
+    abs(square(guess) - x) < 0.001
+  sqrtIter(1.0, x)
+}
+\end{lstlisting}
 %----------
 
 %----------
@@ -1107,6 +1117,11 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 %% result expression which defines its value.  The result expression may
 %% be preceded by auxiliary definitions, which are visible only in the
 %% block itself.
+Neste programa, as chaves \code{\{ ... \}} envolvem um {\em bloco}. 
+Blocos em Scala são eles mesmos expressões. Cada bloco termina com um
+expressão resultado o qual define seu valor. A expressão  resultado pode 
+ser precedida por definições auxiliares, as quais são visíveis somente no
+próprio bloco. 
 %----------
 
 %----------
@@ -1115,9 +1130,13 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 %% expression. However, a semicolon is inserted implicitly at the end of
 %% each line, unless one of the following conditions is
 %% true.
+Cada definição no bloco pode ser seguida para um ponto e vírgula, o qual 
+separa esta definição das definições subsequentes ou a expressão  resultado.
+Entretanto, um ponto e vírgula é inserido implicitamente ao final de cada linha,
+a não ser que uma das condições a seguir seja verdadeira.
 %----------
 
-%----------
+%----------xpto
 %% \begin{enumerate}
 %% \item
 %% Either the line in question ends in a word such as a period 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5254,56 +5254,50 @@ um for-comprehension.
 xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
 \end{lstlisting}
 
-%---------------xpto
+\section{Tradução de For-Comprehensions}
 
-\section{Translation of For-Comprehensions}
-
-Every for-comprehension can be expressed in terms of the three
-higher-order functions \code{map}, \code{flatMap} and \code{filter}.
-Here is the translation scheme, which is also used by the Scala compiler.
+Cada for-comprehension pode ser expresso em termos de três funções de alta-ordem: \code{map}, 
+\code{flatMap} e \code{filter}. Aqui está o esquema de tradução, que também é usado pelo compilador Scala.
 \begin{itemize}
 \item
-A simple for-comprehension
+Um for-comprehension simples
 \begin{lstlisting}
 for (x <- e) yield e'
 \end{lstlisting}
-is translated to
+é traduzido para
 \begin{lstlisting}
 e.map(x => e')
 \end{lstlisting}
 \item
-A for-comprehension
+Um for-comprehension 
 \begin{lstlisting}
 for (x <- e if f; s) yield e'
 \end{lstlisting}
-where \code{f} is a filter and \code{s} is a (possibly empty)
-sequence of generators or filters
-is translated to
+onde \code{f} é um filtro e \code{s} é uma (possivelmente vazia) sequência de geradores ou filtros, 
+é traduzida para 
 \begin{lstlisting}
 for (x <- e.filter(x => f); s) yield e'
 \end{lstlisting}
-and then translation continues with the latter expression.
+e então, a tradução continua com a última expressão.
 \item
-A for-comprehension
+Um for-comprehension 
 \begin{lstlisting}
 for (x <- e; y <- e'; s) yield e''
 \end{lstlisting}
-where \code{s} is a (possibly empty)
-sequence of generators or filters
-is translated to
+onde \code{s} é uma (possivelmente vazia) sequência de geradores ou filtros é traduzida para 
 \begin{lstlisting}
 e.flatMap(x => for (y <- e'; s) yield e'')
 \end{lstlisting}
-and then translation continues with the latter expression.
+e então, a tradução continua com a última expressão.
 \end{itemize}
-For instance, taking our "pairs of integers whose sum is prime" example:
+Por exemplo, tomando nosso exemplo  ``pares de inteiros cuja soma é um primo'':
 \begin{lstlisting}
 for { i <- range(1, n)
       j <- range(1, i)
       if isPrime(i+j)
 } yield {i, j}
 \end{lstlisting}
-Here is what we get when we translate this expression:
+Aqui está o que obtemos quando traduzimos esta expressão:
 \begin{lstlisting}
 range(1, n)
   .flatMap(i =>
@@ -5311,7 +5305,7 @@ range(1, n)
       .filter(j => isPrime(i+j))
       .map(j => (i, j)))
 \end{lstlisting}
-
+%---------------xpto
 Conversely, it would also be possible to express functions \code{map},
 \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
 three functions again, this time implemented using for-comprehensions.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4516,13 +4516,9 @@ def column[A](xs: List[List[A]], index: Int): List[A] =
   xs map (row => row(index))
 \end{lstlisting}
 
-
-%-------------xpto
-
-Closely related to \code{map} is the \code{foreach} method, which
-applies a given function to all elements of a list, but does not
-construct a list of results. The function is thus applied only for its
-side effect. \code{foreach} is defined as follows.
+Um método similar a \code{map} é o método \code{foreach} que aplica uma dada função a todos 
+os elementos de uma lista, mas não constrói uma lista de resultados. A função é assim aplicada
+somente por seu efeito colateral. \code{foreach} é definido como segue. 
 \begin{lstlisting}
   def foreach(f: A => Unit) {
     this match {
@@ -4531,14 +4527,14 @@ side effect. \code{foreach} is defined as follows.
     }
   }
 \end{lstlisting}
-This function can be used for printing all elements of a list, for instance:
+Esta função pode ser usada para imprimir todos os elementos de uma lista, por exemplo:
 \begin{lstlisting}
   xs foreach (x => println(x))
 \end{lstlisting} 
 
-\begin{exercise} Consider a function which squares all elements of a list and
-returns a list with the results. Complete the following two equivalent
-definitions of \code{squareList}.
+\begin{exercise} 
+Considere uma função que eleva ao quadrado todos os elementos de uma lista e retorna
+uma lista com os resultados. Complete as duas definições a seguir de \code{squareList}.
 
 \begin{lstlisting}
 def squareList(xs: List[Int]): List[Int] = xs match {
@@ -4550,55 +4546,55 @@ def squareList(xs: List[Int]): List[Int] =
 \end{lstlisting}
 \end{exercise}
 
-\paragraph{Filtering Lists}
-Another common operation selects from a list all elements fulfilling a
-given criterion. For instance, to return a list of all positive
-elements in some given lists of integers:
+\paragraph{Filtrando Listas}
+
+Outra operação comum seleciona de uma lista todos os elemento que satisfazem um dado 
+critério. Por exemplo, para retornar uma lista de todos os elementos positivos de 
+algumas listas dadas de inteiros:
 \begin{lstlisting}
 def posElems(xs: List[Int]): List[Int] = xs match {
   case Nil => xs
   case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
 }
 \end{lstlisting}
-This pattern is generalized to the \code{filter} method of class \code{List}:
+Este padrão é generalizado para o método \code{filter} da classe \code{List}:
 \begin{lstlisting}
   def filter(p: A => Boolean): List[A] = this match {
     case Nil => this
     case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
   }
 \end{lstlisting}
-Using \code{filter}, \code{posElems} can be more concisely written as
-follows.
+Usando \code{filter}, \code{posElems} pode ser mais concisamente escrito como segue.
 \begin{lstlisting}
 def posElems(xs: List[Int]): List[Int] =
   xs filter (x => x > 0)
 \end{lstlisting}
 
-An operation related to filtering is testing whether all elements of a
-list satisfy a certain condition. Dually, one might also be interested
-in the question whether there exists an element in a list that
-satisfies a certain condition. These operations are embodied in the
-higher-order functions \code{forall} and \code{exists} of class
-\code{List}.
+Uma operação relacionada a filtering é testar se todos os elementos de uma lista satisfazem
+uma dada condição. Dualmente, pode-se também estar interessado na questão se há um elemento 
+em uma lista que satisfaz uma dada condição. Estas operações são incorporadas nas funções 
+de alta ordem \code{forall} e \code{exists} da classe \code{List}.
 \begin{lstlisting}
 def forall(p: A => Boolean): Boolean =
   isEmpty || (p(head) && (tail forall p))
 def exists(p: A => Boolean): Boolean =
   !isEmpty && (p(head) || (tail exists p))
 \end{lstlisting}
-To illustrate the use of \code{forall}, consider the question of whether
-a number if prime. Remember that a number $n$ is prime of it can be
-divided without remainder only by one and itself. The most direct
-translation of this definition would test that $n$ divided by all
-numbers from 2 up to and excluding itself gives a non-zero
-remainder. This list of numbers can be generated using a function
-\code{List.range} which is defined in object \code{List} as follows.
+
+Para ilustrar o uso de \code{forall}, considere a questão se um número é primo. Lembre que um
+número $n$ é primo se puder ser dividido, sem resto, somente por um e por ele mesmo. A 
+tradução mais direta desta definição testará se $n$ dividido por todos os números de $2$ até, mas 
+excluindo, ele mesmo dá resto diferente de zero. Esta lista de números pode ser gerada usando uma 
+função \code{List.range} que é definida no objeto \code{List} como segue. 
 \begin{lstlisting}
 package scala
 object List { ...
   def range(from: Int, end: Int): List[Int] =
     if (from >= end) Nil else from :: range(from + 1, end)
 \end{lstlisting}
+
+%------------xpto
+
 For example, \code{List.range(2, n)}
 generates the list of all integers from 2 up to and excluding $n$.
 The function \code{isPrime} can now simply be defined as follows.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3260,8 +3260,9 @@ do construtor. Em nosso exemplo, \code{Number} obteria um mÅÈtodo de acesso
  \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
+que retorna o parÅ‚metro \code{n} do construtor, onde \code{Sum} obterÅ· dois mÅÈtodos de acesso
  \begin{lstlisting}
  def e1: Expr, e2: Expr
  \end{lstlisting}
@@ -3277,6 +3278,17 @@ do construtor. Em nosso exemplo, \code{Number} obteria um mÅÈtodo de acesso
 %% Case classes allow the constructions of {\em patterns} which refer to
 %% the case class constructor.
  \end{enumerate}
+Consequentemente, para um valor \code{s} de tipo \code{Sum}, digamos, 
+podemos escrever \code{s.e1} para acessar o operando esquerdo. Entretanto, 
+para um valor \code{e} de tipo \code{Expr}, o termo \code{e.e1} serÅ· ilegal,
+pois \code{e1} ÅÈ definido em \code{Sum}; nÅ„o ÅÈ um membro da classe base
+\code{Expr}.
+EntÅ„o, como determinar o construtor e os argumentos do construtor de acesso
+para valores cujo tipo estÅ·tico ÅÈ a classe base \code{Expr}? Isso ÅÈ resolvido
+pela quarta e Å˙ltima particularidade das classes case.
+\item
+Classes case permitem construÅÁÅıes de {\em padrÅıes} que se referem ao construtor 
+da classe case.
 %----------
 
 %----------
@@ -3289,6 +3301,15 @@ do construtor. Em nosso exemplo, \code{Number} obteria um mÅÈtodo de acesso
 %% The \code{match} method takes as argument a number of cases. 
 %% For instance, here is an implementation of \code{eval} using 
 %% pattern matching.
+
+\section{Casamento de PadrÅıes}
+O casamento de padrÅıes ÅÈ uma generalizaÅÁÅ„o do comando \code{switch} do C ou
+Java para hierarquias de classes. Ao invÅÈs de um comando \code{switch}, hÅ· um 
+mÅÈtodo padrÅ„o \code{match}, que ÅÈ definido na classe raÅÌz Scala \code{Any}, e 
+portanto estÅ· disponÅÌvel para todos os objetos. O mÅÈtodo \code{match} recebe como 
+argumento um nÅ˙mero de cases. Por exemplo, aqui estÅ· uma implementaÅÁÅ„o de \code{eval}
+usando casamento de padrÅıes.
+
 \begin{lstlisting}
 def eval(e: Expr): Int = e match {
   case Number(n) => n 
@@ -3297,7 +3318,7 @@ def eval(e: Expr): Int = e match {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -3308,6 +3329,7 @@ def eval(e: Expr): Int = e match {
 %% \code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
 %% \code{l} and \code{r} 
 %% to \code{v}$_1$ and \code{v}$_2$, respectively. 
+Neste exemplo, hÅ· dois cases. Cada case associa um padrÅ„o a uma expressÅ„o. 
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7306,22 +7306,22 @@ componente uma lista de tipos que contem seus parâmetros. Esta lista é
 vaiz para tipos constantes como \code{Boolean}. Assim como nos construtores
 de termos, implementamos o método \code{toString} para mostrar os tipos de forma legível.
 
-Note that \code{Type} is a \code{sealed} class. This means that no
-subclasses or data constructors that extend \code{Type} can be formed
-outside the sequence of definitions in which \code{Type} is defined.
-This makes \code{Type} a {\em closed} algebraic data type with exactly
-three alternatives. By contrast, type \code{Term} is an {\em open}
-algebraic type for which further alternatives can be defined.
+Note que \code{Type} foi declarada com o modificador \code{sealed}. Isto significa que
+nenhuma sub-classe ou construtores de dados que extendam \code{Type} podem ser declarados fora
+da sequência de definições em que \code{Type} foi definida.
+Isto torna \code{Type} um tipo algébrico {\em fechado}  com exatas três alternativas. 
+Em contraste, o tipo \code{Term} is um tipo algébrico {\em aberto} onde mais alternativas
+poderâo ser definidas.
 
-The main parts of the type inferencer are contained in object
-\code{typeInfer}. We start with a utility function which creates
-fresh type variables:
+As principais partes da inferência de tipos estão contidas no objeto
+\code{typeInfer}. Começamos com uma função utilitária que cria novos tipos variáveis:
 \begin{lstlisting}
 object typeInfer {
   private var n: Int = 0
   def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
 \end{lstlisting}
-We next define a class for substitutions. A substitution is an
+Em seguinda, definimos uma classe para substituições.
+ A substitution is an
 idempotent function from type variables to types. It maps a finite
 number of type variables to some types, and leaves all other type
 variables unchanged. The meaning of a substitution is extended

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2979,7 +2979,7 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %%With these classification and access methods, writing an evaluator function is simple:
 Com esta classificação e métodos de acesso, escrever uma função avaliador é simples:
 \begin{lstlisting}
@@ -2997,6 +2997,15 @@ def eval(e: Expr): Int = {
 %% new abstract method \code{isProduct} in class \code{Expr} and
 %% implement that method in subclasses \code{Number}, \code{Sum}, and
 %% \code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
+Entretanto, definir todos esses métodos dentro das classes \code{Sum} e \code{Number}
+é um tanto quanto tedioso. Além do mais, o problema fica ainda pior se desejarmos 
+adicionar novas formas de expressões. Por exemplo, considere adicionar uma nova 
+forma de expressão \code{Prod} para produtos. Não apenas teremos de implementar uma nova classe 
+\code{Prod}, com todos os métodos de acesso e classificação prévios; também teremos de 
+introduzir um novo método abstrato \code{isProduct} dentro da classe \code{Expr} e 
+implementar aquele método na subclasse \code{Number}, \code{Sum}, e \code{Prod}.
+Ter de  modificar código existente quando um sistema cresce é sempre problemático, pois
+introduz problemas de versão e manutenção.  
 %----------
 
 %----------
@@ -3009,6 +3018,15 @@ def eval(e: Expr): Int = {
 %% outside the expression class hierarchy, as we have done
 %% before. Because \code{eval} is now a member of all expression nodes,
 %% all classification and access methods become superfluous, and the implementation is simplified considerably:
+A promessa da programação orientada a objetos é que tais modificações 
+são desnecessárias, dado que podem ser evitadas pela reutilização de código 
+existente e não modificado, através da herança. De fato, uma decomposição 
+mais orientada a objetos para nosso problema resolve a questão. A idéia é tornar
+a operação de alto nível \code{eval} um método para cada classe expressão, ao 
+invés de implementá-lo como uma função fora da hierarquia de classes expressões, como 
+fizemos anteriormente. Como \code{eval} é agora um membro de todos os nós de expressão, 
+quaisquer métodos de classificação e acesso tornam-se supérfluos, e a implementação 
+é simplificada consideravelmente:  
 \begin{lstlisting}
 abstract class Expr {
   def eval: Int
@@ -3019,11 +3037,12 @@ class Number(n: Int) extends Expr {
 class Sum(e1: Expr, e2: Expr) extends Expr {
   def eval: Int = e1.eval + e2.eval
 }
-\end{lstlisting
+\end{lstlisting}
 %----------
 
-%----------}
+%----------
 %%Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
+Além disso, adicionar uma nova classe \code{Prod} não leva a qualquer mudança ao código existente:
 \begin{lstlisting}
 class Prod(e1: Expr, e2: Expr) extends Expr {
   def eval: Int = e1.eval * e2.eval
@@ -3036,12 +3055,20 @@ class Prod(e1: Expr, e2: Expr) extends Expr {
 %% possible way we might want to extend the expression example. We might
 %% want to add new {\em operations} on expressions.  For instance, we might
 %% want to add an operation that pretty-prints an expression tree to standard output.
+A conclusão que tiramos deste exemplo é que a decomposição orientada a objetos
+é a técnica de escolha para a construção de sistemas que devem ser estensíveis
+com novos tipos de dados. Mas há também um outro possível modo para estender a 
+expressão exemplo. Podemos querer adicionar novas {\em operações} sobre expressões.
+Por exemplo, podemos querer adicionar uma operação que imprime uma árvore-expressão
+para a saída padrão.  
 %----------
 
 %----------
 %% If we have defined all classification and access methods, such an
 %% operation can easily be written as an external function. Here is an
 %% example:
+Se definimos todos os métodos de classificação e acesso, tal operação pode ser 
+facilmente escrita como uma função externa. Aqui está um exemplo: 
 \begin{lstlisting}
 def print(e: Expr) {
   if (e.isNumber) Console.print(e.numValue)
@@ -3057,6 +3084,9 @@ def print(e: Expr) {
 %% However, if we had opted for an object-oriented decomposition of
 %% expressions, we would need to add a new \code{print} procedure
 %% to each class:
+Entretanto, se optamos por uma decomposição orientada a objetos das 
+expressões, precisaremos adicionar um novo procedimento \code{print} 
+para cada classe: 
 \begin{lstlisting}
 abstract class Expr {
   def eval: Int
@@ -3079,7 +3109,7 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5628,12 +5628,13 @@ methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
 system is too weak to express this construct, since it can handle only
 type parameters which are fully applied types.
 
-\chapter{Mutable State}
+\chapter{Estdos Mutáveis}
 
-Most programs we have presented so far did not have side-effects
-\footnote{We ignore here the fact that some of our program printed to
-standard output, which technically is a side effect.}.  Therefore, the
-notion of {\em time} did not matter.  For a program that terminates,
+A maioria dos programs apresentados até o momento não possuem efeitos colaterais.
+\footnote{Ignoramos o fato de que algums dos programas imprimem na tela, o que, 
+tecnicamente, é um efeito colateral.}.  Portanto, a noção de {\em time} não
+importou.  
+For a program that terminates,
 any sequence of actions would have led to the same result!  This is
 also reflected by the substitution model of computation, where a
 rewrite step can be applied anywhere in a term, and all rewritings

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1606,20 +1606,25 @@ val sumPowersOfTwo  =  sum(powerOfTwo)
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
 %% applied like any other function. For instance,
+ \code{sumInts}, \code{sumSquares}, e \code{sumPowersOfTwo} podem ser
+aplicados como qualquer outra função. Por exemplo,
 \begin{lstlisting}
 scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
 unnamed0: Int = 2096513
 \end{lstlisting}
 %% How are function-returning functions applied? As an example, in the expression
+Como funções que retornam funções são aplicadas? Como exemplo, na expressão 
 \begin{lstlisting}
 sum(x => x * x)(1, 10) ,
 \end{lstlisting}
 %% the function \code{sum} is applied to the squaring function 
 %% \code{(x => x * x)}. The resulting function is then 
 %% applied to the second argument list, \code{(1, 10)}.
+a função \code{sum} é aplicada a função quadrada \code{(x => x * x)}. 
+O função resultante é então aplicada ao segunda lista de argumentos, \code{(1, 10)}.   
 %----------
 
 %----------
@@ -1631,37 +1636,53 @@ sum(x => x * x)(1, 10) ,
 %% In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
 %% following expression:
 %% \code{(sum(x => x * x))(1, 10)}.
+Essa notação é possível porque aplicações de funções são associativas à esquerda.
+Ou seja, se $\mbox{args}_1$ e $\mbox{args}_2$ são listas de argumentos, então 
+\bda{lcl}
+f(\mbox{args}_1)(\mbox{args}_2) & \ \ \mbox{é equivalente a}\ \ & (f(\mbox{args}_1))(\mbox{args}_2)
+\eda
+Em nosso exemplo, \code{sum(x => x * x)(1, 10)} é equivalente a seguinte expressão:
+\code{(sum(x => x * x))(1, 10)}.
 %----------
 
 %----------
 %% The style of function-returning functions is so useful that Scala has
 %% special syntax for it. For instance, the next definition of \code{sum}
 %% is equivalent to the previous one, but is shorter:
+O estilo ``funções que retornam funções'' é tão útil que Scala tem sintaxe
+especial para ele. Por exemplo, a próxima definição de \code{sum} é equivalente
+a anterior, porém mais curta: 
 \begin{lstlisting}
 def sum(f: Int => Int)(a: Int, b: Int): Int =
   if (a > b) 0 else f(a) + sum(f)(a + 1, b)
 \end{lstlisting}
 %% Generally, a curried function definition 
+Genericamente, uma definição de função currificada
 \begin{lstlisting}
 def f (args$_1$) ... (args$_n$) = E
 \end{lstlisting}
 %%where $n > 1$ expands to
+onde $n > 1$ expande para 
 \begin{lstlisting}
 def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
 \end{lstlisting}
 %%where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
+onde \code{g} é um novo identificador. Ou, menor, usando uma função anônima: 
 \begin{lstlisting}
 def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
 \end{lstlisting}
 %%Performing this step $n$ times yields that
+Realizando este passo $n$ vezes dá aquela 
 \begin{lstlisting}
 def f (args$_1$) ... (args$_n$) = E
 \end{lstlisting}
 %%is equivalent to
+é equivalente a 
 \begin{lstlisting}
 def f = (args$_1$) => ... => (args$_n$) => E .
 \end{lstlisting}
 %%Or, equivalently, using a value definition:
+Ou, equivalentemente, usando uma definição valor:
 \begin{lstlisting}
 val f = (args$_1$) => ... => (args$_n$) => E .
 \end{lstlisting}
@@ -1669,6 +1690,9 @@ val f = (args$_1$) => ... => (args$_n$) => E .
 %% currying} after its promoter, Haskell B.\ Curry, a logician of the
 %% 20th century, even though the idea goes back further to Moses
 %% Sch\"onfinkel and Gottlob Frege.
+Este estilo de definição de função e aplicação é chamado {\em currificado}
+depois que seu divulgador, Haskell B.\ Curry, um lógico do século $20$, mesmo 
+que a idéia nos leve de volta a Moses Sch\"onfinkel e Gottlob Frege.
 %----------
 
 %----------
@@ -1676,6 +1700,10 @@ val f = (args$_1$) => ... => (args$_n$) => E .
 %% its parameter list. Taking the last formulation of \code{sum} as an example,
 %% the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
 %% This is possible because function types associate to the right. I.e.
+O tipo de uma função que retorna função é expresso de modo análogo a sua lista
+de parâmetros. Tomando a última formulação de \code{sum} como exemplo, o tipo 
+para \code{sum} é \code{(Int => Int) => (Int, Int) => Int}.
+Isso é possível porque tipos de funções são associativos à direita. Ou seja, 
 \begin{lstlisting}
 T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
 \end{lstlisting}
@@ -1685,7 +1713,8 @@ T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T
 \begin{exercise}
 %% 1. The \code{sum} function uses a linear recursion. Can you write a
 %% tail-recursive one by filling in the ??'s?
-
+1. A função \code{sum} usa uma recursiva linear. Você poderia alterá-la
+para uma função recursiva de cauda, preenchendo as ?? abaixo?  
 \begin{lstlisting}
 def sum(f: Int => Int)(a: Int, b: Int): Int = {
   def iter(a: Int, result: Int): Int = {
@@ -1702,15 +1731,19 @@ def sum(f: Int => Int)(a: Int, b: Int): Int = {
 \begin{exercise}
 %% Write a function \code{product} that computes the product of the
 %% values of functions at points over a given range.
+Escreva uma função \code{produto} que computa o produto de valores de
+funções em pontos sobre um dado intervalo.  
 \end{exercise}
 
 \begin{exercise}
 %% Write \code{factorial} in terms of \code{product}.
+Escreva \code{fatorial} em termos de \code{produto}.  
 \end{exercise}
 
 \begin{exercise}
 %% Can you write an even more general function which generalizes both
 %% \code{sum} and \code{product}?
+Escreva uma função ainda mais genérica que generaliza ambos \code{sum} e \code{produto}.  
 \end{exercise}
 %----------
 
@@ -1718,6 +1751,9 @@ def sum(f: Int => Int)(a: Int, b: Int): Int = {
 %% \section{Example: Finding Fixed Points of Functions}
 
 %% A number \code{x} is called a {\em fixed point} of a function \code{f} if
+\section{Exemplo: Encontrando Pontos Fixos de Funções}
+
+Um número \code{x} é chamado um {\em ponto fixo} de uma função \code{f} se  
 \begin{lstlisting}
 f(x) = x .
 \end{lstlisting}
@@ -1725,11 +1761,16 @@ f(x) = x .
 %% with an initial guess and then applying \code{f} repeatedly, until the
 %% value does not change anymore (or the change is within a small
 %% tolerance). This is possible if the sequence
+Para algumas funções \code{f} podemos encontrar os pontos fixos iniciando
+com um palpite inicial e então aplicando \code{f} repetidamente, até que o valor 
+não mude mais (ou a mudança seja tolerável). Isso é possível na sequência  
 \begin{lstlisting}
 x, f(x), f(f(x)), f(f(f(x))), ...
 \end{lstlisting}
 %%converges to fixed point of $f$. This idea is captured in
 %%the following ``fixed-point finding function'':
+converge para pontos fixos de $f$. Essa idéia é captada na ``função achadora 
+de pontos fixos'' a seguir:
 \begin{lstlisting}
 val tolerance = 0.0001
 def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
@@ -1744,7 +1785,7 @@ def fixedPoint(f: Double => Double)(firstGuess: Double) = {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% We now apply this idea in a reformulation of the square root function.
 %% Let's start with a specification of \code{sqrt}:
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6657,29 +6657,25 @@ Embora tudo isso funcione, o código não fica muito limpo. O problema
 Nós gostaríamos que o sistema conseguisse descobrir os argumentos de forma correta e automática, semelhante
 ao que é feito quando o tipo de parâmetros é inferido. Isto é o que os parâmetros implícitos permite.
 
-\subsection*{Implicit Parameters: The Basics}
+\subsection*{Noções Básicas sobre Parâmetros Implícitos}
 
-In Scala 2 there is a new \lstinline@implicit@ keyword that can be
-used at the beginning of a parameter list. Syntax:
+Na versão 2 de Scala, há uma nova palavra-chave (\lstinline@implicit@) que pode ser usada no início de uma lista de parâmetros. Sintaxe:
 \begin{lstlisting}
 ParamClauses ::= {`(' [Param {`,' Param}] ')'} 
                  [`(' implicit Param {`,' Param} `)']
 \end{lstlisting}
-If the keyword is present, it makes all parameters in the list
-implicit.  
-For instance, the following version of \lstinline@sum@ has
-\lstinline@m@ as an implicit parameter.
+Se esta palavra chave estiver presente, todos os parâmetros da lista serão implícitos.
+Por exemplo, a versão de \lstinline@sum@ a seguir tem 
+\lstinline@m@ como um parâmetro implícito.
 \begin{lstlisting}
 def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
   if (xs.isEmpty) m.unit
   else m.add(xs.head, sum(xs.tail))
 \end{lstlisting}
-As can be seen from the example, it is possible to combine normal and
-implicit parameters. However, there may only be one implicit parameter
-list for a method or constructor, and it must come last.
+Como pode ser visto no exemplo, é possível combinar parâmetros normais e implícitos. No entanto,
+pode haver apenas uma lista de parâmetros implícitos e ela deve vir por último.
 
-\lstinline@implicit@ can also be used as a modifier for definitions
-and declarations. Examples:
+\lstinline@implicit@ também pode ser usado como um modificador de declarações e definições. Exemplos:
 
 \begin{lstlisting}
 implicit object stringMonoid extends Monoid[String] {
@@ -6692,30 +6688,27 @@ implicit object intMonoid extends Monoid[Int] {
 }
 \end{lstlisting}
 
-The principal idea behind implicit parameters is that arguments for
-them can be left out from a method call. If the arguments
-corresponding to an implicit parameter section are missing, they are
-inferred by the Scala compiler.
+A principal ideia por trás de parâmetros implícitos é que argumentos para eles
+podem ser omitidos em uma chamada de método. Se os argumentos estiverem ausentes,
+eles serão inferidos pelo compilador de Scala.
 
-The actual arguments that are eligible to be passed to an implicit
-parameter are all identifiers X that can be accessed at the point
-of the method call without a prefix and that denote an implicit
-definition or parameter.
+Os argumento atuais que são elegíveis a serem passados implicitamente por parâmetro são
+todos os identificadores X que puderem ser acessado no ponto em que o método é chamado sem
+o uso de prefixo e que denotem uma definição implícita ou parâmetro.
 
-If there are several eligible arguments which match the implicit
-parameter's type, the Scala compiler will chose a most specific one,
-using the standard rules of static overloading resolution.
-For instance, assume the call
+Se existem mais do que um argumento elegíveis que casam com o tipo do parâmetro, o compilador Scala vai
+escolher o mais específico usando as regras padrâo para resolução de sobrecarga.
+Por exemplo, dada a chamada
 \begin{lstlisting}
   sum(List(1, 2, 3))
 \end{lstlisting}
-in a context where \lstinline@stringMonoid@ and \lstinline@intMonoid@
-are visible.  We know that the formal type parameter \lstinline@a@ of
-\lstinline@sum@ needs to be instantiated to \lstinline@int@. The only
-eligible value which matches the implicit formal parameter type
-\lstinline@Monoid[Int]@ is \lstinline@intMonoid@ so this object will %
-be passed as implicit parameter.
+está em um contexto onde \lstinline@stringMonoid@ e \lstinline@intMonoid@
+estão visíveis. Nós sabemos que o tipo genérico \lstinline@A@ do método
+\lstinline@sum@ precisa ser instanciado usando \lstinline@int@. O único valor elegível que casa com
+o parâmetro implícito \lstinline@Monoid[Int]@ é o \lstinline@intMonoid@ e por isso este objeto será passado
+como parâmetro implícito.
 
+A discussão mostra também que 
 This discussion also shows that implicit parameters are inferred after
 any type arguments are inferred. 
 
@@ -8395,6 +8388,9 @@ abstract class Actor extends Thread with MailBox {
   def !(msg: Any) = send(msg)
 }
 \end{lstlisting}
+
+%% A parte a ser traduzida termina aqui!!!
+
 
 \comment{
 As an extended example of an application that uses actors, we come

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3338,7 +3338,7 @@ os valores do seletor da forma \code{Sum(v}$_1$\code{, v}$_2$\code{)} e liga as
 variáveis padrão \code{l} e \code{r} a \code{v}$_1$ e \code{v}$_2$, respectivamente. 
 %----------
 
-%----------xpto
+%----------
 %% In general, patterns are built from
 %% \begin{itemize}
 %% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
@@ -3363,7 +3363,11 @@ argumentos são, novamente, padrões,
 \item literais, tal como \code{1}, \code{true},  "abc", 
 \item identificadores constantes, tais como \code{MAXINT}, \code{EmptySet}.  
 \end{itemize}
-
+Variáveis padrão sempre iniciam com uma letra minúscula, para que possamos
+distinguí-las de identificadores constantes, que iniciam com uma letra 
+maiúscula. Cada nome de variável pode ocorrer somente uma vez em um padrão. 
+Por exemplo, \code{Sum(x, x)} seria ilegal como padrão, pois a variável padrão 
+\code{x} ocorre duas vezes dentro dele.  
 
 %----------
 
@@ -3375,9 +3379,16 @@ e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
 \end{lstlisting}
 %% matches the patterns $p_1 \commadots p_n$ in the order they
 %% are written against the selector value \code{e}.
+\paragraph{Significado do Casamento de Padrões}
+Uma expressão de casamento de padrões
+\begin{lstlisting}
+e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
+\end{lstlisting}
+casa os padrões $p_1 \commadots p_n$ na ordem em que eles são 
+escritos contra o valor seletor \code{e}.
 %----------
 
-%----------
+%----------xpto
 %% \begin{itemize}
 %% \item
 %% A constructor pattern $C(p_1 \commadots p_n)$ matches all values that

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7252,12 +7252,12 @@ Which classes need to be modified?
 
 \chapter{\label{sec:hm}Inferência de Tipos de Hindley/Milner}
 
-This chapter demonstrates Scala's data types and pattern matching by
-developing a type inference system in the Hindley/Milner style
-\cite{milner:polymorphism}. The source language for the type inferencer is
-lambda calculus with a let construct called Mini-ML. Abstract syntax
-trees for the Mini-ML are represented by the following data type of
-\code{Terms}.
+Este capítulo demonstra os tipos de dados Scala e o casamento de padrôes através
+do desenvolvimento de um sistema de inferência de tipos no estilo de Hindley/Milner
+\cite{milner:polymorphism}. 
+A linguagem fonte para a inferência de tipos é o cálculo lambda com uma construção
+chamada Mini-ML. As árvoes de sintaxe abstrata para o Mini-ML 
+são representadas através do tipo de dados \code{Terms}.
 \begin{lstlisting}
 abstract class Term {}
 case class Var(x: String) extends Term {
@@ -7273,14 +7273,13 @@ case class Let(x: String, e: Term, f: Term) extends Term {
   override def toString = "let " + x + " = " + e + " in " + f
 }
 \end{lstlisting}
-There are four tree constructors: \code{Var} for variables, \code{Lam}
-for function abstractions, \code{App} for function applications, and
-\code{Let} for let expressions. Each case class overrides the
-\code{toString} method of class \code{Any}, so that terms can be
-printed in legible form.
+Há quatro construtores de termos: \code{Var} para variáveis, \code{Lam}
+para abstrações lambda, \code{App} para aplicação e
+\code{Let} para expressões de atribuição. Cada uma destas classes sobrescreve o método
+\code{toString} da classe \code{Any}, de forma que os termos podem ser impressos
+de forma legível.
 
-We next define the types that are
-computed by the inference system.
+A seguir, definimos os tipos que serão computados pelo sistema de inferência.
 \begin{lstlisting}
 sealed abstract class Type {}
 case class Tyvar(a: String) extends Type {
@@ -7294,12 +7293,12 @@ case class Tycon(k: String, ts: List[Type]) extends Type {
     k + (if (ts.isEmpty) "" else ts.mkString("[", ",", "]"))
 }
 \end{lstlisting}
-There are three type constructors: \code{Tyvar} for type variables,
-\code{Arrow} for function types and \code{Tycon} for type constructors
-such as \code{Boolean} or \code{List}. Type constructors have as
-component a list of their type parameters. This list is empty for type
-constants such as \code{Boolean}. Again, the type constructors
-implement the \code{toString} method in order to display types legibly.
+Há três construtores de tipos: \code{Tyvar} para o tipo variável,
+\code{Arrow}  para o tipo função e  \code{Tycon}  para o tipo construtor como,
+por exemplo, \code{Boolean} ou \code{List}. O tipo construtor tem como
+componente uma lista de tipos que contem seus parâmetros. Esta lista é
+vaiz para tipos constantes como \code{Boolean}. Assim como nos construtores
+de termos, implementamos o método \code{toString} para mostrar os tipos de forma legível.
 
 Note that \code{Type} is a \code{sealed} class. This means that no
 subclasses or data constructors that extend \code{Type} can be formed

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3388,12 +3388,17 @@ casa os padr\~{o}es $p_1 \commadots p_n$ na ordem em que eles s\~{a}o
 escritos contra o valor seletor \code{e}.
 %----------
 
-%----------xpto
+%----------xpto novo aqui
 \begin{itemize}
 \item
-A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
-are of type \code{C} (or a subtype thereof) and that have been constructed with 
-\code{C}-arguments matching patterns $p_1 \commadots p_n$.
+%%A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
+%%are of type \code{C} (or a subtype thereof) and that have been constructed with 
+%%\code{C}-arguments matching patterns $p_1 \commadots p_n$.
+Um construtor padrão $C(p_1 \commadots p_n)$ casa com todos os valores que são 
+do tipo \code{C} (ou um subtipo dele) e que foram construídos com argumentos \code{C}
+casando com padrões $p_1 \commadots p_n$.
+%-----------
+
 \item 
 A variable pattern \code{x} matches any value and binds the variable
 name to that value.  

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4191,8 +4191,6 @@ Todas as operações sobre listas podem ser expressas em termos das três a segu
 Estas operações são definidas como métodos de objetos listas. Portanto as invocamos 
 escolhendo da lista aqueles que sofrerão a operação. Exemplos: 
 
-%----------xpto
-
 \begin{lstlisting}
 empty.isEmpty   = true
 fruit.isEmpty   = false
@@ -4200,32 +4198,29 @@ fruit.head      = "apples"
 fruit.tail.head = "oranges"
 diag3.head      = List(1, 0, 0)
 \end{lstlisting}
-The \code{head} and \code{tail} methods are defined only for non-empty
-lists.  When selected from an empty list, they throw an exception.
+Os métodos \code{head} e \code{tail} são definidos somente para listas não vazias.
+Quando selecionados para uma lista vazia, eles lançam uma exceção.
 
-As an example of how lists can be processed, consider sorting the
-elements of a list of numbers into ascending order. One simple way to
-do so is {\em insertion sort}, which works as follows: To sort a
-non-empty list with first element \code{x} and rest \code{xs}, sort
-the remainder \code{xs} and insert the element \code{x} at the right
-position in the result. Sorting an empty list will yield the
-empty list. Expressed as Scala code:
+Como um exemplo de como listas podem ser processadas, considere ordenar os elementos 
+de uma lista de números em ordem crescente. Um modo simples de fazer isso é usar o 
+{\em insertion sort}, que trabalha da seguinte maneira: Para ordenar uma lista não 
+vazia com primeiro elemento \code{x} e resto \code{xs}, ordene o restante \code{xs} e 
+insira o elemento \code{x} na posição correta do resultado. Ordenar uma lista vazia dará
+uma lista vazia. Em Scala temos o código:
 \begin{lstlisting}
 def isort(xs: List[Int]): List[Int] =
   if (xs.isEmpty) Nil
   else insert(xs.head, isort(xs.tail))
 \end{lstlisting}
-%----------
 
-\begin{exercise} Provide an implementation of the missing function
-\code{insert}.
+\begin{exercise} Escreva a função faltante \code{insert}.
 \end{exercise}
 
-\paragraph{List patterns} In fact, \code{::} is defined as a case
-class in Scala's standard library. Hence, it is possible to decompose
-lists by pattern matching, using patterns composed from the \code{Nil}
-and \code{::} constructors. For instance, \code{isort} can be written
-alternatively as follows.
+\paragraph{Listas e padrões} De fato, \code{::} é definido como uma 
+classe case na biblioteca padrão Scala. Consequentemente, é possível 
+decompor listas através de casamento de padrões, usando padrões compostos
+a partir dos construtores  \code{Nil} e \code{::}. Por exemplo, \code{isort}
+pode ser escrito aternativamente como segue.
 \begin{lstlisting}
 def isort(xs: List[Int]): List[Int] = xs match {
   case List() => List()
@@ -4239,7 +4234,9 @@ def insert(x: Int, xs: List[Int]): List[Int] = xs match {
   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
 }
 \end{lstlisting}
-%----------
+
+%----------xpto
+
 
 \section{Definition of class List I: First Order Methods}
 \label{sec:list-first-order}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3462,7 +3462,6 @@ abstract class Expr {
 }
 \end{lstlisting}
 
-%----------xpto
 \begin{exercise} Considere as seguintes definições representando árvores de inteiros. 
 Estas definições podem ser vistas como uma representação alternativa para \code{IntSet}: 
 
@@ -3509,11 +3508,12 @@ onde \code{x} é uma variável nova que não é usada a não ser dentro da expre
 
 \chapter{Tipos Genéricos e Métodos}
 
-Classes in Scala can have type parameters. We demonstrate the use of
-type parameters with functional stacks as an example. Say, we want to
-write a data type of stacks of integers, with methods \code{push},
-\code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
-following class hierarchy:
+Classes em Scala podem ter tipos como parâmetros. Demostraremos o uso 
+de tipos parâmetros com pilhas funcionais como exemplo. Digamos, desejamos
+escrever um tipo de dados para pilhas de inteiros, com métodos \code{push},
+\code{top}, \code{pop}, e \code{isEmpty}. Isso é conseguido pela seguinte 
+hierarquia de classes:
+
 \begin{lstlisting}
 abstract class IntStack {
   def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
@@ -3532,18 +3532,19 @@ class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
   def pop = rest
 }
 \end{lstlisting}
-Of course, it would also make sense to define an abstraction for a
-stack of Strings. To do that, one could take the existing abstraction
-for \code{IntStack}, rename it to \code{StringStack} and at the same
-time rename all occurrences of type \code{Int} to \code{String}.
 
-A better way, which does not entail code duplication, is to
-parameterize the stack definitions with the element type.
-Parameterization lets us generalize from a specific instance of a
-problem to a more general one. So far, we have used parameterization
-only for values, but it is available also for types. To arrive at a
-{\em generic} version of \code{Stack}, we equip it with a type
-parameter.
+De fato, faz sentido definir uma abstração para uma pilha de Strings. Para
+isso, pode-se tomar a abstração existente para \code{IntStack}, renomeá-la para 
+\code{StringStack} e ao mesmo tempo renomear todas as ocorrências do tipo
+\code{Int} para \code{String}.
+
+Um modo melhor, que não leva a duplicação de código, é parametrizar as
+definições da pilha com o tipo do elemento. Parametrizações nos levam
+a generalizar a partir de uma instância específica de um problema para 
+uma mais genérica. Até aqui, usamos parametrização somente para valores, mas 
+também está disponível para tipos. Para obtermos uma versão {\em genérica} de
+\code{Stack}, a equiparemos com um parâmetro tipo.
+
 \begin{lstlisting}
 abstract class Stack[A] {
   def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
@@ -3562,6 +3563,9 @@ class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
   def pop = rest
 }
 \end{lstlisting}
+
+%----------xpto
+
 In the definitions above, `\code{A}' is a {\em type parameter} of
 class \code{Stack} and its subclasses.  Type parameters are arbitrary
 names; they are enclosed in brackets instead of parentheses, so that

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6309,6 +6309,10 @@ constructing a stream with first element \code{x} and (unevaluated)
 rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
 \code{xs append ys}.  
 
+Ao inv\'{e}s de \code{x :: xs}, pode-se usar \code{Stream.cons(x, xs)} para
+construir um stream com o primeiro elemento \code{x} e o resto (nao computado)
+
+
 \chapter{Iteradores}
 
 Iteradores s\~{a}o uma vers\~{a}o imperativa dos streams. Assim como streams,

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4448,13 +4448,6 @@ def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
 
 %-------------xpto 
 
-The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
-length of the input list. To see why, note that splitting a list in
-two and merging two sorted lists each take time proportional to the
-length of the argument list(s). Each recursive call of \code{msort}
-halves the number of elements in its input, so there are $O(log(N))$
-consecutive recursive calls until the base case of lists of length 1
-is reached.  However, for longer lists each call spawns off two
 further calls. Adding everything up we obtain that at each of the
 $O(log(N))$ call levels, every element of the original lists takes
 part in one split operation and in one merge operation. Hence, every
@@ -4464,6 +4457,15 @@ $O(N;log(N))$. That cost does not depend on the initial distribution
 of elements in the list, so the worst case cost is the same as the
 average case cost. This makes merge sort an attractive algorithm for
 sorting lists.
+
+A complexidade do \code{msort} é $O(N;log(N))$, onde $N$ é o tamanho da lista de entrada.
+Para ver porque, observe que dividir uma lista em duas e intercalar as duas listas 
+ordenadas leva tempo proporcional ao tamanho das listas argumentos. Cada chamada recursiva 
+de \code{msort} reduz a metade o número de elementos na sua entrada, logo há $O(log(N))$
+chamadas recursivas consecutivas, até que o caso base das listas de tamanho 1 seja 
+alcançado. Entretanto, para listas mais longas, cada chamada gera duas outras chamadas. 
+Somando tudo obtemos 
+
 
 Here is an example how \code{msort} is used.
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -458,7 +458,7 @@ estruturas de dados internas, tais como as definidas acima.
 %      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
 
-%----------xpto
+%----------
 %% Figure~\ref{fig:simple-auction} presents a Scala implementation of a
 %% class \code{Auction} for auction actors that coordinate the bidding
 %% on one item. Objects of this class are created by indicating
@@ -503,17 +503,23 @@ finalmente parar, permanece ativo para um outro período determinado pela consta
 Aqui estão algumas explicações extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
-O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um   
+O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um prazo dado
+em milisegundos e uma função que processa mensagens na caixa de correio. A função é dada
+por uma sequência de cases que especificam um padrão e uma ação para mensagens que 
+casam com o padrão. O método \code{receiveWithin} seleciona a primeira mensagem da 
+caixa de correio que casa com um destes padrões e aplica a ação correspondente a ele. 
 %----------
 
 
-%----------
+%----------xpto
 %% \item
 %% The last case of \code{receiveWithin} is guarded by a
 %% \code{TIMEOUT} pattern. If no other messages are received in the meantime, this
 %% pattern is triggered after the time span which is passed as argument
 %% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
 %% special message, which is triggered by the \code{Actor} implementation itself.
+\item
+O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -215,7 +215,7 @@ a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
 método ~\lstinline@xs.filter(pivot >)@.
 %----------
 
-alb
+
 
 %----------
 %% In the quicksort program, \code{filter} is applied three times to an
@@ -230,6 +230,16 @@ alb
 %% summarize, \code{xs.filter(pivot >)} returns a list consisting
 %% of all elements of the list \code{xs} that are smaller than
 %% \code{pivot}.
+No programa quicksort, \code{filter} é aplicado três vezes a um argumento 
+de função anônima. O primeiro argumento, \code{pivot >}, representa uma 
+função que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
+Este é um exemplo de uma {\em função parcialmente aplicada}. Um outro modo, 
+equivalente de se escrever esta função, que torna o argumento oculto explicito
+é ~\lstinline@x => pivot > x@. A função é anônima, ou seja, não é definida
+com um nome. O tipo do parâmetro  \code{x} é omitido porque um compilador Scala 
+pode inferí-lo automáticamente a partir do contexto onde a função é usada.
+Resumindo, \code{xs.filter(pivot >)} retorna uma lista consistindo de todos os 
+elementos da lista \code{xs} que são menores que \code{pivot}.  
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3744,23 +3744,22 @@ portanto valores destes tipos não podem ser usados como elementos de conjuntos.
 Um desenho mais flexível, que admite elementos destes tipos, usam {\em ligações de visão} 
 ao invés de ligações plenas a tipos como temos visto. A única mudança que isto
 no leva no exemplo abaixo está nos parâmetros tipo:
-%----------xpto
 
 \begin{lstlisting}
 trait Set[A <% Ordered[A]] ...
 class EmptySet[A <% Ordered[A]] ...
 class NonEmptySet[A <% Ordered[A]] ...
 \end{lstlisting}
-View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
-A view bounded type parameter clause \lstinline@[A <% T]@ only
-specifies that the bounded type \lstinline@A@ must be {\em convertible} to
-the bound type \lstinline@T@, using an implicit conversion.
+Ligações visão \lstinline@<%@ são mais fracas que ligações plenas \verb@<:@:
+Uma ligação visão da cláusula do tipo parâmetro \lstinline@[A <% T]@ somente 
+especifica que o tipo ligado \lstinline@A@ deve ser {\em convertido} ao tipo
+ligado \lstinline@T@, usando uma conversão implícita.
 
-The Scala library predefines implicit conversions for a number of
-types, including the primitive types and \lstinline@String@.
-Therefore, the redesign set abstraction can be instantiated with these
-types as well. More explanations on implicit conversions and view
-bounds are given in Section~\ref{sec:implicits}.
+A biblioteca Scala predefine conversões implícitas para vários tipos, incluindo
+os tipos primitivos e \lstinline@String@. Entretanto, o redesenho da abstração conjunto 
+pode ser, do mesmo modo,  instanciada com estes tipos. Mais explicações sobre 
+conversões implicitas e ligações visão são dadas na Seção~\ref{sec:implicits}.
+%----------xpto
 
 \section{Variance Annotations}\label{sec:first-arrays}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1269,14 +1269,23 @@ $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
 $\rightarrow\ldots\rightarrow$  120
 \end{lstlisting}
 
-%----------xpto
+%----------
 %% There is an important difference between the two rewrite sequences:
 %% The terms in the rewrite sequence of \code{gcd} have again and again
 %% the same form. As evaluation proceeds, their size is bounded by a
 %% constant. By contrast, in the evaluation of factorial we get longer
 %% and longer chains of operands which are then multiplied in the last
 %% part of the evaluation sequence.
+Há uma importante diferença entre as duas sentenças reescritas:
+Os termos na sequência reescrita de \code{gcd} tem repetidamente a
+mesma forma. Conforme a avaliação prossegue, seu tamanho é limitado por
+uma constante. Diferentemente, na avaliação do fatorial obtemos cadeias
+cada vez mais longas de operandos que são então multiplicados na última
+parte da sequência de avaliação. 
+%----------
 
+
+%----------xpto
 %% Even though actual implementations of Scala do not work by rewriting
 %% terms, they nevertheless should have the same space behavior as in the
 %% rewrite sequences. In the implementation of \code{gcd}, one notes that
@@ -1288,14 +1297,21 @@ $\rightarrow\ldots\rightarrow$  120
 %% instantiation of \code{gcd}, so that no new stack space is needed.
 %% Hence, tail recursive functions are iterative processes, which can be
 %% executed in constant space.
+Ainda que as atuais implementações de Scala não trabalhem reescrevendo
+termos, elas contudo devem ter o mesmo comportamento de espaço que nas
+sequências reescritas. 
+%----------
 
+%----------
 %% By contrast, the recursive call in \code{factorial} is followed by a
 %% multiplication.  Hence, a new stack frame is allocated for the
 %% recursive instance of factorial, and is deallocated after that
 %% instance has finished. The given formulation of the factorial function
 %% is not tail-recursive; it needs space proportional to its input
 %% parameter for its execution.
+%----------
 
+%----------
 %% More generally, if the last action of a function is a call to another
 %% (possibly the same) function, only a single stack frame is needed for
 %% both functions. Such calls are called ``tail calls''. In principle,
@@ -1306,11 +1322,14 @@ $\rightarrow\ldots\rightarrow$  120
 %% re-use the stack frame of a directly tail-recursive function whose
 %% last action is a call to itself.  Other tail calls might be optimized
 %% also, but one should not rely on this across implementations.
+%----------
 
 %% \begin{exercise} Design a tail-recursive version of
 %% \code{factorial}.
 %% \end{exercise}
 
+
+%----------
 %% \chapter{\label{chap:first-class-funs}First-Class Functions}
 
 %% A function in Scala is a ``first-class value''. Like any other value,
@@ -1319,7 +1338,9 @@ $\rightarrow\ldots\rightarrow$  120
 %% called {\em higher-order} functions. This chapter introduces
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
+%----------
 
+%----------
 %% As a motivating example, consider the following three related tasks:
 %% \begin{enumerate}
 %% \item
@@ -1328,6 +1349,9 @@ $\rightarrow\ldots\rightarrow$  120
 %% def sumInts(a: Int, b: Int): Int =
 %%   if (a > b) 0 else a + sumInts(a + 1, b)
 %% \end{lstlisting}
+%----------
+
+%----------
 %% \item 
 %% Write a function to sum the squares of all integers between two given numbers 
 %% \code{a} and \code{b}:
@@ -1345,6 +1369,9 @@ $\rightarrow\ldots\rightarrow$  120
 %%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
 %% \end{lstlisting}
 %% \end{enumerate}
+%----------
+
+%----------
 %% These functions are all instances of
 %% \(\sum^b_a f(n)\) for different values of $f$. 
 %% We can factor out the common pattern by defining a function \code{sum}:
@@ -1357,7 +1384,9 @@ $\rightarrow\ldots\rightarrow$  120
 %% \code{Int}. So \code{sum} is a function which takes another function as
 %% a parameter. In other words, \code{sum} is a {\em higher-order}
 %% function.
+%----------
 
+%----------
 %% Using \code{sum}, we can formulate the three summing functions as
 %% follows.
 %% \begin{lstlisting}
@@ -1371,14 +1400,18 @@ $\rightarrow\ldots\rightarrow$  120
 %% def square(x: Int): Int = x * x
 %% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
 %% \end{lstlisting}
+%----------
 
+%----------
 %% \section{Anonymous Functions}
 
 %% Parameterization by functions tends to create many small functions. In
 %% the previous example, we defined \code{id}, \code{square} and
 %% \code{power} as separate functions, so that they could be 
 %% passed as arguments to \code{sum}.
+%----------
 
+%----------
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a
@@ -1387,6 +1420,9 @@ $\rightarrow\ldots\rightarrow$  120
 %% \begin{lstlisting}
 %%   (x: Int) => x * x
 %% \end{lstlisting}
+%----------
+
+
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2009,8 +2009,11 @@ precisamos acrescentar no mÅÌnimo um espaÅÁo, ou seja, \code{x+ -y}.
 %----------xpto
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
+O caracter \verb@$@ ÅÈ reservado para identificadores gerados
+pelo compilador; nÅ„o devem ser usados em programas fontes. %$ 
 
 %% The following are reserved words, they may not be used as identifiers:
+Os seguintes sÅ„o palavras reservadas, e nÅ„o devem ser usadas como identificadores:
 \begin{lstlisting}
 abstract    case        catch       class       def    
 do          else        extends     false       final    
@@ -2026,6 +2029,7 @@ _    :    =    =>    <-    <:    <%     >:    #    @
 
 %----------
 %% \subsection*{Types:}
+\subsection*{Types:}
 
 \begin{lstlisting}
 Type          =  SimpleType | FunctionType
@@ -2036,18 +2040,19 @@ Types         =  Type {`,' Type}
 \end{lstlisting}
 
 %% Types can be:
+Tipos podem ser:
  \begin{itemize}
-%% \item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
-%% \item the type \code{Boolean} with values \code{true} and \code{false},
-%% \item the type \code{Unit} with the only value \lstinline@()@,
-%% \item the type \code{String},
-%% \item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
+ \item tipos numÅÈricos \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (com em Java),
+ \item o tipo \code{Boolean} com valores  \code{true} e \code{false},
+ \item o tipo \code{Unit} com o Å˙nico valor  \lstinline@()@,
+ \item o tipo \code{String},
+ \item tipos funÅÁÅ„o, tal como  \code{(Int, Int) => Int} ou \code{String => Int => String}.
  \end{itemize}
 %----------
 
 %----------
 %% \subsection*{Expressions:}
-
+ \subsection*{ExpressÅıes:}
 \begin{lstlisting}
 Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
 InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
@@ -2061,24 +2066,26 @@ Block        = '{' {Def ';'} Expr '}'
 \end{lstlisting}
 
 %% Expressions can be:
-%% \begin{itemize}
-%% \item
+ExpressÅıes podem ser:
+ \begin{itemize}
+ \item
 %% identifiers such as \code{x}, \code{isGoodEnough}, \code{*}, or \code{+-},
-%% \item
+identificadores tais como \code{x}, \code{isGoodEnough}, \code{*}, ou \code{+-},
+ \item
 %% literals, such as \code{0}, \code{1.0}, or \code{"abc"},
-%% \item
+ \item
 %% field and method selections, such as \code{System.out.println},
-%% \item
+ \item
 %% function applications, such as \code{sqrt(x)}, 
-%% \item
+ \item
 %% operator applications, such as \code{-x} or \code{y + x},
-%% \item
+ \item
 %% conditionals, such as \code{if (x < 0) -x else x},
-%% \item
+ \item
 %% blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
-%% \item
+ \item
 %% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
-%% \end{itemize}
+ \end{itemize}
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3318,7 +3318,7 @@ def eval(e: Expr): Int = e match {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -3330,9 +3330,15 @@ def eval(e: Expr): Int = e match {
 %% \code{l} and \code{r} 
 %% to \code{v}$_1$ and \code{v}$_2$, respectively. 
 Neste exemplo, há dois cases. Cada case associa um padrão a uma expressão. 
+Padrões são casados contra o valor do seletor \code{e}. O primeiro padrão do
+nosso exemplo, \code{Number(n)}, casa todos os valores da forma \code{Number(v)},
+onde \code{v} é um valor arbitrário. Naquele caso, a {\em variável padrão} \code{n}
+é ligada ao valor \code{v}. Similarmente, o padrão \code{Sum(l, r)} casa com todos 
+os valores do seletor da forma \code{Sum(v}$_1$\code{, v}$_2$\code{)} e liga as 
+variáveis padrão \code{l} e \code{r} a \code{v}$_1$ e \code{v}$_2$, respectivamente. 
 %----------
 
-%----------
+%----------xpto
 %% In general, patterns are built from
 %% \begin{itemize}
 %% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
@@ -3347,6 +3353,18 @@ Neste exemplo, há dois cases. Cada case associa um padrão a uma expressão.
 %% upper case letter.  Each variable name may occur only once in a
 %% pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
 %% since the pattern variable \code{x} occurs twice in it.
+Em geral, padrões são construídos a partir
+
+\begin{itemize}
+\item Construtores de classes case, por exemplo \code{Number}, \code{Sum}, cujos
+argumentos são, novamente, padrões, 
+\item variáveis padrão, por exemplo \code{n}, \code{e1}, \code{e2}, 
+\item o padrão ``coringa'' \code{_},
+\item literais, tal como \code{1}, \code{true},  "abc", 
+\item identificadores constantes, tais como \code{MAXINT}, \code{EmptySet}.  
+\end{itemize}
+
+
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2341,8 +2341,9 @@ O acesso uniforme garante que clientes não tenham de ser reescritos
 por conta desta mudança.
 %----------
 
-%----------xpto
+%----------
 %% \paragraph{Abstract Classes}
+\paragraph{Classes Abstratas}
 
 %% Consider the task of writing a class for sets of integer numbers with
 %% two operations, \code{incl} and \code{contains}. \code{(s incl x)}
@@ -2350,7 +2351,13 @@ por conta desta mudança.
 %% with all the elements of set \code{s}. \code{(s contains x)} should
 %% return true if the set \code{s} contains the element \code{x}, and
 %% should return \code{false} otherwise. The interface of such sets is
-%% given by:  
+%% given by:
+Considere a tarefa de escrever uma classe para conjuntos de números inteiros com 
+duas operações, \code{incl} e \code{contains}. \code{(s incl x)} deve retornar
+um novo conjunto que contém o elemento \code{x} juntamente com todos os elementos 
+do conjunto \code{s}. \code{(s contains x)} deve retornar \code{true} se o conjunto 
+\code{s} contiver o elemento \code{x}, e deve retornar \code{false}, caso contrário.
+A interface para tais conjuntos é dada por:
 \begin{lstlisting}
 abstract class IntSet {
   def incl(x: Int): IntSet
@@ -2359,7 +2366,7 @@ abstract class IntSet {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% \code{IntSet} is labeled as an \emph{abstract class}. This has two
 %% consequences.  First, abstract classes may have {\em deferred} members
 %% which are declared but which do not have an implementation. In our

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -451,11 +451,6 @@ o formato de mensagens particulares dentro da classe. Estas mensagens
 podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
 que hajam ferramentas automáticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
-% Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
-%
-% Resp: por que trata-se de um modelo de concorrência (o nome do modelo) 
-% usado por Scala que foi inspirado no modelo do Erlang:
-%      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
 
 %----------
@@ -475,7 +470,7 @@ estruturas de dados internas, tais como as definidas acima.
 %% further offers that the auction is closed.
 A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
 \code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
-para esta classe são criados pela indicação
+para esta classe são criados com as informações:
 \begin{itemize}
 \item Um actor vendedor que precisa ser notificado quando o leilão terminou,
 \item o lance mínimo,
@@ -554,8 +549,8 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par�
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussão precedente deu uma idéia de programação distribuída em Scala. Isso
-dá a sensação que Scala tem um rico conjunto de construtores que suportam
+A discussão precedente deu uma idéia de programação distribuída em Scala.Pode parecer 
+que Scala tenha um rico conjunto de construtores que suportam
 processos actor, envio e recebimento de mensagens, programação com timeouts etc.
 De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
 oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
@@ -588,15 +583,14 @@ pode ser modificado livremente se um diferente modelo for necessário em algumas
 aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
 o suficiente para prover as abstrações linguísticas necessárias de um modo 
 conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
-design foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
-hospedeira para domínios de linguagens específicos implementados por módulos de 
+projeto foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
+hospedeira para linguagens de domínios específicos (DSL) implementados por módulos de 
 biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
-pode ser vista como um desses domínios específicos de linguagem, que conceitualmente
+pode ser vista como um dessas linguagens de domínios específicos, que conceitualmente
 estendem o núcleo Scala.  
 %----------
 
 %----------
-% Vinicius - comecei traducao aqui.
 %%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
 \chapter{\label{chap:simple-funs}Expressões e Funções Simples}
 
@@ -661,9 +655,6 @@ unnamed4: Double = 62.83185307179586
 Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
 que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
-% Vinicius - parei traducao aqui.
-
-
 
 %----------
 %% Executing a definition such as \code{def x = e} will not evaluate the
@@ -705,7 +696,7 @@ operandos é avaliada pela repetida aplicação dos seguintes passos de simplifi
 \end{itemize}
 Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
 direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
-nome pelo valor da definição do lado direito. O processo de avaliação pára assim que 
+nome pelo valor da definição do lado direito. O processo de avaliação para assim que 
 encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
 um vetor, ou uma lista.
 %----------
@@ -763,6 +754,7 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
+% Vinicius - parei revisao  aqui. - Antes daqui, tudo OK!
 %----------xpto
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
@@ -772,6 +764,8 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
+
+
 Parâmetros de funções seguem o nome da função e sempre são envolvidos por
 parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
 e dois pontos. Até aqui, só precisamos de tipos numéricos   
@@ -1176,6 +1170,8 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \end{exercise}
 
 %% \chapter{\label{chap:first-class-funs}First-Class Functions}
+\chapter{\label{chap:first-class-funs}Funções na Primeira Classe}
+
 
 %% A function in Scala is a ``first-class value''. Like any other value,
 %% it may be passed as a parameter or returned as a result.  Functions
@@ -1183,6 +1179,14 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% called {\em higher-order} functions. This chapter introduces
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
+
+Uma função em Scala é um valor ``valor de primeira classe''. Como qualquer
+outro valor, ele pode ser passado por parâmetro ou retornado como um resultado.
+Funções que recebem outras funções como parâmetros ou os retornem como resultados
+são chamadas funções de ordem-alta e mostram como podem ser um mecanismo flexível para
+a composição de um programa.
+% Vinicius parei aqui
+
 
 %% As a motivating example, consider the following three related tasks:
 %% \begin{enumerate}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -207,9 +207,15 @@ resultado são chamadas {\em funções de alta ordem.}
 Scala não faz distinção entre nomes de identificadores e nomes de operadores.
 um identificador pode ser ou uma sequência de letras ou digitos que começam
 com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
-
+``\code{+}'', ``\code{*}'', ou ``\code{:}''.  Qualquer identificador pode
+ser usado como operador infixo em Scala. A operação binária $E;op;E'$ é sempre
+interpretado como a chamada de método $E.op(E')$. Isso vale também para 
+operadores binários infixos que iniciam com uma letra. Consequentemente,
+a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
+método ~\lstinline@xs.filter(pivot >)@.
 %----------
 
+alb
 
 %----------
 %% In the quicksort program, \code{filter} is applied three times to an

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1013,7 +1013,7 @@ programas imperativos podem sempre ser modelados por recursão em
 programas funcionais. 
 %----------
 
-%----------xpto
+%----------
 %% Note also that the definition of \code{sqrtIter} contains a return
 %% type, which follows the parameter section. Such return types are
 %% mandatory for recursive functions. For a non-recursive function, the
@@ -1021,6 +1021,12 @@ programas funcionais.
 %% compute it from the type of the function's right-hand side. However,
 %% even for non-recursive functions it is often a good idea to include a
 %% return type for better documentation.
+Observe também que a definição de \code{sqrtIter} contém um tipo retorno,
+que segue o seção de parâmetros. Tais tipos de retorno são mandatórios para 
+funções recursivas. Para uma função não recursiva, o tipo de retorno é opcional;
+se estiver faltando o verificador de tipos o computará a partir do tipo do lado
+direito da função. Entretanto, mesmo para funções não recursivas é sempre boa idéia 
+incluir um tipo de retorno para melhor documentação.  
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3908,16 +3908,12 @@ pois isso enriquece naturalmente relacionamentos de subtipificação. O compilad
 problemas de integridade potenciais. Mesmo se a aproximação do compilador for muito 
 conservadora, frequentemente sugerirá uma generalização útil do método contestado.
 
-%----------xpto
-
-
 \section{Tipos Minimais}
 
 Scala não nos permite parametrizar objetos com tipos. Este é o motivo 
 pelo qual originalmente definimos uma classe genérica \code{EmptyStack[A]}, 
 ainda que um único valor denotando pilhas vazias de tipos arbitrários o 
 fizesse. Para pilhas covariantes, entretanto, pode-se usar o seguinte idioma:
-
 
 \begin{lstlisting}
 object EmptyStack extends Stack[Nothing] { ... }
@@ -3975,88 +3971,90 @@ class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
   def pop = rest
 }
 \end{lstlisting}
-Many classes in the Scala library are generic. We now present two
-commonly used families of generic classes, tuples and functions. The
-discussion of another common class, lists, is deferred to the next
-chapter.
 
-\section{Tuples}
+Muitas classes na biblioteca Scala são genéricas. Agora apresentaremos duas
+comumente usadas famílias de classes genéricas, tuplas e funções. A discussão 
+de uma outra classe bem comum, listas, é postergada para o próximo capítulo.
 
-Sometimes, a function needs to return more than one result. For
-instance, take the function \code{divmod} which returns the integer quotient
-and rest of two given integer arguments.  Of course, one can define a
-class to hold the two results of \code{divmod}, as in:
+\section{Tuplas}
+
+Vez por outra, uma função precisa retornar mais de um resultado. Por exemplo, suponha a 
+função \code{divmod} que retorna o quociente inteiro e o resto de dois argumentos inteiros dados.
+De fato, pode-se definir uma classe para pegar os dois resultados de \code{divmod}, como em:
 \begin{lstlisting}
 case class TwoInts(first: Int, second: Int)
 def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
 \end{lstlisting}
-However, having to define a new class for every possible pair of
-result types is very tedious. In Scala one can use instead a
-generic class \lstinline@Tuple$2$@, which is defined as follows:
+Entretanto, ter que definir uma nova classe para cada possível par de tipos de resultados é 
+bastante tedioso. Em Scala pode-se usar, ao invés, uma classe genérica \lstinline@Tuple$2$@,
+que é definida como segue:   
 \begin{lstlisting}
 package scala
 case class Tuple2[A, B](_1: A, _2: B)
 \end{lstlisting}
-With \code{Tuple2}, the \code{divmod} method can be written as follows.
+Com \code{Tuple2}, o método \code{divmod} pode ser escrito como segue.
 \begin{lstlisting}
 def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
 \end{lstlisting}
-As usual, type parameters to constructors can be omitted if they are
-deducible from value arguments. There exist also tuple classes for
-every other number of elements (the current Scala implementation
-limits this to tuples of some reasonable number of elements).  
 
+Como sempre, parâmetros tipos para construtores podem ser omitidos se forem 
+dedutíveis a partir dos valores dos argumentos. Há também classes tuplas para 
+cada outro número de elementos (a implementação Scala atual limita isto a tuplas
+de algum número razoável de elementos).  
 \comment{
-Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
-\code{Triple} for \code{Tuple3}).  With these conventions,
-\code{divmod} can equivalently be written as follows.
+Também, Scala define um alias \code{Pair} para \code{Tuple2} (bem como com \code{Triple}
+para \code{Tuple3}). Com tais convenções, \code{divmod} pode, equivalentemente ser escrita
+como segue. 
 \begin{lstlisting}
 def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
 \end{lstlisting}
 }
-How are elements of tuples accessed? Since tuples are case classes,
-there are two possibilities. One can either access a tuple's fields
-using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
+
+Como os elementos de tuplas são acessados? Como tuplas são classes case, há duas possibilidades. 
+Pode-se ou acessar os campos da tupla usando os nomes dos parâmetros dos construtores 
+\lstinline@_$i$@, como no seguinte exemplo:
 \begin{lstlisting}
 val xy = divmod(x, y)
 println("quotient: " + xy._1 + ", rest: " + xy._2)
 \end{lstlisting}
-Or one uses pattern matching on tuples, as in the following example:
+Ou usa-se casamento de padrões sobre tuplas, como no seguinte exemplo: 
 \begin{lstlisting}
 divmod(x, y) match {
   case Tuple2(n, d) =>
     println("quotient: " + n + ", rest: " + d)
 }
 \end{lstlisting}
-Note that type parameters are never used in patterns; it would have
-been illegal to write case \code{Tuple2[Int, Int](n, d)}.
+Observe que tipos parâmetros nunca são usados nos padrões; seria ilegal escrever 
+case \code{Tuple2[Int, Int](n, d)}.
 
-Tuples are so convenient that Scala defines special syntax for
-them. To form a tuple with $n$ elements $x_1 \commadots x_n$ one can
-write $(x_1 \commadots x_n)$. This is equivalent to
-\lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
-equivalently for types and for patterns. With that tuple syntax, the
-\lstinline@divmod@ example is written as follows:
+Tuplas são tão convenientes que Scala define uma sintaxe especial para elas. 
+Para formar uma tupla com $n$ elementos $x_1 \commadots x_n$ pode-se escrever
+$(x_1 \commadots x_n)$. Isto é equivalente a \lstinline@Tuple$n$($x_1 \commadots x_n$)@.
+A sintaxe  $(...)$ funciona de modo equivalente para tipos e para padrões. Com esta
+sintaxe para tuplas, o exemplo \lstinline@divmod@ é escrito como segue:
 \begin{lstlisting}
 def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
 divmod(x, y) match {
   case (n, d) => println("quotient: " + n + ", rest: " + d)
 }
 \end{lstlisting}
-\section{Functions}\label{sec:functions}
+\section{Funções}\label{sec:functions}
 
-Scala is a functional language in that functions are first-class
-values.  Scala is also an object-oriented language in that every value
-is an object.  It follows that functions are objects in Scala.  For
-instance, a function from type \code{String} to type \code{Int} is
-represented as an instance of the trait \code{Function1[String, Int]}.
-The \code{Function1} trait is defined as follows.
+Scala é uma linguagem funcional na qual funções são valores de primeira classe. 
+Scala é também uma linguagem orientada a objetos na qual cada valor é um objeto.  
+Segue daí que funções são objetos em Scala. Por exemplo, uma função do tipo 
+\code{String} para o tipo \code{Int} é representada como uma instância do trait
+\code{Funciton1[String, Int]}. O trait \code{Function1} é definido como segue.
+
 \begin{lstlisting}
 package scala
 trait Function1[-A, +B] {
   def apply(x: A): B
 }
 \end{lstlisting}
+
+%-------------xpto
+
 Besides \code{Function1}, there are also definitions of for functions
 of all other arities (the current implementation implements this only
 up to a reasonable limit).  That is, there is one definition for each

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7365,7 +7365,7 @@ Por exemplo o esquema de tipos $\forall a\forall b.a \!\arrow\! b$ seria represe
 \begin{lstlisting}
 TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
 \end{lstlisting}
-A deinição da classe esquema de tipos nã contém uma cláusula extends;
+A definição da classe esquema de tipos não contém uma cláusula extends;
 isso quer dizer que um esquema de tipos herda diretamente da classe
 \code{AnyRef}.  Embora exista apenas uma única maneira de construir um
 esquema de tipos, uma representação usando classe case foi escolhida, pois
@@ -7379,10 +7379,10 @@ oferece formas convenientes de acessar as partes de uma instância deste tipo.
   }
 \end{lstlisting}
 
-Type scheme objects come with a method \code{newInstance}, which
-returns the type contained in the scheme after all universally type
-variables have been renamed to fresh variables. The implementation of
-this method folds (with \code{/:}) the type scheme's type variables
+Os objetos de esquemas de tipos vem com o método \code{newInstance}, que retorna o
+tipo contido no esquema depois de todos os tipos variáveis tiverem sido renomeados
+para novas variáveis. A implementação deste método folds (com \code{/:}) 
+the type scheme's type variables
 with an operation which extends a given substitution \code{s} by
 renaming a given type variable \code{tv} to a fresh type
 variable. The resulting substitution renames all type variables of the
@@ -7509,17 +7509,16 @@ to the derivation rules of the Hindley/Milner type system \cite{milner:polymorph
   } 
   var current: Term = null
 \end{lstlisting}
-To aid error diagnostics, the \code{tp} function stores the currently
-analyzed sub-term in variable \code{current}. Thus, if type checking
-is aborted with a \code{TypeError} exception, this variable will
-contain the subterm that caused the problem.
+Para auxiliar no diagnóstico de erros, a função \code{tp} guarda o sub-termo que
+está sendo analisado na variável \code{current}. Com isso, se a checagem de tipos
+for iterrompido por uma exceção do tipo \code{TypeError}, esta variável conterá o
+sub-termo que causou o problema.
 
-The last function of the type inference module, \code{typeOf}, is a
-simplified facade for \code{tp}. It computes the type of a given term
-$e$ in a given environment $env$. It does so by creating a fresh type
-variable $a$, computing a typing substitution that makes $env \ts e: a$
-into a derivable type judgment, and returning
-the result of applying the substitution to $a$.
+A última função do módulo de inferência de tipos , \code{typeOf}, é uma façade simplificada
+para \code{tp}. Ela computa o tipo de um dado termo
+$e$ em um dado ambiente $env$. Ela o faz através da criação de um novo tipo variável $a$, 
+e da computação da substituição de tipos que faz $env \ts e: a$  se tornar um tipo derivado 
+e retorna o resultado da aplicação da subsituição em $a$.
 \begin{lstlisting}
   def typeOf(env: Env, e: Term): Type = {
     val a = newTyvar()
@@ -7527,13 +7526,12 @@ the result of applying the substitution to $a$.
   }
 }// end typeInfer
 \end{lstlisting}
-To apply the type inferencer, it is convenient to have a predefined
-environment that contains bindings for commonly used constants. The
-module \code{predefined} defines an environment \code{env} that
-contains bindings for the types of booleans, numbers and lists
-together with some primitive operations over them. It also
-defines a fixed point operator \code{fix}, which can be used to
-represent recursion.
+Para usar o sistema de inferência de tipos, é conveniente ter um ambiente
+pré-definido que contém as definições das constantes mais comumente usadas.
+O módulo \code{predefined} define um ambiente \code{env} que contém as definições dos tipos 
+booleanos, números e listas assim como algumas operações primitivas sobre eles.
+Também define um operador de ponto fixo \code{fix}, que pode ser usado para representar uma
+recursão.
 \begin{lstlisting}
 object predefined {
   val booleanType = Tycon("Boolean", List())

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3388,20 +3388,19 @@ casa os padr\~{o}es $p_1 \commadots p_n$ na ordem em que eles s\~{a}o
 escritos contra o valor seletor \code{e}.
 %----------
 
-%----------xpto novo aqui
+
 \begin{itemize}
 \item
-%%A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
-%%are of type \code{C} (or a subtype thereof) and that have been constructed with 
-%%\code{C}-arguments matching patterns $p_1 \commadots p_n$.
 Um construtor padrão $C(p_1 \commadots p_n)$ casa com todos os valores que são 
 do tipo \code{C} (ou um subtipo dele) e que foram construídos com argumentos \code{C}
 casando com padrões $p_1 \commadots p_n$.
-%-----------
+
 
 \item 
-A variable pattern \code{x} matches any value and binds the variable
-name to that value.  
+Uma variável padrão \code{x} casa qualquer valor e liga o nome da variável àquele valor.
+
+
+%----------xpto
 \item 
 The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
 \item A constant pattern \code{C} matches a value which is

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3598,9 +3598,9 @@ val s1 = new EmptyStack[String].push("abc")
 val s2 = new EmptyStack[String].push("abx").push(s1.top)
 println(isPrefix[String](s1, s2))
 \end{lstlisting}
-%----------xpto
 
-\paragraph{Inferência de Tipo Local}
+
+\paragraph{Inferência de Tipos Local}
 Passar parâmetros de tipo tais como \code{[Int]} ou \code{[String]} o
 tempo todo pode tornar-se enfadonho em aplicações onde funções 
 genéricas são muito utilizadas. Frequentemente, a informação dentro
@@ -3616,31 +3616,33 @@ situações como esta. No exemplo acima, poderíamos ter escrito
 \code{isPrefix(s1, s2)} e o tipo do argumento omitido \code{[String]}
 seria inserido pelo mecanismo de inferência de tipos.
 
-\section{Type Parameter Bounds}
+\section{Parâmetros Tipo Ligados}
 
-Now that we know how to make classes generic it is natural to
-generalize some of the earlier classes we have written. For instance
-class \code{IntSet} could be generalized to sets with arbitrary
-element types. Let's try. The abstract class for generic sets is easily
-written.
+Agora que sabemos como criar classes genéricas é natural generalizarmos 
+algumas das classes escritas anteriormente. Por exemplo, a classe \code{IntSet}
+poderia ser generalizada para conjuntos com tipos arbitrários de elementos.
+Vamos tentar. A classe abstrata para conjuntos genéricos é facilmente escrita.
+
 \begin{lstlisting}
 abstract class Set[A] {
   def incl(x: A): Set[A]
   def contains(x: A): Boolean
 }
 \end{lstlisting}
-However, if we still want to implement sets as binary search trees, we
-encounter a problem. The \code{contains} and \code{incl} methods both
-compare elements using methods \code{<} and \code{>}. For
-\code{IntSet} this was OK, since type \code{Int} has these two
-methods. But for an arbitrary type parameter \code{a}, we cannot
-guarantee this. Therefore, the previous implementation of, say,
-\code{contains} would generate a compiler error.
+Entretanto, se ainda quisermos implementar conjuntos como árvores binárias 
+de busca, encontraremos um problema. Os métodos \code{contains} e \code{incl}, 
+ambos comparam elementos usando métodos \code{<} e \code{>}. Para \code{IntSet}
+isto está OK, pois o tipo \code{Int} tem estes dois métodos. Mas para um 
+tipo arbitrário de parâmetro \code{a}, não podemos garantir isso. Logo, a 
+implementação anterior de, digamos, \code{contains} levará a um erro de compilação.
+
 \begin{lstlisting}
   def contains(x: Int): Boolean =
     if (x < elem) left contains x
           ^ < $\mbox{\sl not a member of type}$ A.
 \end{lstlisting}
+
+%----------xpto
 One way to solve the problem is to restrict the legal types that can
 be substituted for type \code{A} to only those types that contain methods
 \code{<} and \code{>} of the correct types. There is a trait

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4112,40 +4112,42 @@ val plus1: Function1[Int, Int] = {
 }
 plus1.apply(2)
 \end{lstlisting}
-%----------xpto
 
-\chapter{Lists}
+\chapter{Listas}
 
-Lists are an important data structure in many Scala programs.  
-A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
-\code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
+Listas são uma importante estrutura de dados em muitos programas Scala. Uma 
+lista contendo os elementos \code{x}$_1$, \ldots, \code{x}$_n$ é escrita
+\code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Alguns exemplos:
+
 \begin{lstlisting}
 val fruit = List("apples", "oranges", "pears")
 val nums  = List(1, 2, 3, 4)
 val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
 val empty = List()
 \end{lstlisting}
-Lists are similar to arrays in languages such as C or Java, but there
-are also three important differences. First, lists are immutable. That
-is, elements of a list cannot be changed by assignment. Second, 
-lists have a recursive structure, whereas arrays are flat. Third,
-lists support a much richer set of operations than arrays usually do.
 
-\section{Using Lists}
+Listas são similares a vetores em linguagens tais como C ou Java, mas há 
+também três importantes diferenças. Primeiro, listas são imutáveis. Ou seja, 
+elementos de uma lista não podem ser mudados por meio de atribuição. Segundo, 
+listas tem uma estrutura recursiva, enquanto vetores são triviais. Terceiro, 
+em geral, listas suportam um conjunto muito mais rico de operações que vetores. 
+ 
+\section{Usando Listas}
 
-\paragraph{The List type}
-Like arrays, lists are {\em homogeneous}. That is, the elements of a
-list all have the same type.  The type of a list with elements of type
-\code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
+\paragraph{O tipo lista}
+
+Do mesmo modo que com vetores, listas são {\em homogêneas}. Ou seja, os elementos 
+de uma lista têm todos o mesmo tipo. O tipo de uma lista com elementos de tipo 
+\code{T} é escrito \code{List[T]} (compare com \code{T[]} em Java).
+
 \begin{lstlisting}
 val fruit: List[String]    = List("apples", "oranges", "pears")
 val nums : List[Int]       = List(1, 2, 3, 4)
 val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
 val empty: List[Int]       = List()
 \end{lstlisting}
-%----------
 
-\paragraph{List constructors}
+\paragraph{Construtores de listas}
 All lists are built from two more fundamental constructors, \code{Nil}
 and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
 list. The infix operator \code{::} expresses list extension. That is,
@@ -4153,6 +4155,13 @@ list. The infix operator \code{::} expresses list extension. That is,
 which is followed by (the elements of) list \code{xs}.  Hence, the
 list values above could also have been defined as follows (in fact
 their previous definition is simply syntactic sugar for the definitions below).
+
+Todas as listas são construídas a partir de dois construtores fundamentais, \code{Nil} e 
+\code{::} (lê-se ``cons''). \code{Nil} representa uma lista vazia. O operador infixo 
+\code{::} expressa a extensão da lista. Ou seja, \code{x :: xs} denota uma lista 
+cujo primeiro elemento é \code{x}, e que é seguido pela (os elementos da) lista \code{xs}.
+Consequentemente, os valores da lista acima podem também ter sido definidos como segue 
+(de fato essa definição prévia é apenas um facilitador sintático para as definições abaixo).
 \begin{lstlisting}
 val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
 val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
@@ -4161,27 +4170,29 @@ val diag3  = (1 :: (0 :: (0 :: Nil))) ::
              (0 :: (0 :: (1 :: Nil))) :: Nil
 val empty  = Nil
 \end{lstlisting}
-The `\code{::}' operation associates to the right: \code{A :: B :: C} is
-interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
-parentheses in the definitions above. For instance, we can write
-shorter
+A operação `\code{::}' é associativa à direita: \code{A :: B :: C} é 
+interpretada como \code{A :: (B :: C)}. Por essa razão, podemos retirar os 
+parênteses das definições acima. Por exemplo, podemos escrever de modo resumido
 \begin{lstlisting}
 val nums  =  1 :: 2 :: 3 :: 4 :: Nil
 \end{lstlisting}
-%----------
 
-\paragraph{Basic operations on lists}
+\paragraph{Operações básicas sobre listas}
 All operations on lists can be expressed in terms of the following three:
+Todas as operações sobre listas podem ser expressas em termos das três a seguir:
 
 \begin{tabular}{ll}
-\code{head}  &  returns the first element of a list,\\
-\code{tail}  &  returns the list consisting of all elements except the\\
-& first element,\\
-\code{isEmpty} & returns \code{true} iff the list is empty
+\code{head}  & retorna o primeiro elemento de uma lista,\\
+\code{tail}  & retorna a lista que consiste de todos os elementos exceto o\\
+& primeiro elemento,\\
+\code{isEmpty} & returns \code{true} se e só se a lista for vazia.
 \end{tabular}
 
-These operations are defined as methods of list objects. So we invoke
-them by selecting from the list that's operated on. Examples:
+Estas operações são definidas como métodos de objetos listas. Portanto as invocamos 
+escolhendo da lista aqueles que sofrerão a operação. Exemplos: 
+
+%----------xpto
+
 \begin{lstlisting}
 empty.isEmpty   = true
 fruit.isEmpty   = false

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7544,31 +7544,26 @@ Threads podem chamar o método \code{wait} e esperar até que o método \code{no
 objeto seja chamado por alguma outra thread. Chamadas ao método
 \code{notify} quando não existam threads esperando por um sinal são ignoradas.
 
-Existe também uma forma do método \code{wait} basead em tempo em que a
+Existe também uma forma do método \code{wait} baseada em tempo em que a
 execução é bloqueada enquanto nenhum sinal seja recebido ou um dado espaço de tempo (dado em
 milisegundos) tenha passado. Além disso, há o método \code{notifyAll} que desbloqueia todas
 as threads que estejam esperando por um sinal. Estes métodos, assim como a classe \code{Monitor} 
 são primitivos em Scala, ou seja, eles são implementados usando os mecanismos internos do sistema de execução
 dos programas.
 
-Typicamente, uma thread espera até que um certa condição ocorra. 
+Tipicamente, uma thread espera até que um certa condição ocorra. 
 Se esta condição não ocorrer até o tempo definido na chamada do método \code{wait}, 
-a thread fica com execução suspensa até que alguma outra thread 
-estally, a thread waits for some condition to be established. If the
-condition does not hold at the time of the wait call, the thread
-blocks until some other thread has established the condition. It is
-the responsibility of this other thread to wake up waiting processes
-by issuing a \code{notify} or \code{notifyAll}. Note however, that
-there is no guarantee that a waiting process gets to run immediately
-after the call to notify is issued. It could be that other processes
-get to run first which invalidate the condition again. Therefore, the
-correct form of waiting for a condition $C$ uses a while loop:
+a thread fica com execução suspensa até que alguma outra thread estabeleça tal condição
+ou que o tempo definido tenha passado. É responsabilidade desta outra thread reiniciar
+os processos que estavam esperando através da chamada dos métodos \code{notify} ou \code{notifyAll}. 
+Note que não existe garantia de que um processo em espera execute imediatamente após a chamada do método
+\code{notify}. Pode ocorrer de outros processos que executem antes invalidem novamente esta condição,
+deixando as threads suspensas.  Portanto, a forma correta de esperar uma condição $C$ usa um laço do tipo while:
 \begin{lstlisting}
 while (!$C$) wait()
 \end{lstlisting}
 
-As an example of how monitors are used, here is is an implementation
-of a bounded buffer class.
+Como um exemplo de como os monitores são usados, aqui está uma implementação de uma classe de buffer com limites.
 \begin{lstlisting}
 class BoundedBuffer[A](N: Int) {
   var in = 0, out = 0, n = 0
@@ -7588,8 +7583,8 @@ class BoundedBuffer[A](N: Int) {
   }
 }
 \end{lstlisting}
-And here is a program using a bounded buffer to communicate between a
-producer and a consumer process.
+E aqui está um programa usando esta classe para comunicar entre processos
+consumidores e produtores.
 \begin{lstlisting}
 import scala.concurrent.ops._
 ...
@@ -7598,9 +7593,8 @@ spawn { while (true) { val s = produceString ; buf.put(s) } }
 spawn { while (true) { val s = buf.get ; consumeString(s) } }
 }
 \end{lstlisting}
-The \code{spawn} method spawns a new thread which executes the
-expression given in the parameter. It is defined in object \code{concurrent.ops}
-as follows.
+O método \code{spawn} dispara uma nova thread que executa a expressão passada como
+parâmetro. Foi definida no objeto \code{concurrent.ops} da seguinte maneira:
 \begin{lstlisting}
 def spawn(p: => Unit) {
   val t = new Thread() { override def run() = p }
@@ -7636,12 +7630,12 @@ class LVar[A] {
 
 \section{SyncVars}
 
-A synchronized variable (or syncvar for short) offers \code{get} and
-\code{put} operations to read and set the variable. \code{get} operations
-block until the variable has been defined. An \code{unset} operation
-resets the variable to undefined state.
+Uma variável sincronizada (ou syncvar) oferece as operações \code{get} e 
+\code{put} para ler e escrever na variável. As operações \code{get} bloqueiam
+a execução até que o valor da variável tenha sido definido. Um operação \code{unset}
+coloca o valor da variável em um valor indefinido.
 
-Here's the standard implementation of synchronized variables.
+Aqui segue uma implementação padrão de variáveis sincronizadas:
 \begin{lstlisting}
 package scala.concurrent
 class SyncVar[A] {
@@ -8140,27 +8134,23 @@ statement following it.
 \section{Actors}
 \label{sec:actors}
 
-Chapter~\ref{chap:example-auction} sketched as a program example the
-implementation of an electronic auction service. This service was
-based on high-level actor processes that work by inspecting messages
-in their mailbox using pattern matching. A refined and optimized
-implementation of actors is found in the \lstinline@scala.actors@
-package.  We now give a sketch of a simplified version of the actors library.
+Chapter~\ref{chap:example-auction} apresentou um programa como exemplo de implementação
+de um serviço de leilão eletrônico. Este serviço foi baseado em atores quue representam processos 
+de alto nível e trabalham inspecionando as mensagens em sua caixa-postal usando casamento de padrões.
+Uma implementação mais refinada e otimizada de atores pode ser encontrada no pacote \lstinline@scala.actors@.
+Agora mostraremos um rascunho de uma versão simplificada da biblioteca de atores.
 
-The code below is different from the implementation in the \lstinline@scala.actors@
-package, so it should be seen as an example how a simple version of
-actors could be implemented.  It is not a description how actors are actually defined and
-implemented in the standard Scala library. For the latter, please
-refer to the Scala API documentation.
+O código apresentado a seguir é diferente da implementação presente no pacote \lstinline@scala.actors@ e, 
+portanto, deve ser vista como um exemplo de como uma versão simplificada dos atores poderia ser implementada.
+Ela não descreve como os atores foram definidos e implementados na biblioteca padrão de Scala. Caso deseje
+essa informação, por favor consulte a documentação da API de Scala.
 
-A simplified actor is just a thread whose communication primitives are those
-of a mailbox.  Such an actor can be defined as a mixin composition
-extension of Java's standard
-\code{Thread} class with the \code{MailBox} class. We also override
-the \code{run} method of the \code{Thread} class, so that it executes the
-behavior of the actor that is defined by its \code{act} method.
-The \code{!} method simply calls the \code{send} method of the
-\code{MailBox} class:
+Um ator simplificado é apenas uma thread cujas primitivas de comunicação são aquelas de uma caixa postal.
+Tal ator pode ser definido como uma composição mixin da extensão da classe Java padrão 
+\code{Thread} com a classe \code{MailBox}. Nós também sobre-escrevemos o método \code{run} da classe \code{Thread}, de 
+tal forma que ele execute o comportamento de um ator que é definido pelo método \code{act}.
+O método \code{!} simplesmente chama o método \code{send} da classe 
+\code{MailBox}:
 \begin{lstlisting}
 abstract class Actor extends Thread with MailBox {
   def act(): Unit

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7369,33 +7369,30 @@ oferece formas convenientes de acessar as partes de uma instância deste tipo.
 
 Os objetos de esquemas de tipos vem com o método \code{newInstance}, que retorna o
 tipo contido no esquema depois de todos os tipos variáveis tiverem sido renomeados
-para novas variáveis. A implementação deste método folds (com \code{/:}) 
-the type scheme's type variables
-with an operation which extends a given substitution \code{s} by
-renaming a given type variable \code{tv} to a fresh type
-variable. The resulting substitution renames all type variables of the
-scheme to fresh ones. This substitution is then applied to the type
-part of the type scheme.
+para novas variáveis. A implementação deste método reduz (com \code{/:}) 
+os tipos variáveis do esquema de tipos  com uma função que extende uma dada substituição 
+\code{s} renomeando um dado tipo variável \code{tv} em um novo tipo variável.
+A substituição resultante renomeia todos os tipos variáveis do esquema em novos.
+Esta substituição é então aplicada o tipo do esquema de tipos.
 
-The last type we need in the type inferencer is
-\code{Env}, a type for environments, which associate variable names
-with type schemes. They are represented by a type alias \code{Env} in
-module \code{typeInfer}:
+O último tipo que necessitamos no sistema de inferência de tipos é 
+\code{Env}, um tipo para os ambientes, que associa nomes de variáveis à esquema de tipos. 
+Eles são representados pelo tipo \code{Env} no módulo \code{typeInfer}:
 \begin{lstlisting}
   type Env = List[(String, TypeScheme)]
 \end{lstlisting}
-There are two operations on environments. The \code{lookup} function
-returns the type scheme associated with a given name, or \code{null}
-if the name is not recorded in the environment.
+Existem duas operações nos ambientes. A função  \code{lookup} 
+retorna o esquema de tipos associado com um dado nome ou \code{null}
+se o nome não foi registrado no ambiente.
 \begin{lstlisting}
   def lookup(env: Env, x: String): TypeScheme = env match {
     case List() => null
     case (y, t) :: env1 => if (x == y) t else lookup(env1, x)
   }
 \end{lstlisting}
-The \code{gen} function turns a given type into a type scheme,
-quantifying over all type variables that are free in the type, but
-not in the environment.
+A função \code{gen} retorna um esquema de tipos dado um tipo,
+quantificando todos os tipos variáveis que estão livres no tipo, mas
+não no ambiente.
 \begin{lstlisting}
   def gen(env: Env, t: Type): TypeScheme = 
     TypeScheme(tyvars(t) diff tyvars(env), t)

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5614,9 +5614,9 @@ methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
 system is too weak to express this construct, since it can handle only
 type parameters which are fully applied types.
 
-\chapter{Estdos Mutáveis}
+\chapter{Estados Mutáveis}
 
-A maioria dos programs apresentados até o momento não possuem efeitos colaterais.
+A maioria dos programas apresentados até o momento não possuem efeitos colaterais.
 \footnote{Ignoramos o fato de que algums dos programas imprimem na tela, o que, 
 tecnicamente, é um efeito colateral.}.  Portanto, a noção de {\em time} não
 importou.  
@@ -7393,9 +7393,9 @@ não no ambiente.
   def gen(env: Env, t: Type): TypeScheme = 
     TypeScheme(tyvars(t) diff tyvars(env), t)
 \end{lstlisting}
-The set of free type variables of a type is simply the set of all type
-variables which occur in the type. It is represented here as a list of
-type variables, which is constructed as follows.
+o conjunto de tipos variáveis livres é simplesmente o conjunto de todos
+os tipos variáveis que ocorrem no tipo. É representado por uma lista de tipos
+variáveis construído da seguinte maneira.
 \begin{lstlisting}
   def tyvars(t: Type): List[Tyvar] = t match {
     case tv @ Tyvar(a) => 
@@ -7406,29 +7406,29 @@ type variables, which is constructed as follows.
       (List[Tyvar]() /: ts) ((tvs, t) => tvs union tyvars(t))
   }
 \end{lstlisting}
-Note that the syntax \code{tv @ ...} in the first pattern introduces a variable
-which is bound to the pattern that follows. Note also that the explicit type parameter \code{[Tyvar]} in the expression of the third
-clause is needed to make local type inference work.
+Note que a sintaxe \code{tv @ ...} no primeiro padrão introduz a variável 
+que está ligada ao padrão seguinte. 
+Note também que o tipo parâmetro \code{[Tyvar]} explícito na expressão da terceita cláusula é necessário para
+que a inferência de tipos locais funcione.
 
-The set of free type variables of a type scheme is the set of free
-type variables of its type component, excluding any quantified type variables:
+O conjunto de tipos variáveis livres de um esquema de tipos é o conjunto de tipos variáveis livre do seu tipo componente,
+excluíndo-se quaisquer tipos variáveis quantificáveis.
 \begin{lstlisting}
   def tyvars(ts: TypeScheme): List[Tyvar] = 
     tyvars(ts.tpe) diff ts.tyvars
 \end{lstlisting}
-Finally, the set of free type variables of an environment is the union
-of the free type variables of all type schemes recorded in it.
+Finalmente, o conjunto  tipos variáveis livres de um ambiente é a união
+de todos os  tipos variáveis livres de todos os esquemas de tipos registrados neste ambiente.
 \begin{lstlisting}
   def tyvars(env: Env): List[Tyvar] =
     (List[Tyvar]() /: env) ((tvs, nt) => tvs union tyvars(nt._2))
 \end{lstlisting}
-A central operation of Hindley/Milner type checking is unification,
-which computes a substitution to make two given types equal (such a
-substitution is called a {\em unifier}).  Function \code{mgu} computes
-the most general unifier of two given types $t$ and $u$ under a
-pre-existing substitution $s$.  That is, it returns the most general
-substitution $s'$ which extends $s$, and which makes $s'(t)$ and
-$s'(u)$ equal types. 
+A principal operação da checagem de tipos de Hindley/Milner é a unificação,
+que computa a substituição para fazer que dois tipos dados se tornem iguais
+ (esta subsituição é chamada um {\em unificador}\footnote{unifier}).  A função \code{mgu} computa
+o unificador mais geral de dois tipos dados $t$ e $u$ sob um substituição pre-existente $s$.  
+Isto é, ele retorna a substituição mais geral $s'$ que herda de $s$, e que faz com que $s'(t)$ e
+$s'(u)$ retornem tipos iguais. 
 \begin{lstlisting}
   def mgu(t: Type, u: Type, s: Subst): Subst = (s(t), s(u)) match {
     case (Tyvar(a), Tyvar(b)) if (a == b) =>
@@ -7445,23 +7445,21 @@ $s'(u)$ equal types.
       throw new TypeError("cannot unify " + s(t) + " with " + s(u))
   }
 \end{lstlisting}
-The \code{mgu} function throws a \code{TypeError} exception if no
-unifier substitution exists. This can happen because the two types
-have different type constructors at corresponding places, or because a
-type variable is unified with a type that contains the type variable
-itself. Such exceptions are modeled here as instances of case classes
-that inherit from the predefined \code{Exception} class.
+A função \code{mgu} lança uma exceção do tipo \code{TypeError} se não existir uma
+substituição unificadora. Isto pode ocorrer quando os dois tipos tem diferentes
+tipos construtores em seus lugares correspondentes ou quando um tipo variável é 
+unificado com um tipo que contém um tipo variável dele mesmo.
+Estas exceções foram modeladas como instâncias de classe case que herdam um classe
+ \code{Exception} pré-definida.
 \begin{lstlisting}
   case class TypeError(s: String) extends Exception(s) {}
 \end{lstlisting}
-The main task of the type checker is implemented by function
-\code{tp}. This function takes as parameters an environment $env$, a
-term $e$, a proto-type $t$, and a
-pre-existing substitution $s$.  The function yields a substitution
-$s'$ that extends $s$ and that
-turns $s'(env) \ts e: s'(t)$ into a derivable type judgment according
-to the derivation rules of the Hindley/Milner type system \cite{milner:polymorphism}.  A
-\code{TypeError} exception is thrown if no such substitution exists.
+A principal tarefa do checador de tipos é implementada pela função
+\code{tp}. Esta função recebe como parâmetro um ambiente $env$,  um termo $e$, um tipo $t$, e
+uma substituição pre-existente $s$.  A função retorna uma substituição
+$s'$ que herda de  $s$ e que torna $s'(env) \ts e: s'(t)$ num julgamento de tipos derivável de acordo
+com as regras de derivação do sistema de tipos de Hindley/Milner\cite{milner:polymorphism}.  Uma exceção do tipo
+\code{TypeError} é lançada se não existe uma substituição com estas características.
 \begin{lstlisting}
   def tp(env: Env, e: Term, t: Type, s: Subst): Subst = {
     current = e
@@ -7737,7 +7735,7 @@ da chamada de um ou mais dos métodos apresentados a seguir.
   def notify()
   def notifyAll()
 \end{lstlisting}
-The \code{synchronized} method executes its argument computation
+O método \code{synchronized} method executes its argument computation
 \code{e} in mutual exclusive mode -- at any one time, only one thread
 can execute a \code{synchronized} argument of a given monitor.
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2634,7 +2634,7 @@ type long = scala.Long
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% For efficiency, the compiler usually represents values of type
 %% \code{scala.Int} by 32 bit integers, values of type
 %% \code{scala.Boolean} by Java's booleans, etc.  But it converts these
@@ -2643,10 +2643,18 @@ type long = scala.Long
 %% parameter of type \code{AnyRef}.  Hence, the special representation of
 %% primitive values is just an optimization, it does not change the
 %% meaning of a program.
+Por eficiência, o compilador geralmente representa valor de tipo
+\code{scala.Int} por inteiros de 32 bits, valores de tipo \code{scala.Boolean}
+por boleanos Java etc. Mas converte essas representações especializadas para 
+objetos quando requeridos, por exemplo, quando um valor primitivo \code{Int} é 
+passada a uma função com um parâmetro de tipo \code{AnyRef}. Consequentemente, a
+representação de valores primitivos é apenas uma otimização, não muda o significado
+de um programa.
 %----------
 
 %----------
 %% Here is a specification of class \code{Boolean}.
+Aqui está a especificação da classe \code{Boolean}.
 \begin{lstlisting}
 package scala
 abstract class Boolean {
@@ -2671,6 +2679,11 @@ abstract class Boolean {
 %% the actual implementation in the standard Scala library. For
 %% efficiency reasons the standard implementation uses built-in
 %% booleans.
+Boleanos podem ser definidos usando somente classes e objetos, sem
+referência ao tipos básicos para boleanos ou números. Uma possível 
+implementação da claro \code{Boolean} é dada abaixo. Esta não é 
+a implementação atual na biblioteca padrão Scala. Por razões de 
+eficiência a implementação padrão usa boleanos primitivos.
 \begin{lstlisting}
 package scala
 abstract class Boolean {
@@ -2698,7 +2711,7 @@ case object False extends Boolean {
 
 %----------
 %% Here is a partial specification of class \code{Int}.
-
+Aqui está uma especificação parcial da classe \code{Int}.
 \begin{lstlisting}
 package scala
 abstract class Int extends AnyVal {
@@ -2709,26 +2722,29 @@ abstract class Int extends AnyVal {
   def + (that: Double): Double
   def + (that: Float): Float
   def + (that: Long): Long
-  def + (that: Int): Int         // analogous for -, *, /, %
+  def + (that: Int): Int         // análogo para -, *, /, %
 
-  def << (cnt: Int): Int         // analogous for >>, >>>
+  def << (cnt: Int): Int         // análogo para  >>, >>>
 
   def & (that: Long): Long
-  def & (that: Int): Int         // analogous for |, ^
+  def & (that: Int): Int         // análogo para |, ^
 
   def == (that: Double): Boolean
   def == (that: Float): Boolean
-  def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
+  def == (that: Long): Boolean   // análogo para !=, <, >, <=, >=
 }
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% Class \code{Int} can in principle also be implemented using just
 %% objects and classes, without reference to a built in type of
 %% integers. To see how, we consider a slightly simpler problem, namely
 %% how to implement a type \code{Nat} of natural (i.e. non-negative)
 %% numbers. Here is the definition of an abstract class \code{Nat}:
+A classe \code{Int} pode em princípio também ser implementada usando
+apenas objetos e classes, sem referência a um tipo construído para 
+inteiros. Para ver como, consideraremos 
 \begin{lstlisting}
 abstract class Nat {
   def isZero: Boolean

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3808,7 +3808,7 @@ checagem especial em tempo de execução. Aqui está um exemplo:
 \begin{lstlisting}
 val x = new Array[String](1)
 val y: Array[Any] = x
-y(0) = new Rational(1, 2)  // isto é syntactic sugar para
+y(0) = new Rational(1, 2)  // isto \'{e} syntactic sugar para
                            // y.update(0, new Rational(1, 2))
 \end{lstlisting}
 Na primeira linha, um novo vetor de strings é criado. Na segunda linha, 
@@ -6185,33 +6185,28 @@ other hand, assignment gives us new ways to formulate programs
 elegantly. As always, it depends on the situation whether purely
 functional programming or programming with assignments works best.
 
-\chapter{Computing with Streams}
+\chapter{Computando com Streams}
 
-The previous chapters have introduced variables, assignment and
-stateful objects.  We have seen how real-world objects that change
-with time can be modeled by changing the state of variables in a
-computation.  Time changes in the real world thus are modeled by time
-changes in program execution. Of course, such time changes are usually
-stretched out or compressed, but their relative order is the same.
-This seems quite natural, but there is a also price to pay: Our simple
-and powerful substitution model for functional computation is no
-longer applicable once we introduce variables and assignment.
+Os capítulos anteriores apresentaram variáveis, atribuição e objetos com estado.
+Vimos como objetos no mundo real mudam com o tempo e podem ser modelados através da
+mudança de estado das suas variáveis durante a computação. Desta maneira, mudanças no 
+tempo no mundo real  são modeladas por mudanças no tempo durante a execução do programa.
+Obviamente, usa-se uma escala e estas mudanças no tempo são alargadas ou comprimidas, mas
+sua ordem relativa permanece a mesma. Isto pode parecer natural, mas existe um preço a se
+pagar: o modelo de substituição usado na computação funcional não pode ser aplicado ao se
+introduzir variáveis e atribuições.
 
-Is there another way? Can we model state change in the real world
-using only immutable functions? Taking mathematics as a guide, the
-answer is clearly yes: A time-changing quantity is simply modeled by
-a function \code{f(t)} with a time parameter \code{t}. The same can be
-done in computation. Instead of overwriting a variable with successive
-values, we represent all these values as successive elements in a
-list. So, a mutable variable \code{var x: T} gets replaced by an
-immutable value \code{val x: List[T]}. In a sense, we trade space for
-time -- the different values of the variable now all exist concurrently
-as different elements of the list.  One advantage of the list-based
-view is that we can ``time-travel'', i.e. view several successive
-values of the variable at the same time. Another advantage is that we
-can make use of the powerful library of list processing functions,
-which often simplifies computation. For instance, consider the
-imperative way to compute the sum of all prime numbers in an interval:
+Será que não existe uma outra maneira? Não seria possível modelar mudanças de estado no mundo
+real usando somente funções imutáveis? Tomando matemática como um guia, a resposta claramente é sim:
+um quantidade que muda no tempo é modelada através da função \code{f(t)} que tem como parâmetro \code{t}
+para representar o tempo. O mesmo pode ser feito na computação. Ao invés de sobre-escrever uma variável com
+sucessivos valores, podemos representar estes valores como sucessivos elementos em uma lista.
+Desta forma, a variável mutável \code{var x: T} pode ser substituída por uma variável imutável \code{val x: List[T]}. 
+De certa maneira, troca-se espaço por tempo -- os diferentes valores da variável agora existem concorrentemente como
+diferentes elementos da lista. Uma das vantagens do modelo baseado em lista é a possibilidade de ``viajar no tempo'', ou seja,
+de ver sucessivos valores da variável ao mesmo tempo. Uma outra vantagem é que podemos fazer uso da poderosa biblioteca de 
+funções processamento de listas, que normalmente simplifica a computação. Por exemplo, considere a forma imperativa de computar
+a soma de todos os primos em um intervalo:
 \begin{lstlisting}
 def sumPrimes(start: Int, end: Int): Int = {
   var i = start
@@ -6223,96 +6218,91 @@ def sumPrimes(start: Int, end: Int): Int = {
   acc
 }
 \end{lstlisting}
-Note that the variable \code{i} ``steps through'' all values of the interval
+Note que a variável \code{i} ``passa por'' todos os valores do intervalo
 \code{[start .. end-1]}.
 
-A more functional way is to represent the list of values of variable \code{i} directly as \code{range(start, end)}. Then the function can be rewritten as follows.
+Uma forma mais funcional, é representar a lista de valores da variável \code{i} diretamente como \code{range(start, end)}. 
+Então a função pode ser re-escrita da seguinte maneira:
 \begin{lstlisting}
 def sumPrimes(start: Int, end: Int) =
   sum(range(start, end) filter isPrime)
 \end{lstlisting}
 
-No contest which program is shorter and clearer!  However, the
-functional program is also considerably less efficient since it
-constructs a list of all numbers in the interval, and then another one
-for the prime numbers. Even worse from an efficiency point of view is
-the following example:
+Não dúvida que o programa é mais curto e mais claro! Porém, o 
+programa funcional é também consideravelmente menos eficiente, uma
+vez que ele constrói a lista de todos os número no intervalo e, posteriormente,
+constrói uma outra lista com os números primos. Ainda pior sob o ponto de vista
+da eficiência é o seguinte exemplo:
 
-To find the second prime number between \code{1000} and \code{10000}:
+Para encontrar o segundo número primio entre \code{1000} e \code{10000}:
 \begin{lstlisting}
   range(1000, 10000) filter isPrime at 1
 \end{lstlisting}
-Here, the list of all numbers between \code{1000} and \code{10000} is
-constructed.  But most of that list is never inspected!
+Aqui, a lista de todos os números entre \code{1000} e \code{10000} é construída,
+mas a maior parte da lista nunca é usada!
 
-However, we can obtain efficient execution for examples like these by
-a trick:
+No entanto, pode-se obter uma execução eficiente para exemplos como este usando
+um truque:
 \begin{quote}
 %\red
- Avoid computing the tail of a sequence unless that tail is actually
-     necessary for the computation.
+ Nunca compute o resto (tail) de uma sequência a não ser que o resto seja realmente
+necessário para a computação.
 \end{quote}
-We define a new class for such sequences, which is called \code{Stream}.
+Para isso, definimos uma nova classe para sequências, que é chamada \code{Stream}.
 
-Streams are created using the constant \code{empty} and the constructor \code{cons},
-which are both defined in module \code{scala.Stream}. For instance, the following
-expression constructs a stream with elements \code{1} and \code{2}:
+Streams são criados usando a constante  \code{empty} e o construtor \code{cons},
+ambos definidos no módulo \code{scala.Stream}. Por exemplo, a seguinte expressão constrói
+um stream como os elementos \code{1} e \code{2}:
 \begin{lstlisting}
 Stream.cons(1, Stream.cons(2, Stream.empty))
 \end{lstlisting}
-As another example, here is the analogue of \code{List.range},
-but returning a stream instead of a list:
+Como um outro exemplo, este é o análogo de \code{List.range},
+mas que retorna um stream ao invés de uma lista:
 \begin{lstlisting}
 def range(start: Int, end: Int): Stream[Int] =
   if (start >= end) Stream.empty
   else Stream.cons(start, range(start + 1, end))
 \end{lstlisting}
-(This function is also defined as given above in module
-\code{Stream}).  Even though \code{Stream.range} and \code{List.range}
-look similar, their execution behavior is completely different: 
+(Esta função também foi definida como mostrado anteriormente no módulo 
+\code{Stream}).  Embora \code{Stream.range} e \code{List.range} se pareçam,
+seu comportamento em tempo de execução é completamente diferente: 
 
-\code{Stream.range} immediately returns with a \code{Stream} object
-whose first element is \code{start}.  All other elements are computed
-only when they are \emph{demanded} by calling the \code{tail} method
-(which might be never at all).  
+\code{Stream.range} retorna imediatamente um objeto do tipo \code{Stream} cujo primeiro
+elemento é \code{start}.  Todos os outros elementos são computados somente quando eles são 
+\emph{demandados} através da chamada do método \code{tail} (o que pode nunca acontecer).  
 
-Streams are accessed just as lists. Similarly to lists, the basic access
-methods are \code{isEmpty}, \code{head} and \code{tail}. For instance,
-we can print all elements of a stream as follows.
+Streams são acessados exatamente como listas. Similarmente às listas, os métodos básicos de acesso são
+ \code{isEmpty}, \code{head} e \code{tail}. Por exemplo, podemos
+imprimir todos os elementos de um stream da seguinte maneira.
 \begin{lstlisting}
 def print(xs: Stream[A]) {
   if (!xs.isEmpty) { Console.println(xs.head); print(xs.tail) }
 }
 \end{lstlisting}
-Streams also support almost all other methods defined on lists (see
-below for where their methods sets differ). For instance, we can find
-the second prime number between \code{1000} and \code{10000} by applying methods
-\code{filter} and \code{apply} on an interval stream:
+Streams também oferecem praticamente todos os outros métodos definidos nas listas (veja a seguir onde
+os conjuntos de métodos são diferentes). Por exemplo, podemos encontrar o segundo número primo entre 
+\code{1000} e \code{10000} através do uso dos métodos 
+\code{filter} e \code{apply} no stream que fornece o intervalo:
 \begin{lstlisting}
   Stream.range(1000, 10000) filter isPrime at 1
 \end{lstlisting}
-The difference to the previous list-based implementation is that now
-we do not needlessly construct and test for primality any numbers
-beyond 1013.
+A diferença entre a implementação anterior que usada lista, é que agora não
+construímos nem testamos se é primo nenhum número maior que 1013.
 
-\paragraph{Consing and appending streams} Two methods in class \code{List}
-which are not supported by class \code{Stream} are \code{::} and
-\code{:::}.  The reason is that these methods are dispatched on their
-right-hand side argument, which means that this argument needs to be
-evaluated before the method is called. For instance, in the case of
-\code{x :: xs} on lists, the tail \code{xs} needs to be evaluated
-before \code{::} can be called and the new list can be constructed.
-This does not work for streams, where we require that the tail of a
-stream should not be evaluated until it is demanded by a \code{tail} operation.
-The argument why list-append \code{:::} cannot be adapted to streams is analogous.
-
-Instead of \code{x :: xs}, one uses \code{Stream.cons(x, xs)} for
-constructing a stream with first element \code{x} and (unevaluated)
-rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
-\code{xs append ys}.  
+\paragraph{Retorno e concatenação de streams} Há dois métodos na classe \code{List}
+que não estão presentes na classe \code{Stream}. São eles \code{::} e
+\code{:::}.  O motivo é que estes métodos são chamados pelo argumento da direita, o
+que significa que este argumento precisa ser computado antes que o método seja chamado.
+Por exemplo, no caso de \code{x :: xs} nas listas, o resto \code{xs} precisa ser computado
+antes de \code{::} ser chamado e a nova lista ser construída.
+Isto não funciona para streams, onde queremos que o resto de um stream 
+não seja computado até que seja demandado pela chamada ao método \code{tail}.
+O argumento pelo qual a concatenação de listas \code{:::} não pode ser adaptado para streams
+é análogo.
 
 Ao inv\'{e}s de \code{x :: xs}, pode-se usar \code{Stream.cons(x, xs)} para
-construir um stream com o primeiro elemento \code{x} e o resto (nao computado)
+construir um stream com o primeiro elemento \code{x} e o resto (n\~{a}o computado).
+Ao invés de \code{xs ::: ys}, pode-se usar \code{xs append ys}.  
 
 
 \chapter{Iteradores}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -9,7 +9,7 @@
 
 \chapter{\label{chap:example-one}Um primeiro exemplo}
 
-Para começar, apresentamos um primeiro exemplo, a implementação de Quicksort em Scala.
+Para comeÃ§ar, apresentamos um primeiro exemplo, a implementaÃ§Ã£o de Quicksort em Scala.
 
 \begin{lstlisting}
 def sort(xs: Array[Int]) {
@@ -35,20 +35,20 @@ def sort(xs: Array[Int]) {
 }
 \end{lstlisting}
 
-A implementação se parece muito com a que você faria em Java
-ou C. Nós usamos os mesmos operadores e estruturas de controle.
-Existem também algumas pequenas diferenças sintáticas, particularmente:
+A implementaÃ§Ã£o se parece muito com a que vocÃª faria em Java
+ou C. NÃ³s usamos os mesmos operadores e estruturas de controle.
+Existem tambÃ©m algumas pequenas diferenÃ§as sintÃ¡ticas, particularmente:
 \begin{itemize}
 \item
-As declarações começam usando palavras reservadas. Particularmente, declarações de funções são iniciadas
-com a palavra \code{def}, declarações de variáveis são iniciadas com a palavra \code{var} e
-declaração de constantes (chamadas de valores) são iniciadas com a palavra \code{val}.
+As declaraÃ§Ãµes comeÃ§am usando palavras reservadas. Particularmente, declaraÃ§Ãµes de funÃ§Ãµes sÃ£o iniciadas
+com a palavra \code{def}, declaraÃ§Ãµes de variÃ¡veis sÃ£o iniciadas com a palavra \code{var} e
+declaraÃ§Ã£o de constantes (chamadas de valores) sÃ£o iniciadas com a palavra \code{val}.
 \item
-O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
+O tipo de um parÃ¢metro em uma funÃ§Ã£o Ã© declarado apÃ³s o nome do parÃ¢metro seguido de dois pontos(:).
 O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
-A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
-O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
+A  declaraÃ§Ã£o de vetores do tipo \code{T} Ã© feita usando a expressÃ£o \code{Array[T]} ao invÃ©s de \code{T[]}. 
+O i-Ã©simo elemento de um vetor \code{a} Ã© acessado usando \code{a(i)} ao invÃ©s de \code{a[i]}.
 %----------
 %\item
 %Functions can be nested inside other functions. Nested functions can
@@ -57,10 +57,10 @@ O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invé
 %\code{swap} and \code{sort1}, and therefore need not be passed as a
 %parameter to them.
 \item
-Funções podem ser aninhadas umas dentro das outras. Funções aninhadas podem
-acessar parâmetros e variáveis locais de suas funções externas. Por
-exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e 
-\code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
+FunÃ§Ãµes podem ser aninhadas umas dentro das outras. FunÃ§Ãµes aninhadas podem
+acessar parÃ¢metros e variÃ¡veis locais de suas funÃ§Ãµes externas. Por
+exemplo, o nome do vetor \code{xs} Ã© visÃ­vel nas funÃ§Ãµes \code{swap} e 
+\code{sort1}, e portanto nÃ£o precisam ser passadas como um parÃ¢metro para elas.
 %----------
 \end{itemize}
 
@@ -76,13 +76,13 @@ exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e
 %completely different. Here is Quicksort again, this time written in
 %functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
-com algumas peculiaridades sintáticas. De fato é possível escrever
-programas em estilo imperativo ou orientado a objetos. Isto é 
-importante, porque é uma das coisas que facilitam combinar componentes
+com algumas peculiaridades sintÃ¡ticas. De fato Ã© possÃ­vel escrever
+programas em estilo imperativo ou orientado a objetos. Isto Ã© 
+importante, porque Ã© uma das coisas que facilitam combinar componentes
 Scala com componentes escritos em linguagens convencionais, tais como Java,
 C\# ou Visual Basic.
-Entretanto, também é possível escrever programas num estilo completamente
-diferente. Aqui está o Quicksort novamente, desta vez escrito em 
+Entretanto, tambÃ©m Ã© possÃ­vel escrever programas num estilo completamente
+diferente. Aqui estÃ¡ o Quicksort novamente, desta vez escrito em 
 estilo funcional.
 %----------
 \begin{lstlisting}
@@ -114,19 +114,19 @@ def sort(xs: Array[Int]): Array[Int] = {
 %% less than or greater or equal to pivot.}
 %% \item The result is obtained by appending the three sub-arrays together.
 %% \end{itemize}
-O programa funcional captura a essência do algoritmo quicksort de modo conciso:
+O programa funcional captura a essÃªncia do algoritmo quicksort de modo conciso:
 \begin{itemize}
-\item Se o vetor está vazio ou consiste de um único elemento, já está ordenado,
-      então retorne imediatamente.
-\item Se o vetor não está vazio, escolha um elemento do meio do vetor como pivô.
+\item Se o vetor estÃ¡ vazio ou consiste de um Ãºnico elemento, jÃ¡ estÃ¡ ordenado,
+      entÃ£o retorne imediatamente.
+\item Se o vetor nÃ£o estÃ¡ vazio, escolha um elemento do meio do vetor como pivÃ´.
 \item Particione o vetor em dois subvetores contendo, respectivamente os elementos
- que são menores que o elemento pivô, maiores que, e um terceiro vetor que contém
- elementos iguais ao pivô.
-\item Ordene os dois primeiros subvetores por uma chamada recursiva da função de 
-ordenação.\footnote{Isso não é exatamente o que o algoritmo imperativo faz; este 
-último particiona o vetor em dois subvetores contendo elementos menores que ou 
-maiores ou iguais ao pivô.}
-\item O resultado é obtido pela concatenação dos três subvetores.
+ que sÃ£o menores que o elemento pivÃ´, maiores que, e um terceiro vetor que contÃ©m
+ elementos iguais ao pivÃ´.
+\item Ordene os dois primeiros subvetores por uma chamada recursiva da funÃ§Ã£o de 
+ordenaÃ§Ã£o.\footnote{Isso nÃ£o Ã© exatamente o que o algoritmo imperativo faz; este 
+Ãºltimo particiona o vetor em dois subvetores contendo elementos menores que ou 
+maiores ou iguais ao pivÃ´.}
+\item O resultado Ã© obtido pela concatenaÃ§Ã£o dos trÃªs subvetores.
 \end{itemize}
 %----------
 
@@ -138,12 +138,12 @@ maiores ou iguais ao pivô.}
 %% implementation returns a new sorted array and leaves the argument
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
-Tanto a implementação imperativa quanto a funcional tem mesma complexidade
-assintótica -- $O(N;log(N))$ no caso médio e $O(Nœô¤æ2)$ no pior caso. Mas onde
-a implementação imperativa opera localmente, modificando o vetor original,
-a implementação funcional retorna um novo vetor ordenado e deixa o vetor
-original inalterado. A implementação funcional, portanto, requer mais
-memória transiente que a imperativa.
+Tanto a implementaÃ§Ã£o imperativa quanto a funcional tem mesma complexidade
+assintÃ³tica -- $O(N;log(N))$ no caso mÃ©dio e $O(NË†2)$ no pior caso. Mas onde
+a implementaÃ§Ã£o imperativa opera localmente, modificando o vetor original,
+a implementaÃ§Ã£o funcional retorna um novo vetor ordenado e deixa o vetor
+original inalterado. A implementaÃ§Ã£o funcional, portanto, requer mais
+memÃ³ria transiente que a imperativa.
 %----------
 
 %----------
@@ -154,12 +154,12 @@ memória transiente que a imperativa.
 %% standard Scala library, and which itself is implemented in
 %% Scala. Because arrays are instances of \verb@Seq@ all sequence
 %% methods are available for them.
-A implementação funcional faz parecer que Scala é uma linguagem
-especializada para operações funcionais sobre vetores. De fato, não é;
-todas as operações usadas no exemplo são simples métodos de biblioteca
-de uma classe {\em sequência} \code{Seq[T]} que é parte da biblioteca
-padrão Scala, e onde ela mesma é implementada em Scala. Como vetores são 
-instâncias de \verb@Seq@, todos os métodos de sequência estão disponíveis
+A implementaÃ§Ã£o funcional faz parecer que Scala Ã© uma linguagem
+especializada para operaÃ§Ãµes funcionais sobre vetores. De fato, nÃ£o Ã©;
+todas as operaÃ§Ãµes usadas no exemplo sÃ£o simples mÃ©todos de biblioteca
+de uma classe {\em sequÃªncia} \code{Seq[T]} que Ã© parte da biblioteca
+padrÃ£o Scala, e onde ela mesma Ã© implementada em Scala. Como vetores sÃ£o 
+instÃ¢ncias de \verb@Seq@, todos os mÃ©todos de sequÃªncia estÃ£o disponÃ­veis
 para eles.
 %----------
 
@@ -170,11 +170,11 @@ para eles.
 %% array consisting of all the elements of the original array for which the
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
-Em particular, há o método \code{filter} que recebe como argumento uma
-{\em função predicado}. Esta função predicado deve mapear elementos do 
-vetor para valores boleanos. O resultado de \code{filter} é um vetor
-consistindo de todos os elementos do vetor original para o qual a função
-predicado é verdadeira. O método \code{filter} de um objeto tipo
+Em particular, hÃ¡ o mÃ©todo \code{filter} que recebe como argumento uma
+{\em funÃ§Ã£o predicado}. Esta funÃ§Ã£o predicado deve mapear elementos do 
+vetor para valores boleanos. O resultado de \code{filter} Ã© um vetor
+consistindo de todos os elementos do vetor original para o qual a funÃ§Ã£o
+predicado Ã© verdadeira. O mÃ©todo \code{filter} de um objeto tipo
 \code{Array[T]} portanto tem a assinatura. 
 %----------
 
@@ -188,11 +188,11 @@ def filter(p: T => Boolean): Array[T]
 %% of type \code{t} and return a \code{Boolean}.  Functions like
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
-Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
+Aqui, \code{T=>Boolean} Ã© o tipo das funÃ§Ãµes que recebem um elemento 
 do tipo \code{T} e retornam um valor booleano do tipo \code{Boolean}. 
-Funções como \code{filter} 
-que recebem uma outra função como argumento ou retornam uma função como
-resultado são chamadas {\em funções de alta ordem.}     
+FunÃ§Ãµes como \code{filter} 
+que recebem uma outra funÃ§Ã£o como argumento ou retornam uma funÃ§Ã£o como
+resultado sÃ£o chamadas {\em funÃ§Ãµes de alta ordem.}     
 %----------
 
 %----------
@@ -205,15 +205,15 @@ resultado são chamadas {\em funções de alta ordem.}
 %% for binary infix operators which start with a letter. Hence, the
 %% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
 %% method call ~\lstinline@xs.filter(pivot >)@.
-Scala não faz distinção entre nomes de identificadores e nomes de operadores.
-um identificador pode ser ou uma sequência de letras ou digitos que começam
-com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
+Scala nÃ£o faz distinÃ§Ã£o entre nomes de identificadores e nomes de operadores.
+um identificador pode ser ou uma sequÃªncia de letras ou digitos que comeÃ§am
+com uma letra, ou podem ser uma sequÃªncia de caracteres especiais, tais como 
 ``\code{+}'', ``\code{*}'', ou ``\code{:}''.  Qualquer identificador pode
-ser usado como operador infixo em Scala. A operação binária $E;op;E'$ é sempre
-interpretado como a chamada de método $E.op(E')$. Isso vale também para 
-operadores binários infixos que iniciam com uma letra. Consequentemente,
-a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
-método ~\lstinline@xs.filter(pivot >)@.
+ser usado como operador infixo em Scala. A operaÃ§Ã£o binÃ¡ria $E;op;E'$ Ã© sempre
+interpretado como a chamada de mÃ©todo $E.op(E')$. Isso vale tambÃ©m para 
+operadores binÃ¡rios infixos que iniciam com uma letra. Consequentemente,
+a expressÃ£o  ~\lstinline@xs filter (pivot >)@~ Ã© equivalente Ã  chamada de
+mÃ©todo ~\lstinline@xs.filter(pivot >)@.
 %----------
 
 
@@ -231,25 +231,25 @@ método ~\lstinline@xs.filter(pivot >)@.
 %% summarize, \code{xs.filter(pivot >)} returns a list consisting
 %% of all elements of the list \code{xs} that are smaller than
 %% \code{pivot}.
-No programa quicksort, \code{filter} é aplicado três vezes a um argumento 
-de função anônima. O primeiro argumento, \code{pivot >}, representa uma 
-função que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
-Este é um exemplo de uma {\em função parcialmente aplicada}. Um outro modo, 
-equivalente de se escrever esta função, que torna o argumento oculto explicito
-é ~\lstinline@x => pivot > x@. A função é anônima, ou seja, não é definida
-com um nome. O tipo do parâmetro  \code{x} é omitido porque um compilador Scala 
-pode inferí-lo automáticamente a partir do contexto onde a função é usada.
+No programa quicksort, \code{filter} Ã© aplicado trÃªs vezes a um argumento 
+de funÃ§Ã£o anÃ´nima. O primeiro argumento, \code{pivot >}, representa uma 
+funÃ§Ã£o que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
+Este Ã© um exemplo de uma {\em funÃ§Ã£o parcialmente aplicada}. Um outro modo, 
+equivalente de se escrever esta funÃ§Ã£o, que torna o argumento oculto explicito
+Ã© ~\lstinline@x => pivot > x@. A funÃ§Ã£o Ã© anÃ´nima, ou seja, nÃ£o Ã© definida
+com um nome. O tipo do parÃ¢metro  \code{x} Ã© omitido porque um compilador Scala 
+pode inferÃ­-lo automÃ¡ticamente a partir do contexto onde a funÃ§Ã£o Ã© usada.
 Resumindo, \code{xs.filter(pivot >)} retorna uma lista consistindo de todos os 
-elementos da lista \code{xs} que são menores que \code{pivot}.  
+elementos da lista \code{xs} que sÃ£o menores que \code{pivot}.  
 %----------
 
 %----------
 %% Looking again in detail at the first, imperative implementation of
 %% Quicksort, we find that many of the language constructs used in the
 %% second solution are also present, albeit in a disguised form.
-Olhando novamente em detalhes para a primeira, implementação imperativa
+Olhando novamente em detalhes para a primeira, implementaÃ§Ã£o imperativa
 do Quicksort, percebemos que muitos dos construtores da linguagem 
-usados na segunda solução estão presentes, embora de modo distinto.
+usados na segunda soluÃ§Ã£o estÃ£o presentes, embora de modo distinto.
 %----------
 
 
@@ -263,23 +263,23 @@ usados na segunda solução estão presentes, embora de modo distinto.
 %% Of course, a compiler is free (if it is moderately smart, even expected)
 %% to recognize the special case of calling the \code{+} method over
 %% integer arguments and to generate efficient inline code for it.
-Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
-ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
-são métodos de seus operandos esquerdos. Consequentemente, a expressão 
-\code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
-do valor inteiro de \code{i}. De fato, um compilador é livre (se 
+Por exemplo, operadores binÃ¡rios padrÃ£o, tais como \code{+}, \code{-},
+ou \code{<} nÃ£o sÃ£o tratados de modo especial. Assim como \code{append}, 
+sÃ£o mÃ©todos de seus operandos esquerdos. Consequentemente, a expressÃ£o 
+\code{i+1} Ã© vista como a invocaÃ§Ã£o de \code{i.+(1)} do mÃ©todo \code{+}      
+do valor inteiro de \code{i}. De fato, um compilador Ã© livre (se 
 moderadamente esperto, ainda que  esperado) para reconhecer o caso 
-especial da chamada de método \code{+} sobre argumentos inteiros e 
-para gerar código inline eficiente para isso.  
+especial da chamada de mÃ©todo \code{+} sobre argumentos inteiros e 
+para gerar cÃ³digo inline eficiente para isso.  
 %----------
 
 %----------
 %% For efficiency and better error diagnostics the \code{while} loop is a
 %% primitive construct in Scala. But in principle, it could have just as
 %% well been a predefined function. Here is a possible implementation of it:
-Por eficiência e melhor detecção de erros o laço \code{while} é um construtor 
-primitivo em Scala. Mas em princípio, poderia do mesmo modo ser uma função 
-predefinida. Aqui está uma possível implementação para ele: 
+Por eficiÃªncia e melhor detecÃ§Ã£o de erros o laÃ§o \code{while} Ã© um construtor 
+primitivo em Scala. Mas em princÃ­pio, poderia do mesmo modo ser uma funÃ§Ã£o 
+predefinida. Aqui estÃ¡ uma possÃ­vel implementaÃ§Ã£o para ele: 
 %----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
@@ -293,11 +293,11 @@ def While (p: => Boolean) (s: => Unit) {
 %% parameter it takes a command function which also takes no parameters
 %% and yields a result of type \lstinline@Unit@. \code{While} invokes the
 %% command function as long as the test function yields true.
-A função \code{While} recebe como primeiro parâmetro uma função teste,
-que não recebe parâmetros e produz um valor boleano. Como segundo parâmetro 
-recebe uma função comando que também não recebe parâmetros e produz como 
-resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
-enquanto a função teste produzir verdadeiro.
+A funÃ§Ã£o \code{While} recebe como primeiro parÃ¢metro uma funÃ§Ã£o teste,
+que nÃ£o recebe parÃ¢metros e produz um valor boleano. Como segundo parÃ¢metro 
+recebe uma funÃ§Ã£o comando que tambÃ©m nÃ£o recebe parÃ¢metros e produz como 
+resultado o tipo  \lstinline@Unit@. \code{While} invoca a funÃ§Ã£o comando
+enquanto a funÃ§Ã£o teste produzir verdadeiro.
 %----------
 
 %----------
@@ -312,13 +312,13 @@ enquanto a função teste produzir verdadeiro.
 %% ``expression-oriented'' formulation of the \lstinline@swap@ function
 %% in the first implementation of quicksort, which makes this explicit:
 O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
-no Java; é usado sempre que uma função não retornar um resultado interessante.
-De fato, porque Scala é uma linguagem orientada a expressões, cada função 
-retorna algum resultado. Se nenhuma expressão de retorno é  explicitamente
-fornecida, o valor \lstinline@()@, que é pronunciado ``unit'', é assumido.
-Este valor é do tipo \lstinline@Unit@. Funções que retornam ``unit'' são 
-também chamadas {\em procedimentos}. Aqui está uma formulação mais 
-``orientada a expressão'' da função \lstinline@swap@ na primeira implementação
+no Java; Ã© usado sempre que uma funÃ§Ã£o nÃ£o retornar um resultado interessante.
+De fato, porque Scala Ã© uma linguagem orientada a expressÃµes, cada funÃ§Ã£o 
+retorna algum resultado. Se nenhuma expressÃ£o de retorno Ã©  explicitamente
+fornecida, o valor \lstinline@()@, que Ã© pronunciado ``unit'', Ã© assumido.
+Este valor Ã© do tipo \lstinline@Unit@. FunÃ§Ãµes que retornam ``unit'' sÃ£o 
+tambÃ©m chamadas {\em procedimentos}. Aqui estÃ¡ uma formulaÃ§Ã£o mais 
+``orientada a expressÃ£o'' da funÃ§Ã£o \lstinline@swap@ na primeira implementaÃ§Ã£o
 do quicksort, que explicita isto:
 %----------
 
@@ -334,10 +334,10 @@ def swap(i: Int, j: Int) {
 %% \lstinline@return@ keyword is not necessary. Note that functions
 %% returning an explicit value always need an ``='' before their
 %% body or defining expression.  
-O valor resultante desta função é simplesmente sua última expressão---uma
-palavra chave \lstinline@return@ não é necessária. Observe que funções 
-que retornam um valor explícito sempre precisam de um ``='' antes de
-seus corpos ou expressões de definição.
+O valor resultante desta funÃ§Ã£o Ã© simplesmente sua Ãºltima expressÃ£o---uma
+palavra chave \lstinline@return@ nÃ£o Ã© necessÃ¡ria. Observe que funÃ§Ãµes 
+que retornam um valor explÃ­cito sempre precisam de um ``='' antes de
+seus corpos ou expressÃµes de definiÃ§Ã£o.
 %----------
 
 \chapter{Programando com Atores e Mensagens}
@@ -351,14 +351,14 @@ seus corpos ou expressões de definição.
 %% its incoming messages which is represented as a queue. It can work
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
-Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
-é particularmente indicada. Considere a tarefa de implementar um serviço
-de leilão eletrônico. Podemos usar um modelo de processo no estilo 
-actor do Erlang para implementar os participantes do leilão. Actors são 
-objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
-para suas mensagens de entrada que é representada para uma fila. Pode
+Aqui estÃ¡ um exemplo que mostra uma Ã¡rea de aplicaÃ§Ã£o para a qual Scala 
+Ã© particularmente indicada. Considere a tarefa de implementar um serviÃ§o
+de leilÃ£o eletrÃ´nico. Podemos usar um modelo de processo no estilo 
+actor do Erlang para implementar os participantes do leilÃ£o. Actors sÃ£o 
+objetos para os quais as mensagens sÃ£o enviadas. Cada actor tem uma caixa de correio 
+para suas mensagens de entrada que Ã© representada para uma fila. Pode
 trabalhar sequencialmente nas mensagens da sua caixa de correio, ou buscar 
-por mensagens que casam com algum padrão. 
+por mensagens que casam com algum padrÃ£o. 
 %----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
@@ -383,11 +383,11 @@ case object AuctionOver                      extends AuctionReply
 %% and that communicates with the seller and winning bidder to close the
 %% transaction. We present an overview of a simple implementation
 %% here.
-Para cada item negociado há um actor leiloeiro que publica a 
-informação sobre o item negociado, que aceita ofertas de clientes
-e que se comunica com o vendedor e com o vencedor do leilão 
-para fechar a transação. Apresentamos uma visão superficial de uma
- implementação aqui.
+Para cada item negociado hÃ¡ um actor leiloeiro que publica a 
+informaÃ§Ã£o sobre o item negociado, que aceita ofertas de clientes
+e que se comunica com o vendedor e com o vencedor do leilÃ£o 
+para fechar a transaÃ§Ã£o. Apresentamos uma visÃ£o superficial de uma
+ implementaÃ§Ã£o aqui.
 %----------
 
 %----------
@@ -397,10 +397,10 @@ para fechar a transação. Apresentamos uma visão superficial de uma
 %% service, and \code{AuctionReply} for replies from the service to the
 %% clients.  For both base classes there exists a number of cases, which
 %% are defined in Figure~\ref{fig:simple-auction-msgs}.
-Como primeiro passo, definimos as mensagens que são trocadas durante um
-leilão. Há duas classes base abstratas \code{AuctionMessage} para mensagens 
-de clientes do serviço de leilão, e \code{AuctionReply} para respostas 
-do serviço aos clientes. Para ambas as classes base há um número de casos 
+Como primeiro passo, definimos as mensagens que sÃ£o trocadas durante um
+leilÃ£o. HÃ¡ duas classes base abstratas \code{AuctionMessage} para mensagens 
+de clientes do serviÃ§o de leilÃ£o, e \code{AuctionReply} para respostas 
+do serviÃ§o aos clientes. Para ambas as classes base hÃ¡ um nÃºmero de casos 
 definidos na Figura~\ref{fig:simple-auction-msgs}.
 %----------
 
@@ -446,14 +446,14 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 %% might well be ultimately mapped to small XML documents. We expect
 %% automatic tools to exist that convert between XML documents and
 %% internal data structures like the ones defined above.
-Para cada classe base, há um número de {\em classes case} que definem
+Para cada classe base, hÃ¡ um nÃºmero de {\em classes case} que definem
 o formato de mensagens particulares dentro da classe. Estas mensagens
-podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
-que hajam ferramentas automáticas que convertam entre documentos XML e 
+podem em Ãºltimo caso ser mapeadas a pequenos documentos XML. Esperamos
+que hajam ferramentas automÃ¡ticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
 % Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
 %
-% Resp: por que trata-se de um modelo de concorrência (o nome do modelo) 
+% Resp: por que trata-se de um modelo de concorrÃªncia (o nome do modelo) 
 % usado por Scala que foi inspirado no modelo do Erlang:
 %      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
@@ -473,19 +473,19 @@ estruturas de dados internas, tais como as definidas acima.
 %% message. Before finally stopping, it stays active for another period
 %% determined by the \code{timeToShutdown} constant and replies to
 %% further offers that the auction is closed.
-A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
-\code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
-para esta classe são criados pela indicação
+A Figura~\ref{fig:simple-auction} apresenta uma implementaÃ§Ã£o Scala para a classe
+\code{Auction} para actors do leilÃ£o que coordenam os lances sobre um item. Objetos
+para esta classe sÃ£o criados pela indicaÃ§Ã£o
 \begin{itemize}
-\item Um actor vendedor que precisa ser notificado quando o leilão terminou,
-\item o lance mínimo,
-\item a data de quando o leilão foi fechado.
+\item Um actor vendedor que precisa ser notificado quando o leilÃ£o terminou,
+\item o lance mÃ­nimo,
+\item a data de quando o leilÃ£o foi fechado.
 \end{itemize}  
-O comportamento do actor é definido por seu método \code{act}. Este método seleciona
-repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, até que o 
-leilão seja fechado, o que é sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
-finalmente parar, permanece ativo para um outro período determinado pela constante 
-\code{timeToShutdown} e replica para ofertas posteriores que o leilão está fechado.    
+O comportamento do actor Ã© definido por seu mÃ©todo \code{act}. Este mÃ©todo seleciona
+repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, atÃ© que o 
+leilÃ£o seja fechado, o que Ã© sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
+finalmente parar, permanece ativo para um outro perÃ­odo determinado pela constante 
+\code{timeToShutdown} e replica para ofertas posteriores que o leilÃ£o estÃ¡ fechado.    
 %----------
 
 %----------
@@ -500,14 +500,14 @@ finalmente parar, permanece ativo para um outro período determinado pela consta
 %% messages matching the pattern. The \code{receiveWithin} method selects
 %% the first message in the mailbox which matches one of these patterns
 %% and applies the corresponding action to it.
-Aqui estão algumas explicações extras sobre os construtores usados neste programa:
+Aqui estÃ£o algumas explicaÃ§Ãµes extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
-O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um prazo dado
-em milisegundos e uma função que processa mensagens na caixa de correio. A função é dada
-por uma sequência de cases que especificam um padrão e uma ação para mensagens que 
-casam com o padrão. O método \code{receiveWithin} seleciona a primeira mensagem da 
-caixa de correio que casa com um destes padrões e aplica a ação correspondente a ele. 
+O mÃ©todo \code{receiveWithin} da classe \code{Actor} recebe como parÃ¢metro um prazo dado
+em milisegundos e uma funÃ§Ã£o que processa mensagens na caixa de correio. A funÃ§Ã£o Ã© dada
+por uma sequÃªncia de cases que especificam um padrÃ£o e uma aÃ§Ã£o para mensagens que 
+casam com o padrÃ£o. O mÃ©todo \code{receiveWithin} seleciona a primeira mensagem da 
+caixa de correio que casa com um destes padrÃµes e aplica a aÃ§Ã£o correspondente a ele. 
 %----------
 
 
@@ -519,10 +519,10 @@ caixa de correio que casa com um destes padrões e aplica a ação correspondent
 %% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
 %% special message, which is triggered by the \code{Actor} implementation itself.
 \item
-O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
-Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrão é disparado
-após o prazo que foi passado como argumento para o método envolvente \code{receiveWithin}.
-\code{TIMEOUT} é uma mensagem especial, que é disparada pela própria implementação do 
+O Ãºltimo case de \code{receiveWithin} Ã© guardado por um padrÃ£o \code{TIMEOUT}.  
+Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrÃ£o Ã© disparado
+apÃ³s o prazo que foi passado como argumento para o mÃ©todo envolvente \code{receiveWithin}.
+\code{TIMEOUT} Ã© uma mensagem especial, que Ã© disparada pela prÃ³pria implementaÃ§Ã£o do 
 \code{Actor}.    
 %----------
 
@@ -537,10 +537,10 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 %% parameter.
 %% \end{itemize}
 \item
-Mensagens de resposta são enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
-\code{!} é usado aqui como um operador binário com um actor e uma mensagem como argumentos.
-Isto é equivalente em Scala ao chamado de método \code{destino.!(AlgumaMensagem)}, ou seja, 
-a invocação do método \code{!} do actor destino com a mensagem dada como parâmetro.
+Mensagens de resposta sÃ£o enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
+\code{!} Ã© usado aqui como um operador binÃ¡rio com um actor e uma mensagem como argumentos.
+Isto Ã© equivalente em Scala ao chamado de mÃ©todo \code{destino.!(AlgumaMensagem)}, ou seja, 
+a invocaÃ§Ã£o do mÃ©todo \code{!} do actor destino com a mensagem dada como parÃ¢metro.
 \end{itemize}    
 %----------
 
@@ -554,14 +554,14 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussão precedente deu uma idéia de programação distribuída em Scala. Isso
-dá a sensação que Scala tem um rico conjunto de construtores que suportam
-processos actor, envio e recebimento de mensagens, programação com timeouts etc.
-De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
-oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
-ele mesma implementada em Scala, baseado no modelo thread subjacente à linguagem 
-hospedeira (Java ou .NET). A implementação de todas as características da 
-classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
+A discussÃ£o precedente deu uma idÃ©ia de programaÃ§Ã£o distribuÃ­da em Scala. Isso
+dÃ¡ a sensaÃ§Ã£o que Scala tem um rico conjunto de construtores que suportam
+processos actor, envio e recebimento de mensagens, programaÃ§Ã£o com timeouts etc.
+De fato, o oposto Ã© verdadeiro. Todos os construtores discutidos acima sÃ£o 
+oferecidos como mÃ©todos na classe biblioteca \code{Actor}. Aquela classe Ã©
+ele mesma implementada em Scala, baseado no modelo thread subjacente Ã  linguagem 
+hospedeira (Java ou .NET). A implementaÃ§Ã£o de todas as caracterÃ­sticas da 
+classe \code{Actor} usada aqui Ã© dada na SeÃ§Ã£o~\ref{sec:actors}.     
 %----------
 
 %----------
@@ -579,38 +579,38 @@ classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
-As vantagens da abordagem baseada em biblioteca são a relativa simplicidade
-da linguagem núcleo e a flexibilidade para os criadores de biblioteca. Como 
-a linguagem núcleo não precisa especificar detalhes da comunicação dos 
-processos de alto nível, pode ser mantida mais simples e geral. Como
-um modelo particular de mensagens numa caixa de correio é um módulo biblioteca, 
-pode ser modificado livremente se um diferente modelo for necessário em algumas 
-aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
-o suficiente para prover as abstrações linguísticas necessárias de um modo 
+As vantagens da abordagem baseada em biblioteca sÃ£o a relativa simplicidade
+da linguagem nÃºcleo e a flexibilidade para os criadores de biblioteca. Como 
+a linguagem nÃºcleo nÃ£o precisa especificar detalhes da comunicaÃ§Ã£o dos 
+processos de alto nÃ­vel, pode ser mantida mais simples e geral. Como
+um modelo particular de mensagens numa caixa de correio Ã© um mÃ³dulo biblioteca, 
+pode ser modificado livremente se um diferente modelo for necessÃ¡rio em algumas 
+aplicaÃ§Ãµes. A abordagem requer, entretanto, que a linguagem nÃºcleo seja expressiva
+o suficiente para prover as abstraÃ§Ãµes linguÃ­sticas necessÃ¡rias de um modo 
 conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
-design foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
-hospedeira para domínios de linguagens específicos implementados por módulos de 
-biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
-pode ser vista como um desses domínios específicos de linguagem, que conceitualmente
-estendem o núcleo Scala.  
+design foi deixÃ¡-la flexÃ­vel o suficiente para atuar como uma conveniente linguagem
+hospedeira para domÃ­nios de linguagens especÃ­ficos implementados por mÃ³dulos de 
+biblioteca. Por exemplo, a construÃ§Ã£o de comunicaÃ§Ã£o actor apresentada acima
+pode ser vista como um desses domÃ­nios especÃ­ficos de linguagem, que conceitualmente
+estendem o nÃºcleo Scala.  
 %----------
 
 %----------
 % Vinicius - comecei traducao aqui.
 %%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
-\chapter{\label{chap:simple-funs}Expressões e Funções Simples}
+\chapter{\label{chap:simple-funs}ExpressÃµes e FunÃ§Ãµes Simples}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
 Os exemplos anteriores deram uma ideia do que pode ser feito com Scala. Agora,
-introduzimos as suas construções de linguagem uma a uma de uma maneira mais sistemática.
-Vamos começar com os menores elementos: expressões e funções.
+introduzimos as suas construÃ§Ãµes de linguagem uma a uma de uma maneira mais sistemÃ¡tica.
+Vamos comeÃ§ar com os menores elementos: expressÃµes e funÃ§Ãµes.
 
 
 %%\section{Expressions And Simple Functions}
-\section{Expressões e Funções Simples}
+\section{ExpressÃµes e FunÃ§Ãµes Simples}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
@@ -618,8 +618,8 @@ Vamos começar com os menores elementos: expressões e funções.
 %% types. For example:
 %----------
 Scala vem com um interpretador que pode ser visto como uma calculadora sofisticada.
-O usuário interage com a calculadora digitando expressões. A calculadora retorna o
-resultado do cálculo e o seu tipo de dado. Por exemplo: 
+O usuÃ¡rio interage com a calculadora digitando expressÃµes. A calculadora retorna o
+resultado do cÃ¡lculo e o seu tipo de dado. Por exemplo: 
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -633,8 +633,8 @@ unnamed2: java.lang.String = hello world!
 \end{lstlisting}
 %It is also possible to name a sub-expression and use the name instead
 %of the expression afterwards:
-Também é possível dar nome a uma sub-expressão e usar o nome, ao invés da expressão, 
-nas expressões seguintes:
+TambÃ©m Ã© possÃ­vel dar nome a uma sub-expressÃ£o e usar o nome, ao invÃ©s da expressÃ£o, 
+nas expressÃµes seguintes:
 \begin{lstlisting}
 scala> def scale = 5
 scale: Int
@@ -658,8 +658,8 @@ unnamed4: Double = 62.83185307179586
 %% Definitions start with the reserved word \code{def}; they introduce a
 %% name which stands for the expression following the \code{=} sign.  The
 %% interpreter will answer with the introduced name and its type.
-Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
-que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
+DefiniÃ§Ãµes comeÃ§am com a palavra reservada \code{def}. Elas introduzem um nome
+que representa a expressÃ£o que vem depois do sÃ­mbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
 % Vinicius - parei traducao aqui.
 
@@ -673,11 +673,11 @@ responde com o nome introduzido e o seu tipo de dado.
 %% evaluation of the definition. If \code{x} is then used subsequently,
 %% it is immediately replaced by the pre-computed value of
 %% \code{e}, so that the expression need not be evaluated again.
-Executando uma definição tal como \code{def x = e} não avaliará a expressão \code{e}. 
-Ao invés \code{e} é avaliado sempre que \code{x} for usado. Alternativamente, Scala 
-oferece um valor definição \code{val x = e}, o qual avalia o lado direito de \code{e}
-como parte da avaliação da definição. Se \code{x} é então usado subsequentemente, é 
-imediatamente substituído pelo valor pré-computado de \code{e}, logo a expressão não 
+Executando uma definiÃ§Ã£o tal como \code{def x = e} nÃ£o avaliarÃ¡ a expressÃ£o \code{e}. 
+Ao invÃ©s \code{e} Ã© avaliado sempre que \code{x} for usado. Alternativamente, Scala 
+oferece um valor definiÃ§Ã£o \code{val x = e}, o qual avalia o lado direito de \code{e}
+como parte da avaliaÃ§Ã£o da definiÃ§Ã£o. Se \code{x} Ã© entÃ£o usado subsequentemente, Ã© 
+imediatamente substituÃ­do pelo valor prÃ©-computado de \code{e}, logo a expressÃ£o nÃ£o 
 precisa ser avaliada novamente.
 %----------
 
@@ -696,17 +696,17 @@ precisa ser avaliada novamente.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
-Como as expressões são avaliadas? Uma expressão consistindo de operadores e 
-operandos é avaliada pela repetida aplicação dos seguintes passos de simplificação:
+Como as expressÃµes sÃ£o avaliadas? Uma expressÃ£o consistindo de operadores e 
+operandos Ã© avaliada pela repetida aplicaÃ§Ã£o dos seguintes passos de simplificaÃ§Ã£o:
 \begin{itemize}
-\item escolha a operação mais a esquerda.
+\item escolha a operaÃ§Ã£o mais a esquerda.
 \item avalie seu operando
 \item aplique o operador aos valores do operando.
 \end{itemize}
-Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
-direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
-nome pelo valor da definição do lado direito. O processo de avaliação pára assim que 
-encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
+Um nome definido por \code{def} Ã© avaliado substituindo o nome pela definiÃ§Ã£o do lado
+direito (nÃ£o avaliada). Um nome definido por \code{val} Ã© avaliado pela substituiÃ§Ã£o do 
+nome pelo valor da definiÃ§Ã£o do lado direito. O processo de avaliaÃ§Ã£o pÃ¡ra assim que 
+encontrarmos um valor. Um valor Ã© algum dado, tal como uma cadeia de caracteres, um nÃºmero, 
 um vetor, ou uma lista.
 %----------
 
@@ -725,7 +725,7 @@ um vetor, ou uma lista.
 %% called {\em reduction}.
 
 \example
-Aqui está uma avaliação de uma expressão aritmética.
+Aqui estÃ¡ uma avaliaÃ§Ã£o de uma expressÃ£o aritmÃ©tica.
 
 \begin{lstlisting}
 $\,\,\,$   (2 * pi) * radius
@@ -734,15 +734,15 @@ $\rightarrow$  6.283185307179586 * radius
 $\rightarrow$  6.283185307179586 * 10
 $\rightarrow$  62.83185307179586
 \end{lstlisting}
-O processo de simplificar gradualmente expressões para valores é 
-chamado {\em redução}.
+O processo de simplificar gradualmente expressÃµes para valores Ã© 
+chamado {\em reduÃ§Ã£o}.
 %----------
 
 
 \section{Parameters}
 
 %% Using \code{def}, one can also define functions with parameters. For example:
-Usando \code{def}, pode-se também definir funções com parâmetros. Por exemplo:
+Usando \code{def}, pode-se tambÃ©m definir funÃ§Ãµes com parÃ¢metros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -763,7 +763,7 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
-%----------
+%----------xpto
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
 %% following the parameter name and a colon.  At the present time, we
@@ -772,13 +772,9 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
-Parâmetros de funções seguem o nome da função e sempre são envolvidos por
-parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
-e dois pontos. Até aqui, só precisamos de tipos numéricos, tal como o tipo
-\code{scala.Double} dos números de precisão dupla. Scala define {\em tipos
-aliases} para alguns tipos básicos, logo podemos escrever tipos numéricos 
-como em Java. Por exemplo, \code{double} é um tipo alias de \code{scala.Double}
-e \code{int} é um tipo alias para \code{scala.Int}.       
+ParÃ¢metros de funÃ§Ãµes seguem o nome da funÃ§Ã£o e sempre sÃ£o envolvidos por
+parÃªnteses. Cada parÃ¢metro vem com um tipo que segue o nome do parÃ¢metro
+e dois pontos. AtÃ© aqui, sÃ³ precisamos de tipos numÃ©ricos   
 %----------
 
 %----------
@@ -788,11 +784,6 @@ e \code{int} é um tipo alias para \code{scala.Int}.
 %% the function's right hand side, and at the same time all formal
 %% parameters of the function are replaced by their corresponding actual
 %% arguments.
-Funções com parâmetros são avaliadas analogamente a operadores em expressões.
-Primeiro, os argumentos da função são avaliados (da esquerda para direita). 
-Então, a aplicação da função é substituído pelo lado direito da função, e
-ao mesmo tempo todos os parâmetros formais são substituídos pelos seus 
-argumentos atuais. 
 %----------
 
 \example\ 
@@ -813,10 +804,6 @@ $\rightarrow$  25
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
 %% have yielded the following reduction sequence:
-O exemplo mostra que o interpretador reduz argumentos de funções a valores 
-antes de reescrever a aplicação da função. Pode-se ao invés escolher aplicar
-a função a argumentos não reduzidos. Isto levará a seguinte sequência de 
-redução: 
 %----------
 
 \begin{lstlisting}
@@ -836,10 +823,6 @@ $\rightarrow$  25
 %% expressions that use only pure functions and that therefore can be
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
-A segunda ordem de avaliação é conhecida como \emph{chamada por nome},
-e a primeira por \emph{chamada por valor}. Para expressões que se utilizam
-apenas de funções e que portanto podem ser reduzidas com o modelo de 
-substituição, ambos os esquemas levam ao mesmo valor final.
 %----------
 
 %----------
@@ -849,13 +832,8 @@ substituição, ambos os esquemas levam ao mesmo valor final.
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
-Chamada por valor tem a vantagem de evitar avaliações repetidas de argumentos.
-Chamada por nome tem a vantagem de evitar avaliações de argumentos quando o 
-parâmetro não é usado pela função. Chamada por valor é geralmente mais 
-eficiente que chamada por nome, mas uma avaliação de chamada por valor
-pode entrar em laço infinito, enquanto uma avaliação de chamada por nome 
-termina. Considere: 
 %----------
+
 \begin{lstlisting}
 scala> def loop: Int = loop
 loop: Int
@@ -867,9 +845,6 @@ first: (Int,Int)Int
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
-Então \code{first(1, loop)} é reduzido com uma chamada por nome a \code{1},
-enquanto o mesmo termo, através de uma chamada por valor reduz a si mesmo 
-repetidamente, logo a avaliação não termina.  
 %----------
 \begin{lstlisting}
 $\,\,\,$   first(1, loop)
@@ -880,8 +855,7 @@ $\rightarrow$  ...
 %----------
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
-Scala usa chamada por valor por default, mas muda para avaliação de chamada por nome 
-se o tipo do parâmetro for precedido por \code{=>}. 
+
 \example\ 
  
 \begin{lstlisting}
@@ -891,8 +865,8 @@ constOne: (Int,=> Int)Int
 scala> constOne(1, loop)
 unnamed0: Int = 1
 
-scala> constOne(loop, 2)               // leva a laço infinito
-^C                                     // para a execução com Ctrl-C
+scala> constOne(loop, 2)               // gives an infinite loop.
+^C                                     // stops execution with Ctrl-C
 \end{lstlisting}
 %----------
 
@@ -906,13 +880,6 @@ scala> constOne(loop, 2)               // leva a laço infinito
 %% same syntax to choose between two expressions. That's why Scala's
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
-\section{Expressões Condicionais}
-O \code{if-else} do Scala leva a uma escolha entre duas alternativas. Sua
-sintaxe é a mesma do \code{if-else} do Java. Mas onde o \code{if-else} do 
-Java pode ser usado somente como uma alternativa entre comandos, Scala 
-permite a mesma sintaxe para escolher entre duas expressões. Isso porque o
-\code{if-else} do Scala serve também como um substituto para a expressão 
-condicional do Java \code{... ? ... : ...}.      
 %----------
 
 %----------
@@ -927,16 +894,6 @@ condicional do Java \code{... ? ... : ...}.
 %% \code{true} and
 %% \code{false}, comparison operators, boolean negation \code{!} and the
 %% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
-\exemplo\
-\begin{lstlisting}
-scala> def abs(x: Double) = if (x >= 0) x else -x
-abs: (Double)Double
-\end{lstlisting}
-Expressões boleanas em Scala são similares as em Java; são formadas
-a partir de constantes.  
-\code{true} e
-\code{false}, operadores de comparação, negação boleana \code{!} e os 
-operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}. 
 %----------
 
 %----------
@@ -949,14 +906,6 @@ operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}.
 %% def sqrt(x: Double): Double = ...
 %% \end{lstlisting}
 %% which computes the square root of \code{x}.
-
-%% \section{\label{sec:sqrt}Example: Raiz Quadrada pelo Método de Newton}
-Agora ilustraremos elementos da linguagem intruduzidos até aqui na
-construção de um programa mais interessante. A tarefa é escrever um função  
- \begin{lstlisting}
- def sqrt(x: Double): Double = ...
- \end{lstlisting}
-que computa a raiz quadrada de \code{x}. 
 %----------
 
 %----------
@@ -967,21 +916,14 @@ que computa a raiz quadrada de \code{x}.
 %% example, the next three columns indicate the guess \code{y}, the
 %% quotient \code{x/y}, and their average for the first approximations of
 %% $\sqrt 2$.
-Um modo comum de se computar raizes quadradas é pelo método das aproximações
-sucessivas de Newton. Inicia-se com um palpite inicial \code{y} (digamos:
-\code{y = 1}). Então melhora-se repetidamente o atual palpite \code{y} 
-tomando-se a média de \code{y} e \code{x/y}. Como um exemplo, as próximas
-três colunas indicam o palpite \code{y}, o quociente \code{x/y}, e suas
-médias para as primeiras aproximações para $\sqrt 2$.       
+%% \begin{lstlisting}
+%% 1            2/1 = 2               1.5
+%% 1.5          2/1.5 = 1.3333        1.4167
+%% 1.4167       2/1.4167 = 1.4118     1.4142
+%% 1.4142       ...                   ...
 
-\begin{lstlisting}
-1            2/1 = 2               1.5
-1.5          2/1.5 = 1.3333        1.4167
-1.4167       2/1.4167 = 1.4118     1.4142
-1.4142       ...                   ...
-
-$y$            $x/y$                   $(y + x/y)/2$
-\end{lstlisting}
+%% $y$            $x/y$                   $(y + x/y)/2$
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -989,28 +931,14 @@ $y$            $x/y$                   $(y + x/y)/2$
 %% which each represent one of the elements of the algorithm.  
 
 %% We first define a function for iterating from a guess to the result:
-
-Este algoritmo pode ser implementado em Scala por um conjunto de pequenas funções,
-onde cada uma representa um dos elementos do algoritmo.
-
-Primeiro definimos uma função para iterar do palpite para o resultado:
-%-----------
-
-
-\begin{lstlisting}
-def sqrtIter(guess: Double, x: Double): Double =
-  if (isGoodEnough(guess, x)) guess
-  else sqrtIter(improve(guess, x), x)
-\end{lstlisting}
-
-%-----------
+%% \begin{lstlisting}
+%% def sqrtIter(guess: Double, x: Double): Double =
+%%   if (isGoodEnough(guess, x)) guess
+%%   else sqrtIter(improve(guess, x), x)
+%% \end{lstlisting}
 %% Note that \code{sqrtIter} calls itself recursively.  Loops in
 %% imperative programs can always be modeled by recursion in functional
-%% programs.
- 
-Observe que \code{sqrtIter} chama a si mesmo recursivamente. Laços em 
-programas imperativos podem sempre ser modelados por recursão em 
-programas funcionais. 
+%% programs. 
 %----------
 
 %----------
@@ -1021,38 +949,27 @@ programas funcionais.
 %% compute it from the type of the function's right-hand side. However,
 %% even for non-recursive functions it is often a good idea to include a
 %% return type for better documentation.
-Observe também que a definição de \code{sqrtIter} contém um tipo retorno,
-que segue o seção de parâmetros. Tais tipos de retorno são mandatórios para 
-funções recursivas. Para uma função não recursiva, o tipo de retorno é opcional;
-se estiver faltando o verificador de tipos o computará a partir do tipo do lado
-direito da função. Entretanto, mesmo para funções não recursivas é sempre boa idéia 
-incluir um tipo de retorno para melhor documentação.  
 %----------
 
 %----------
 %% As a second step, we define the two functions called by
 %% \code{sqrtIter}: a function to \code{improve} the guess and a
 %% termination test \code{isGoodEnough}. Here is their definition.
+%% \begin{lstlisting}
+%% def improve(guess: Double, x: Double) =
+%%   (guess + x / guess) / 2
+%----------
 
-Como segundo passo, definimos as duas funções chamadas por:
-\code{sqrtIter}: uma função para melhorar (\code{improve}) o palpite e um
-teste de terminação \code{isGoodEnough}. Aqui estão suas definições.
-\begin{lstlisting}
-def improve(guess: Double, x: Double) =
-  (guess + x / guess) / 2    
-
-def isGoodEnough(guess: Double, x: Double) =
-  abs(square(guess) - x) < 0.001
-\end{lstlisting}
+%----------
+%% def isGoodEnough(guess: Double, x: Double) =
+%%   abs(square(guess) - x) < 0.001
+%% \end{lstlisting}
 
 %% Finally, the \code{sqrt} function itself is defined by an application
 %% of \code{sqrtIter}.
-Finalmente, a própria função \code{sqrt} é definida como uma aplicação de
-\code{sqrtIter}.
-  
-\begin{lstlisting}
-def sqrt(x: Double) = sqrtIter(1.0, x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = sqrtIter(1.0, x)
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1064,13 +981,6 @@ def sqrt(x: Double) = sqrtIter(1.0, x)
 
 %% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
 %% \end{exercise}
-\begin{exercise} O teste \code{isGoodEnough} não é muito preciso para pequenos 
-números e podem levar a não terminação para números muito grandes (por que?).
-Crie uma versão diferente para \code{isGoodEnough} que não tenham esses problemas.
-\end{exercise}
-
-\begin{exercise} Simule a execução da expressão \code{sqrt(4)}.
-\end{exercise}
 %----------
 
 %----------
@@ -1082,33 +992,23 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 %% \code{improve} and \code{isGoodEnough}. The names of these functions
 %% are relevant only for the implementation of \code{sqrt}. We normally
 %% do not want users of \code{sqrt} to access these functions directly.
-\section{Aninhamento de Funções}
-
-A programação funcional encoraja a construção de muitas pequenas funções
-auxiliares. Nos últimos exemplos, a implementação de \code{sqrt} faz uso da
-funções auxiliares \code{sqrtIter}, \code{improve} e \code{isGoodEnough}.
-Os nomes destas funções são relevantes somente para a implementação de 
-\code{sqrt}. Normalmente não queremos que os usuários de \code{sqrt} acessem
-estas funções diretamente.  
 %----------
 
 %----------
 %% We can enforce this (and avoid name-space pollution) by including
 %% the helper functions within the calling function itself:
-Nós podemos reforçar isto (e evitar poluição de nomes) incluindo
-funções auxiliares dentro das próprias funções: 
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double, x: Double): Double =
-    if (isGoodEnough(guess, x)) guess
-    else sqrtIter(improve(guess, x), x)
-  def improve(guess: Double, x: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double, x: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0, x)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double, x: Double): Double =
+%%     if (isGoodEnough(guess, x)) guess
+%%     else sqrtIter(improve(guess, x), x)
+%%   def improve(guess: Double, x: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double, x: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0, x)
+%% }
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1117,11 +1017,6 @@ def sqrt(x: Double) = {
 %% result expression which defines its value.  The result expression may
 %% be preceded by auxiliary definitions, which are visible only in the
 %% block itself.
-Neste programa, as chaves \code{\{ ... \}} envolvem um {\em bloco}. 
-Blocos em Scala são eles mesmos expressões. Cada bloco termina com um
-expressão resultado o qual define seu valor. A expressão  resultado pode 
-ser precedida por definições auxiliares, as quais são visíveis somente no
-próprio bloco. 
 %----------
 
 %----------
@@ -1130,10 +1025,6 @@ próprio bloco.
 %% expression. However, a semicolon is inserted implicitly at the end of
 %% each line, unless one of the following conditions is
 %% true.
-Cada definição no bloco pode ser seguida para um ponto e vírgula, o qual 
-separa esta definição das definições subsequentes ou a expressão  resultado.
-Entretanto, um ponto e vírgula é inserido implicitamente ao final de cada linha,
-a não ser que uma das condições a seguir seja verdadeira.
 %----------
 
 %----------
@@ -1147,42 +1038,30 @@ a não ser que uma das condições a seguir seja verdadeira.
 %% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
 %% because these cannot contain multiple statements anyway.
 %% \end{enumerate}
-\begin{enumerate}
-\item 
-Ou a linha em questão termina com uma palavra tal que um ponto ou um 
-operador infixo não são legais ao final da expressão.
-\item 
-Ou a próxima linha inicia com uma palavra que não pode iniciar uma expressão.
-\item
-Ou estamos dentro de parênteses \prog{$($...$)$} ou chaves \prog{}, porque 
-estes não podem conter multiplos comandos de qualquer modo.
-\end{enumerate}
 %----------
 
 %----------
 %% Therefore, the following are all legal:
-Entretanto, os seguintes são legais:
+%% \begin{lstlisting}
+%% def f(x: Int) = x + 1;
+%% f(1) + f(2)
 
-\begin{lstlisting}
-def f(x: Int) = x + 1;
-f(1) + f(2)
+%% def g1(x: Int) = x + 1
+%% g(1) + g(2)
 
-def g1(x: Int) = x + 1
-g(1) + g(2)
+%% def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
 
-def g2(x: Int) = {x + 1};  /* `;' mandatório */ g2(1) + g2(2)
+%% def h1(x) = 
+%%   x + 
+%%   y
+%% h1(1) * h1(2)
 
-def h1(x) = 
-  x + 
-  y
-h1(1) * h1(2)
-
-def h2(x: Int) = (
-  x     // parênteses mandatório, senão um ponto e vírgula
-  + y   // será inserido após o `x'.
-)
-h2(1) / h2(2)
-\end{lstlisting}
+%% def h2(x: Int) = (
+%%   x     // parentheses mandatory, otherwise a semicolon
+%%   + y   // would be inserted after the `x'.
+%% )
+%% h2(1) / h2(2)
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1192,100 +1071,76 @@ h2(1) / h2(2)
 %% \code{sqrt} example. We need not pass \code{x} around as an additional parameter of
 %% the nested functions, since it is always visible in them as a
 %% parameter of the outer function \code{sqrt}. Here is the simplified code:
-Scala usa as regras usuais de escopo de bloco estruturado. Um nome definido em
-algum outro bloco é também visível em algum bloco interno, desde que não tenha
-sido redefinido lá. Esta regra nos permite simplificar nosso exemplo \code{sqrt}.
-Não precisamos passar \code{x} como parâmetro adicional de funções aninhadas, dado
-que está sempre visível nelas como um parâmetro da função externa \code{sqrt}.
-Aqui está o código simplificado:
-   
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double): Double =
-    if (isGoodEnough(guess)) guess
-    else sqrtIter(improve(guess))
-  def improve(guess: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double): Double =
+%%     if (isGoodEnough(guess)) guess
+%%     else sqrtIter(improve(guess))
+%%   def improve(guess: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0)
+%% }
+%% \end{lstlisting}
 %----------
 
 
-\section{Tail Recursion}
+%% \section{Tail Recursion}
 
-%%Consider the following function to compute the greatest common divisor
-%%of two given numbers.
-Considere a seguinte função para calcular o maior divisor comum entre
-dois números dados.
+%% Consider the following function to compute the greatest common divisor
+%% of two given numbers.
 
-\begin{lstlisting}
-def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+%% \end{lstlisting}
 
-%%Using our substitution model of function evaluation, 
-Usando nosso modelo de substituição da função de avaliação,
-\code{gcd(14, 21)} evaluates as follows:
+%% Using our substitution model of function evaluation, 
+%% \code{gcd(14, 21)} evaluates as follows:
 
-\begin{lstlisting}
-$\,\,$      gcd(14, 21)  
-$\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14)
-$\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
-$\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
-$\rightarrow\!$     gcd(14, 7)
-$\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
-$\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
-$\rightarrow\!$     gcd(7, 0)
-$\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
-$\rightarrow$ $\rightarrow$  7
-\end{lstlisting}
+%% \begin{lstlisting}
+%% $\,\,$      gcd(14, 21)  
+%% $\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14)
+%% $\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
+%% $\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
+%% $\rightarrow\!$     gcd(14, 7)
+%% $\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
+%% $\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
+%% $\rightarrow\!$     gcd(7, 0)
+%% $\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
+%% $\rightarrow$ $\rightarrow$  7
+%% \end{lstlisting}
 
-%%Contrast this with the evaluation of another recursive function, 
-Contraste isto com a avaliação de uma outra função recursiva,
-\code{factorial}:
+%% Contrast this with the evaluation of another recursive function, 
+%% \code{factorial}:
 
-\begin{lstlisting}
-def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
+%% \end{lstlisting}
 
-%%The application \code{factorial(5)} rewrites as follows:
-A aplicação de \code{factorial(5)} é reescrita como segue: 
-
-\begin{lstlisting}
-$\,\,\,$       factorial(5)
-$\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(4)
-$\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
-$\rightarrow\ldots\rightarrow$  120
-\end{lstlisting}
-
-%----------
+%% The application \code{factorial(5)} rewrites as follows:
+%% \begin{lstlisting}
+%% $\,\,\,$       factorial(5)
+%% $\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(4)
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
+%% $\rightarrow\ldots\rightarrow$  120
+%% \end{lstlisting}
 %% There is an important difference between the two rewrite sequences:
 %% The terms in the rewrite sequence of \code{gcd} have again and again
 %% the same form. As evaluation proceeds, their size is bounded by a
 %% constant. By contrast, in the evaluation of factorial we get longer
 %% and longer chains of operands which are then multiplied in the last
 %% part of the evaluation sequence.
-Há uma importante diferença entre as duas sentenças reescritas:
-Os termos na sequência reescrita de \code{gcd} tem repetidamente a
-mesma forma. Conforme a avaliação prossegue, seu tamanho é limitado por
-uma constante. Diferentemente, na avaliação do fatorial obtemos cadeias
-cada vez mais longas de operandos que são então multiplicados na última
-parte da sequência de avaliação. 
-%----------
 
-
-%----------xpto
 %% Even though actual implementations of Scala do not work by rewriting
 %% terms, they nevertheless should have the same space behavior as in the
 %% rewrite sequences. In the implementation of \code{gcd}, one notes that
@@ -1297,21 +1152,14 @@ parte da sequência de avaliação.
 %% instantiation of \code{gcd}, so that no new stack space is needed.
 %% Hence, tail recursive functions are iterative processes, which can be
 %% executed in constant space.
-Ainda que as atuais implementações de Scala não trabalhem reescrevendo
-termos, elas contudo devem ter o mesmo comportamento de espaço que nas
-sequências reescritas. 
-%----------
 
-%----------
 %% By contrast, the recursive call in \code{factorial} is followed by a
 %% multiplication.  Hence, a new stack frame is allocated for the
 %% recursive instance of factorial, and is deallocated after that
 %% instance has finished. The given formulation of the factorial function
 %% is not tail-recursive; it needs space proportional to its input
 %% parameter for its execution.
-%----------
 
-%----------
 %% More generally, if the last action of a function is a call to another
 %% (possibly the same) function, only a single stack frame is needed for
 %% both functions. Such calls are called ``tail calls''. In principle,
@@ -1322,14 +1170,11 @@ sequências reescritas.
 %% re-use the stack frame of a directly tail-recursive function whose
 %% last action is a call to itself.  Other tail calls might be optimized
 %% also, but one should not rely on this across implementations.
-%----------
 
 %% \begin{exercise} Design a tail-recursive version of
 %% \code{factorial}.
 %% \end{exercise}
 
-
-%----------
 %% \chapter{\label{chap:first-class-funs}First-Class Functions}
 
 %% A function in Scala is a ``first-class value''. Like any other value,
@@ -1338,9 +1183,7 @@ sequências reescritas.
 %% called {\em higher-order} functions. This chapter introduces
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
-%----------
 
-%----------
 %% As a motivating example, consider the following three related tasks:
 %% \begin{enumerate}
 %% \item
@@ -1349,9 +1192,6 @@ sequências reescritas.
 %% def sumInts(a: Int, b: Int): Int =
 %%   if (a > b) 0 else a + sumInts(a + 1, b)
 %% \end{lstlisting}
-%----------
-
-%----------
 %% \item 
 %% Write a function to sum the squares of all integers between two given numbers 
 %% \code{a} and \code{b}:
@@ -1369,9 +1209,6 @@ sequências reescritas.
 %%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
 %% \end{lstlisting}
 %% \end{enumerate}
-%----------
-
-%----------
 %% These functions are all instances of
 %% \(\sum^b_a f(n)\) for different values of $f$. 
 %% We can factor out the common pattern by defining a function \code{sum}:
@@ -1384,9 +1221,7 @@ sequências reescritas.
 %% \code{Int}. So \code{sum} is a function which takes another function as
 %% a parameter. In other words, \code{sum} is a {\em higher-order}
 %% function.
-%----------
 
-%----------
 %% Using \code{sum}, we can formulate the three summing functions as
 %% follows.
 %% \begin{lstlisting}
@@ -1400,18 +1235,14 @@ sequências reescritas.
 %% def square(x: Int): Int = x * x
 %% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
 %% \end{lstlisting}
-%----------
 
-%----------
 %% \section{Anonymous Functions}
 
 %% Parameterization by functions tends to create many small functions. In
 %% the previous example, we defined \code{id}, \code{square} and
 %% \code{power} as separate functions, so that they could be 
 %% passed as arguments to \code{sum}.
-%----------
 
-%----------
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a
@@ -1420,9 +1251,6 @@ sequências reescritas.
 %% \begin{lstlisting}
 %%   (x: Int) => x * x
 %% \end{lstlisting}
-%----------
-
-
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -63,17 +63,24 @@ exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e
 \code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
 %----------
 \end{itemize}
-So far, Scala looks like a fairly conventional language with some
-syntactic peculiarities. In fact it is possible to write programs in a
-conventional imperative or object-oriented style. This is important
-because it is one of the things that makes it easy to combine Scala
-components with components written in mainstream languages such as
-Java, C\# or Visual Basic.
 
-However, it is also possible to write programs in a style which looks
-completely different. Here is Quicksort again, this time written in
-functional style.
+%----------
+%So far, Scala looks like a fairly conventional language with some
+%syntactic peculiarities. In fact it is possible to write programs in a
+%conventional imperative or object-oriented style. This is important
+%because it is one of the things that makes it easy to combine Scala
+%components with components written in mainstream languages such as
+%Java, C\# or Visual Basic.
+%
+%However, it is also possible to write programs in a style which looks
+%completely different. Here is Quicksort again, this time written in
+%functional style.
+Pelo que vimos, Scala se parece com uma linguagem bem convencional 
+com algumas peculiaridades sintáticas. De fato é possível escrever
+programas em estilo imperativo ou orientado a objetos. 
 
+
+%----------
 \begin{lstlisting}
 def sort(xs: Array[Int]): Array[Int] = {
   if (xs.length <= 1) xs

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4148,14 +4148,6 @@ val empty: List[Int]       = List()
 \end{lstlisting}
 
 \paragraph{Construtores de listas}
-All lists are built from two more fundamental constructors, \code{Nil}
-and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
-list. The infix operator \code{::} expresses list extension. That is,
-\code{x :: xs} represents a list whose first element is \code{x},
-which is followed by (the elements of) list \code{xs}.  Hence, the
-list values above could also have been defined as follows (in fact
-their previous definition is simply syntactic sugar for the definitions below).
-
 Todas as listas são construídas a partir de dois construtores fundamentais, \code{Nil} e 
 \code{::} (lê-se ``cons''). \code{Nil} representa uma lista vazia. O operador infixo 
 \code{::} expressa a extensão da lista. Ou seja, \code{x :: xs} denota uma lista 
@@ -4178,7 +4170,6 @@ val nums  =  1 :: 2 :: 3 :: 4 :: Nil
 \end{lstlisting}
 
 \paragraph{Operações básicas sobre listas}
-All operations on lists can be expressed in terms of the following three:
 Todas as operações sobre listas podem ser expressas em termos das três a seguir:
 
 \begin{tabular}{ll}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6743,10 +6743,11 @@ implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
 }
 \end{lstlisting}
 
-\subsection*{View Bounds}
+\subsection*{Parâmetros de Tipos Delimitados}
 
-View bounds are convenient syntactic sugar for implicit
-parameters. Consider for instance a generic sort method:
+Parâmetros de Tipos Delimitados\footnote{View bounds} são uma sintaxe simplificada\footnote{Syntactic sugar}
+ e conveniente para parâmetros implícitos. 
+Considere por exemplo, um método de ordenação genérico:
 \begin{lstlisting}
 def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
   if (xs.isEmpty || xs.tail.isEmpty) xs
@@ -6755,20 +6756,19 @@ def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
     merge(ys, zs)
   }
 \end{lstlisting}
-The view bounded type parameter \lstinline@[a <$\mbox{\%}$ Ordered[a]]@
-expresses that \lstinline@sort@ is applicable to lists of type
-\lstinline@a@ such that there exists an implicit conversion from
-\lstinline@a@ to \lstinline@Ordered[a]@. The definition is treated as
-a shorthand for the following method signature with an implicit
-parameter:
+O parâmetros de tipo delimitado \lstinline@[A <$\mbox{\%}$ Ordered[A]]@
+expressa que  \lstinline@sort@ pode ser usado com listas do tipo 
+\lstinline@A@ onde exista uma conversão implícita de 
+\lstinline@A@ para \lstinline@Ordered[A]@. A definição é tratada como um atalho para a seguinte
+assinatura de método com parâmetro implícito:
 \begin{lstlisting}
 def sort[A](xs: List[A])(implicit $c$: A => Ordered[A]): List[A] = ...
 \end{lstlisting}
-(Here, the parameter name $c$ is chosen arbitrarily in a way
-that does not collide with other names in the program.)
+(Aqui o nome do parâmetro $c$ foi escolhido arbitrariamente, garantindo-se que 
+não era um nome já usado no programa.)
 
-As a more detailed example, consider the \lstinline@merge@ method that
-comes with the \lstinline@sort@ method above:
+Como um exemplo mais detalhado, considere o método \lstinline@merge@ que vêm com
+o método \lstinline@sort@ citado anteriormente:
 \begin{lstlisting}
 def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
   if (xs.isEmpty) ys
@@ -6776,8 +6776,8 @@ def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
   else if (xs.head < ys.head) xs.head :: merge(xs.tail, ys)
   else if ys.head :: merge(xs, ys.tail)
 \end{lstlisting}
-After expanding view bounds and inserting implicit conversions, this
-method implementation becomes:
+Depois de expandir os parâmetros de tipo delimitado e inserir as conversões implícitas
+a implementação deste método ficaria assim:
 \begin{lstlisting}
 def merge[A](xs: List[A], ys: List[A])
             (implicit $c$: A => Ordered[A]): List[A] =
@@ -6786,10 +6786,10 @@ def merge[A](xs: List[A], ys: List[A])
   else if (c(xs.head) < ys.head) xs.head :: merge(xs.tail, ys)
   else if ys.head :: merge(xs, ys.tail)(c)
 \end{lstlisting}
-The last two lines of this method definition illustrate two different
-uses of the implicit parameter $c$. It is applied in a conversion in
-the condition of the second to last line, and it is passed as implicit
-argument in the recursive call to \lstinline@merge@ on the last line.
+
+As duas últimas linhas da definição do método ilustram dois diferentes usos
+do parâmetro implícito $c$. Ele é usado na conversão da condição na penúltima linha e passado
+como parãmetro implícito na chamada recursiva de \lstinline@merge@ na última linha.
 
 \comment{
 \chapter{Combinator Parsing}\label{sec:combinator-parsing}
@@ -7250,7 +7250,7 @@ Which classes need to be modified?
 \end{exercise}
 }
 
-\chapter{\label{sec:hm}Hindley/Milner Type Inference}
+\chapter{\label{sec:hm}Inferência de Tipos de Hindley/Milner}
 
 This chapter demonstrates Scala's data types and pattern matching by
 developing a type inference system in the Hindley/Milner style

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1285,7 +1285,7 @@ parte da sequência de avaliação.
 %----------
 
 
-%----------xpto
+%----------
 %% Even though actual implementations of Scala do not work by rewriting
 %% terms, they nevertheless should have the same space behavior as in the
 %% rewrite sequences. In the implementation of \code{gcd}, one notes that
@@ -1299,7 +1299,14 @@ parte da sequência de avaliação.
 %% executed in constant space.
 Ainda que as atuais implementações de Scala não trabalhem reescrevendo
 termos, elas contudo devem ter o mesmo comportamento de espaço que nas
-sequências reescritas. 
+sequências reescritas. Na implementação de \code{gcd}, nota-se que  a 
+chamada recursiva para \code{gcd} é a última ação realizada na avaliação 
+do seu corpo. Pode-se também dizer que \code{gcd} é uma recursão de cauda
+(tail-recursive). A última chamada numa função recursiva de cauda pode ser
+implementada por um salto ao início da função. Os argumentos dessa chamada 
+pode sobrescrever os parâmetros da atual instanciação de \code{gcd}, portanto 
+nenhum espaço na pilha é necessário. Consequentemente, funções recursivas de 
+cauda são processos iterativos, que podem ser executados em espaço constante.     
 %----------
 
 %----------
@@ -1309,6 +1316,12 @@ sequências reescritas.
 %% instance has finished. The given formulation of the factorial function
 %% is not tail-recursive; it needs space proportional to its input
 %% parameter for its execution.
+Em contraste, a chamada recursiva em \code{factorial} é seguida por uma 
+multiplicação. consequentemente, um novo espaço na pilha é alocado para a 
+instância recursiva de fatorial, e é desalocada após o término daquela 
+instância. A formulação dada para a função fatorial não é recursiva de cauda;
+ precisa de espaço proporcional aos seus parâmetros de entrada para sua
+execução. 
 %----------
 
 %----------
@@ -1322,11 +1335,22 @@ sequências reescritas.
 %% re-use the stack frame of a directly tail-recursive function whose
 %% last action is a call to itself.  Other tail calls might be optimized
 %% also, but one should not rely on this across implementations.
+Genericamente, se a última ação da função é uma chamada a outra função
+(possivelmente a mesma), apenas um único espaço na pilha é requerido para 
+ambas funções. Tais chamadas são denominadas ``tail call''. Em 
+princípio, tail calls sempre podem reutilizar o espaço da pilha da função 
+de chamada. Entretanto, alguns ambientes de execução (tais como Java VM) 
+carecem das primitivas para fazer um espaço de pilha reutilizável para 
+tail calls eficientes. A produção de uma implementação Scala de qualidade é,
+portanto, requerida somente para reutilizar o espaço de pilha de uma função 
+recursiva de cauda cuja última ação é chamar a si mesma. Outras chamadas de 
+cauda podem ser otimizadas também, mas não deve-se confiar nisso ao longo das
+implementações. 
 %----------
 
-%% \begin{exercise} Design a tail-recursive version of
-%% \code{factorial}.
-%% \end{exercise}
+\begin{exercise} Escreva uma implementação recursiva de cauda de 
+\code{factorial}.
+\end{exercise}
 
 
 %----------
@@ -1338,68 +1362,91 @@ sequências reescritas.
 %% called {\em higher-order} functions. This chapter introduces
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
+
+ \chapter{\label{chap:first-class-funs}Funções de Primeira Classe}
+Uma função em Scala é um valor de primeira classe. Como qualquer outro valor, 
+pode ser passado como um parâmetro ou retornado como um resultado. Funções que 
+recebem outras funções como parâmetros ou as retornam como resultados são 
+denominadas funções de {\em alta ordem}. Este capítulo introduz funções de alta ordem 
+e mostra como elas fornecem um mecanismo flexível para a composição de programas.
 %----------
 
 %----------
 %% As a motivating example, consider the following three related tasks:
-%% \begin{enumerate}
-%% \item
-%% Write a function to sum all integers between two given numbers \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int =
-%%   if (a > b) 0 else a + sumInts(a + 1, b)
-%% \end{lstlisting}
+Como um exemplo de motivação, considere as três tarefas relacionadas a seguir:
+\begin{enumerate}
+\item
+%%Write a function to sum all integers between two given numbers \code{a} and \code{b}:
+Escreva uma função que some todos os inteiros entre dois dados números, \code{a} e \code{b}:  
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int =
+  if (a > b) 0 else a + sumInts(a + 1, b)
+\end{lstlisting}
 %----------
 
 %----------
-%% \item 
+ \item 
 %% Write a function to sum the squares of all integers between two given numbers 
 %% \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def square(x: Int): Int = x * x
-%% def sumSquares(a: Int, b: Int): Int =
-%%   if (a > b) 0 else square(a) + sumSquares(a + 1, b)
-%% \end{lstlisting}
-%% \item
+Escreva uma função para somar os quadrados de todos os inteiros entre dois dados números, 
+ \code{a} e \code{b}:
+
+\begin{lstlisting}
+def square(x: Int): Int = x * x
+def sumSquares(a: Int, b: Int): Int =
+  if (a > b) 0 else square(a) + sumSquares(a + 1, b)
+\end{lstlisting}
+\item
 %% Write a function to sum the powers $2^n$ of all integers $n$ between
 %% two given numbers \code{a} and \code{b}:
-%% \begin{lstlisting}
-%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-%% def sumPowersOfTwo(a: Int, b: Int): Int =
-%%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
-%% \end{lstlisting}
-%% \end{enumerate}
+Escreva uma função para somar as potências $2^n$ de todos os $n$ inteiros entre
+dois dados números \code{a} e \code{b}:  
+
+\begin{lstlisting}
+def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+def sumPowersOfTwo(a: Int, b: Int): Int =
+  if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
+\end{lstlisting}
+\end{enumerate}
 %----------
 
 %----------
 %% These functions are all instances of
 %% \(\sum^b_a f(n)\) for different values of $f$. 
 %% We can factor out the common pattern by defining a function \code{sum}:
-%% \begin{lstlisting}
-%% def sum(f: Int => Int, a: Int, b: Int): Int =
-%%   if (a > b) 0 else f(a) + sum(f, a + 1, b)
-%% \end{lstlisting}
+Estas funções são todas instâncias de \(\sum^b_a f(n)\) para diferentes valores de $x$.
+Podemos obter o padrão comum definindo uma função \code{sum}: 
+\begin{lstlisting}
+def sum(f: Int => Int, a: Int, b: Int): Int =
+  if (a > b) 0 else f(a) + sum(f, a + 1, b)
+\end{lstlisting}
 %% The type \code{Int => Int} is the type of functions that
 %% take arguments of type \code{Int} and return results of type
 %% \code{Int}. So \code{sum} is a function which takes another function as
 %% a parameter. In other words, \code{sum} is a {\em higher-order}
 %% function.
+O tipo \code{Int => Int} é o tipo de funções que recebem argumentos do tipo
+\code{Int} e retornam resultados do tipo \code{Int}. Então \code{sum} é uma 
+função que recebe uma outra função como parâmetro. Em outras palavras, \code{sum}
+é uma função de {\em alta ordem}.     
 %----------
 
 %----------
 %% Using \code{sum}, we can formulate the three summing functions as
 %% follows.
-%% \begin{lstlisting}
-%% def sumInts(a: Int, b: Int): Int = sum(id, a, b)
-%% def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
-%% def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
-%% \end{lstlisting}
-%% where
-%% \begin{lstlisting}
-%% def id(x: Int): Int = x
-%% def square(x: Int): Int = x * x
-%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-%% \end{lstlisting}
+Usando \code{sum}, podemos formular as três funções de soma como segue: 
+\begin{lstlisting}
+def sumInts(a: Int, b: Int): Int = sum(id, a, b)
+def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
+def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
+\end{lstlisting}
+%%where
+onde 
+\begin{lstlisting}
+def id(x: Int): Int = x
+def square(x: Int): Int = x * x
+def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+\end{lstlisting}
 %----------
 
 %----------
@@ -1409,9 +1456,13 @@ sequências reescritas.
 %% the previous example, we defined \code{id}, \code{square} and
 %% \code{power} as separate functions, so that they could be 
 %% passed as arguments to \code{sum}.
+\section{Funções Anônimas}
+Parametrização por funções tende a criar várias pequenas funções. No exemplo 
+anterior, definimos \code{id}, \code{square} e \code{power} como funções 
+separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}.    
 %----------
 
-%----------
+%----------xpto
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -564,7 +564,7 @@ hospedeira (Java ou .NET). A implementação de todas as características da
 classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
 %----------
 
-%----------xpto
+%----------
 %% The advantages of the library-based approach are relative simplicity
 %% of the core language and flexibility for library designers. Because
 %% the core language need not specify details of high-level process
@@ -663,6 +663,9 @@ que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
 % Vinicius - parei traducao aqui.
 
+
+
+%----------
 %% Executing a definition such as \code{def x = e} will not evaluate the
 %% expression \code{e}.  Instead \code{e} is evaluated whenever \code{x}
 %% is used. Alternatively, Scala offers a value definition 
@@ -670,7 +673,15 @@ responde com o nome introduzido e o seu tipo de dado.
 %% evaluation of the definition. If \code{x} is then used subsequently,
 %% it is immediately replaced by the pre-computed value of
 %% \code{e}, so that the expression need not be evaluated again.
- 
+Executando uma definição tal como \code{def x = e} não avaliará a expressão \code{e}. 
+Ao invés \code{e} é avaliado sempre que \code{x} for usado. Alternativamente, Scala 
+oferece um valor definição \code{val x = e}, o qual avalia o lado direito de \code{e}
+como parte da avaliação da definição. Se \code{x} é então usado subsequentemente, é 
+imediatamente substituído pelo valor pré-computado de \code{e}, logo a expressão não 
+precisa ser avaliada novamente.
+%----------
+
+%----------xpto 
 %% How are expressions evaluated? An expression consisting of operators
 %% and operands is evaluated by repeatedly applying the following
 %% simplification steps.
@@ -685,7 +696,10 @@ responde com o nome introduzido e o seu tipo de dado.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
+%----------
 
+
+%----------
 %% \example
 %% Here is an evaluation of an arithmetic expression.
 %% \begin{lstlisting}
@@ -697,6 +711,8 @@ responde com o nome introduzido e o seu tipo de dado.
 %% \end{lstlisting}
 %% The process of stepwise simplification of expressions to values is
 %% called {\em reduction}.
+%----------
+
 
 \section{Parameters}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3600,20 +3600,21 @@ println(isPrefix[String](s1, s2))
 \end{lstlisting}
 %----------xpto
 
-\paragraph{Local Type Inference}
-Passing type parameters such as \code{[Int]} or \code{[String]} all
-the time can become tedious in applications where generic functions
-are used a lot. Quite often, the information in a type parameter is
-redundant, because the correct parameter type can also be determined
-by inspecting the function's value parameters or expected result type.
-Taking the expression \code{isPrefix[String](s1, s2)} as an
-example, we know that its value parameters are both of type
-\code{Stack[String]}, so we can deduce that the type parameter must
-be \code{String}. Scala has a fairly powerful type inferencer which
-allows one to omit type parameters to polymorphic functions and
-constructors in situations like these.  In the example above, one
-could have written \code{isPrefix(s1, s2)} and the missing type argument
-\code{[String]} would have been inserted by the type inferencer. 
+\paragraph{Inferência de Tipo Local}
+Passar parâmetros de tipo tais como \code{[Int]} ou \code{[String]} o
+tempo todo pode tornar-se enfadonho em aplicações onde funções 
+genéricas são muito utilizadas. Frequentemente, a informação dentro
+de um parâmetro de tipo é redundante, porque o parâmetro tipo correto
+pode também ser determinado pela inspeção dos parâmetros valores da 
+função ou do tipo esperado do resultado. Tomando a expressão 
+\code{isPrefix[String](s1, s2)} como um exemplo, sabemos que seus
+parâmetros valor são ambos do tipo \code{Stack[String]}, portanto 
+podemos deduzir que o parâmetro tipo deve ser \code{String}. Scala 
+tem um poderoso mecanismo de inferência que nos permite omitir 
+parâmetros tipo para funções polimórficas e construtores em 
+situações como esta. No exemplo acima, poderíamos ter escrito
+\code{isPrefix(s1, s2)} e o tipo do argumento omitido \code{[String]}
+seria inserido pelo mecanismo de inferência de tipos.
 
 \section{Type Parameter Bounds}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6323,35 +6323,32 @@ Os iteradores possuem um conjunto de métodos além de \code{next} e
 oferecem uma funcionalidade correspondente à do método equivalente em uma lista.
 
 \paragraph{Append}
-Method \code{append} constructs an iterator which resumes with the
-given iterator ~\code{it}~ after the current iterator has finished.
+O método \code{append} constrói uma iterador que começa com o código dado de iteração ~\code{it}~ depois 
+que o iterador atual tem terminado.
 \begin{lstlisting}
   def append[B >: A](that: Iterator[B]): Iterator[B] = new Iterator[B] {
     def hasNext = Iterator.this.hasNext || that.hasNext
     def next = if (Iterator.this.hasNext) Iterator.this.next else that.next
   }    
 \end{lstlisting}
-The terms \code{Iterator.this.next} and \code{Iterator.this.hasNext}
-in the definition of \code{append} call the corresponding methods as
-they are defined in the enclosing \code{Iterator} class.  If the
-\code{Iterator} prefix to \code{this} would have been missing,
-\code{hasNext} and \code{next} would have called recursively the
-methods being defined in the result of \code{append}, which is not
-what we want.
+Os termos \code{Iterator.this.next} e \code{Iterator.this.hasNext}
+na definição de \code{append} chamam os métodos correspondentes definidos na classe \code{Iterator} 
+que contém o método \code{append}. Se o prefixo
+\code{Iterator} não fosse adicionado ao \code{this},
+\code{hasNext} e \code{next} chamariam recursivamente os métodos definidos no resultado de \code{append},
+o que não era o efeito desejado.
 
-\paragraph{Map, FlatMap, Foreach} Method \code{map} 
-constructs an iterator which returns all elements of the original
-iterator transformed by a given function \code{f}.
+\paragraph{Map, FlatMap, Foreach} O método \code{map} 
+constrói um iterador que retorna todos os elementos do iterador original transformados por uma dada função \code{f}.
 \begin{lstlisting}
   def map[B](f: A => B): Iterator[B] = new Iterator[B] {
     def hasNext = Iterator.this.hasNext
     def next = f(Iterator.this.next)
   }
 \end{lstlisting}
-Method \code{flatMap} is like method \code{map}, except that the
-transformation function \code{f} now returns an iterator.
-The result of \code{flatMap} is the iterator resulting from appending
-together all iterators returned from successive calls of \code{f}.
+O método \code{flatMap} é similar ao método \code{map}, exceto que a função de transformação \code{f} retorna um iterador 
+ao invés de um elemento. O resultado de \code{flatMap} é um iterador resultante da anexação (\code{append}) de todos os iteradores resultantes
+das sucessivas chamadas de \code{f}.
 \begin{lstlisting}
   def flatMap[B](f: A => Iterator[B]): Iterator[B] = new Iterator[B] {
     private var cur: Iterator[B] = Iterator.empty
@@ -6365,7 +6362,7 @@ together all iterators returned from successive calls of \code{f}.
       else error("next on empty iterator")
   }
 \end{lstlisting}
-Closely related to \code{map} is the \code{foreach} method, which
+Também relacionado à \code{map}, temos o método \code{foreach} que aplica uma
 applies a given function to all elements of an iterator, but does not
 construct a list of results
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -79,7 +79,7 @@ Pelo que vimos, Scala se parece com uma linguagem bem convencional
 com algumas peculiaridades sintáticas. De fato é possível escrever
 programas em estilo imperativo ou orientado a objetos. Isto é 
 importante, porque é uma das coisas que facilitam combinar componentes
-Scala com componentes escritos em linguagens centrais, tais como Java,
+Scala com componentes escritos em linguagens convencionais, tais como Java,
 C\# ou Visual Basic.
 Entretanto, também é possível escrever programas num estilo completamente
 diferente. Aqui está o Quicksort novamente, desta vez escrito em 
@@ -139,11 +139,11 @@ maiores ou iguais ao pivô.}
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
 Tanto a implementação imperativa quanto a funcional tem mesma complexidade
-assintótica---$O(N;log(N))$ no caso médio e $O(Nˆ2)$ no pior caso. Mas onde
+assintótica -- $O(N;log(N))$ no caso médio e $O(Nˆ2)$ no pior caso. Mas onde
 a implementação imperativa opera localmente, modificando o vetor original,
 a implementação funcional retorna um novo vetor ordenado e deixa o vetor
 original inalterado. A implementação funcional, portanto, requer mais
-memória  transiente que a imperativa.
+memória transiente que a imperativa.
 %----------
 
 %----------
@@ -189,7 +189,8 @@ def filter(p: T => Boolean): Array[T]
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
 Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
-do tipo \code{t} e retornam um \code{Boolean}. Funções como \code{filter}
+do tipo \code{T} e retornam um valor booleano do tipo \code{Boolean}. 
+Funções como \code{filter} 
 que recebem uma outra função como argumento ou retornam uma função como
 resultado são chamadas {\em funções de alta ordem.}     
 %----------
@@ -266,7 +267,7 @@ Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
 ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
 são métodos de seus operandos esquerdos. Consequentemente, a expressão 
 \code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
-do valor inteiro de \code{x}. De fato, um compilador é livre (se 
+do valor inteiro de \code{i}. De fato, um compilador é livre (se 
 moderadamente esperto, ainda que  esperado) para reconhecer o caso 
 especial da chamada de método \code{+} sobre argumentos inteiros e 
 para gerar código inline eficiente para isso.  
@@ -351,7 +352,7 @@ seus corpos ou expressões de definição.
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
 Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
-é particularmente afim. Considere a tarefa de implementar um serviço
+é particularmente indicada. Considere a tarefa de implementar um serviço
 de leilão eletrônico. Podemos usar um modelo de processo no estilo 
 actor do Erlang para implementar os participantes do leilão. Actors são 
 objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
@@ -450,6 +451,7 @@ o formato de mensagens particulares dentro da classe. Estas mensagens
 podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
 que hajam ferramentas automáticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
+% Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
 %----------
 
 %----------
@@ -535,21 +537,30 @@ estruturas de dados internas, tais como as definidas acima.
 %----------
 
 %----------
-\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
+% Vinicius - comecei traducao aqui.
+%%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
+\chapter{\label{chap:simple-funs}Expressões e Funções Simples}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
+Os exemplos anteriores deram uma ideia do que pode ser feito com Scala. Agora,
+introduzimos as suas construções de linguagem uma a uma de uma maneira mais sistemática.
+Vamos começar com os menores elementos: expressões e funções.
 
-\section{Expressions And Simple Functions}
+
+%%\section{Expressions And Simple Functions}
+\section{Expressões e Funções Simples}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
 %% expressions. The calculator returns the evaluation results and their
 %% types. For example:
 %----------
-
+Scala vem com um interpretador que pode ser visto como uma calculadora sofisticada.
+O usuário interage com a calculadora digitando expressões. A calculadora retorna o
+resultado do cálculo e o seu tipo de dado. Por exemplo: 
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -561,8 +572,10 @@ unnamed1: Int = 11
 scala> "hello" + " world!"
 unnamed2: java.lang.String = hello world!
 \end{lstlisting}
-It is also possible to name a sub-expression and use the name instead
-of the expression afterwards:
+%It is also possible to name a sub-expression and use the name instead
+%of the expression afterwards:
+Também é possível dar nome a uma sub-expressão e usar o nome, ao invés da expressão, 
+nas expressões seguintes:
 \begin{lstlisting}
 scala> def scale = 5
 scale: Int
@@ -580,9 +593,16 @@ radius: Int
 scala> 2 * pi * radius
 unnamed4: Double = 62.83185307179586
 \end{lstlisting}
+
+
+
 %% Definitions start with the reserved word \code{def}; they introduce a
 %% name which stands for the expression following the \code{=} sign.  The
 %% interpreter will answer with the introduced name and its type.
+Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
+que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
+responde com o nome introduzido e o seu tipo de dado.
+% Vinicius - parei traducao aqui.
 
 %% Executing a definition such as \code{def x = e} will not evaluate the
 %% expression \code{e}.  Instead \code{e} is evaluated whenever \code{x}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -97,138 +97,184 @@ def sort(xs: Array[Int]): Array[Int] = {
   }
 }
 \end{lstlisting}
-
-The functional program captures the essence of the quicksort algorithm
-in a concise way:
+%----------                
+%% The functional program captures the essence of the quicksort algorithm
+%% in a concise way:
+%% \begin{itemize}
+%% \item If the array is empty or consists of a single element, 
+%%       it is already sorted, so return it immediately.
+%% \item If the array is not empty, pick an an element in the middle of
+%%       it as a pivot.
+%% \item Partition the array into two sub-arrays containing elements that
+%% are less than, respectively greater than the pivot element, and a
+%% third array which contains elements equal to pivot.
+%% \item Sort the first two sub-arrays by a recursive invocation of
+%% the sort function.\footnote{This is not quite what the imperative algorithm does;
+%% the latter partitions the array into two sub-arrays containing elements
+%% less than or greater or equal to pivot.}
+%% \item The result is obtained by appending the three sub-arrays together.
+%% \end{itemize}
+O programa funcional captura a essência do algoritmo quicksort de modo conciso:
 \begin{itemize}
-\item If the array is empty or consists of a single element, 
-      it is already sorted, so return it immediately.
-\item If the array is not empty, pick an an element in the middle of
-      it as a pivot.
-\item Partition the array into two sub-arrays containing elements that
-are less than, respectively greater than the pivot element, and a
-third array which contains elements equal to pivot.
-\item Sort the first two sub-arrays by a recursive invocation of
-the sort function.\footnote{This is not quite what the imperative algorithm does;
-the latter partitions the array into two sub-arrays containing elements
-less than or greater or equal to pivot.}
-\item The result is obtained by appending the three sub-arrays together.
+\item Se o vetor está vazio ou consiste de um único elemento, já está ordenado,
+      então retorne imediatamente.
+\item Se o vetor não está vazio, escolha um elemento do meio do vetor como pivô.
+\item Particione o vetor em dois subvetores contendo, respectivamente os elementos
+ que são menores que o elemento pivô, maiores que, e um terceiro vetor que contém
+ elementos iguais ao pivô.
+\item Ordene os dois primeiros subvetores por uma chamada recursiva da função de 
+ordenação.\footnote{Isso não é exatamente o que o algoritmo imperativo faz; este 
+último particiona o vetor em dois subvetores contendo elementos menores que ou 
+maiores ou iguais ao pivô.}
+\item O resultado é obtido pela concatenação dos três subvetores.
 \end{itemize}
-Both the imperative and the functional implementation have the same
-asymptotic complexity -- $O(N;log(N))$ in the average case and
-$O(N^2)$ in the worst case. But where the imperative implementation
-operates in place by modifying the argument array, the functional
-implementation returns a new sorted array and leaves the argument
-array unchanged. The functional implementation thus requires more
-transient memory than the imperative one.
+%----------
 
-The functional implementation makes it look like Scala is a language
-that's specialized for functional operations on arrays. In fact, it is
-not; all of the operations used in the example are simple library
-methods of a {\em sequence} class \code{Seq[T]} which is part of the
-standard Scala library, and which itself is implemented in
-Scala. Because arrays are instances of \verb@Seq@ all sequence
-methods are available for them.
+%----------
+%% Both the imperative and the functional implementation have the same
+%% asymptotic complexity -- $O(N;log(N))$ in the average case and
+%% $O(N^2)$ in the worst case. But where the imperative implementation
+%% operates in place by modifying the argument array, the functional
+%% implementation returns a new sorted array and leaves the argument
+%% array unchanged. The functional implementation thus requires more
+%% transient memory than the imperative one.
+%----------
 
-In particular, there is the method \code{filter} which takes as
-argument a {\em predicate function}. This predicate function must map
-array elements to boolean values. The result of \code{filter} is an
-array consisting of all the elements of the original array for which the
-given predicate function is true. The \code{filter} method of an object
-of type \code{Array[T]} thus has the signature
+%----------
+%% The functional implementation makes it look like Scala is a language
+%% that's specialized for functional operations on arrays. In fact, it is
+%% not; all of the operations used in the example are simple library
+%% methods of a {\em sequence} class \code{Seq[T]} which is part of the
+%% standard Scala library, and which itself is implemented in
+%% Scala. Because arrays are instances of \verb@Seq@ all sequence
+%% methods are available for them.
+%----------
+
+%----------
+%% In particular, there is the method \code{filter} which takes as
+%% argument a {\em predicate function}. This predicate function must map
+%% array elements to boolean values. The result of \code{filter} is an
+%% array consisting of all the elements of the original array for which the
+%% given predicate function is true. The \code{filter} method of an object
+%% of type \code{Array[T]} thus has the signature
+%----------
+
 
 \begin{lstlisting}
 def filter(p: T => Boolean): Array[T]
 \end{lstlisting}
 
-Here, \code{T => Boolean} is the type of functions that take an element
-of type \code{t} and return a \code{Boolean}.  Functions like
-\code{filter} that take another function as argument or return one as
-result are called {\em higher-order} functions.
+%----------
+%% Here, \code{T => Boolean} is the type of functions that take an element
+%% of type \code{t} and return a \code{Boolean}.  Functions like
+%% \code{filter} that take another function as argument or return one as
+%% result are called {\em higher-order} functions.
+%----------
 
-Scala does not distinguish between identifiers and operator names. An
-identifier can be either a sequence of letters and digits which begins
-with a letter, or it can be a sequence of special characters, such as
-``\code{+}'', ``\code{*}'', or ``\code{:}''.  Any identifier can
-be used as an infix operator in Scala.  The binary operation $E;op;E'$
-is always interpreted as the method call $E.op(E')$. This holds also
-for binary infix operators which start with a letter. Hence, the
-expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
-method call ~\lstinline@xs.filter(pivot >)@.
+%----------
+%% Scala does not distinguish between identifiers and operator names. An
+%% identifier can be either a sequence of letters and digits which begins
+%% with a letter, or it can be a sequence of special characters, such as
+%% ``\code{+}'', ``\code{*}'', or ``\code{:}''.  Any identifier can
+%% be used as an infix operator in Scala.  The binary operation $E;op;E'$
+%% is always interpreted as the method call $E.op(E')$. This holds also
+%% for binary infix operators which start with a letter. Hence, the
+%% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
+%% method call ~\lstinline@xs.filter(pivot >)@.
+%----------
 
-In the quicksort program, \code{filter} is applied three times to an
-anonymous function argument.  The first argument, \code{pivot >},
-represents a function that takes an argument $x$ and returns the value
-~\lstinline@pivot > $x$@. This is an example of a {\em partially applied
-function}.  Another, equivalent way to write this function which makes
-the missing argument explicit is ~\lstinline@x => pivot > x@.
-The function is anonymous, i.e.\ it is not defined with a name. The
-type of the \code{x} parameter is omitted because a Scala compiler can
-infer it automatically from the context where the function is used. To
-summarize, \code{xs.filter(pivot >)} returns a list consisting
-of all elements of the list \code{xs} that are smaller than
-\code{pivot}.
 
-Looking again in detail at the first, imperative implementation of
-Quicksort, we find that many of the language constructs used in the
-second solution are also present, albeit in a disguised form.
+%----------
+%% In the quicksort program, \code{filter} is applied three times to an
+%% anonymous function argument.  The first argument, \code{pivot >},
+%% represents a function that takes an argument $x$ and returns the value
+%% ~\lstinline@pivot > $x$@. This is an example of a {\em partially applied
+%% function}.  Another, equivalent way to write this function which makes
+%% the missing argument explicit is ~\lstinline@x => pivot > x@.
+%% The function is anonymous, i.e.\ it is not defined with a name. The
+%% type of the \code{x} parameter is omitted because a Scala compiler can
+%% infer it automatically from the context where the function is used. To
+%% summarize, \code{xs.filter(pivot >)} returns a list consisting
+%% of all elements of the list \code{xs} that are smaller than
+%% \code{pivot}.
+%----------
 
-For instance, ``standard'' binary operators such as \code{+},
-\code{-}, or \code{<} are not treated in any special way. Like
-\code{append}, they are methods of their left operand. Consequently,
-the expression \code{i + 1} is regarded as the invocation
-\code{i.+(1)} of the \code{+} method of the integer value \code{x}.
-Of course, a compiler is free (if it is moderately smart, even expected)
-to recognize the special case of calling the \code{+} method over
-integer arguments and to generate efficient inline code for it.
+%----------
+%% Looking again in detail at the first, imperative implementation of
+%% Quicksort, we find that many of the language constructs used in the
+%% second solution are also present, albeit in a disguised form.
+%----------
 
-For efficiency and better error diagnostics the \code{while} loop is a
-primitive construct in Scala. But in principle, it could have just as
-well been a predefined function. Here is a possible implementation of it:
+
+
+%----------
+%% For instance, ``standard'' binary operators such as \code{+},
+%% \code{-}, or \code{<} are not treated in any special way. Like
+%% \code{append}, they are methods of their left operand. Consequently,
+%% the expression \code{i + 1} is regarded as the invocation
+%% \code{i.+(1)} of the \code{+} method of the integer value \code{x}.
+%% Of course, a compiler is free (if it is moderately smart, even expected)
+%% to recognize the special case of calling the \code{+} method over
+%% integer arguments and to generate efficient inline code for it.
+%----------
+
+%----------
+%% For efficiency and better error diagnostics the \code{while} loop is a
+%% primitive construct in Scala. But in principle, it could have just as
+%% well been a predefined function. Here is a possible implementation of it:
+%----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
   if (p) { s ; While(p)(s) }
 }
 \end{lstlisting}
-The \code{While} function takes as first parameter a test function,
-which takes no parameters and yields a boolean value. As second
-parameter it takes a command function which also takes no parameters
-and yields a result of type \lstinline@Unit@. \code{While} invokes the
-command function as long as the test function yields true.
+%----------
+%% The \code{While} function takes as first parameter a test function,
+%% which takes no parameters and yields a boolean value. As second
+%% parameter it takes a command function which also takes no parameters
+%% and yields a result of type \lstinline@Unit@. \code{While} invokes the
+%% command function as long as the test function yields true.
+%----------
 
-Scala's \lstinline@Unit@ type roughly corresponds to \lstinline@void@
-in Java; it is used whenever a function does not return an interesting
-result. In fact, because Scala is an expression-oriented language,
-every function returns some result. If no explicit return expression
-is given, the value \lstinline@()@, which is pronounced ``unit'', is
-assumed.  This value is of type \lstinline@Unit@.
-Unit-returning functions are also called {\em procedures}.  
-Here's a more
-``expression-oriented'' formulation of the \lstinline@swap@ function
-in the first implementation of quicksort, which makes this explicit:
+%----------
+%% Scala's \lstinline@Unit@ type roughly corresponds to \lstinline@void@
+%% in Java; it is used whenever a function does not return an interesting
+%% result. In fact, because Scala is an expression-oriented language,
+%% every function returns some result. If no explicit return expression
+%% is given, the value \lstinline@()@, which is pronounced ``unit'', is
+%% assumed.  This value is of type \lstinline@Unit@.
+%% Unit-returning functions are also called {\em procedures}.  
+%% Here's a more
+%% ``expression-oriented'' formulation of the \lstinline@swap@ function
+%% in the first implementation of quicksort, which makes this explicit:
+%----------
+
 \begin{lstlisting}
 def swap(i: Int, j: Int) {
   val t = xs(i); xs(i) = xs(j); xs(j) = t
   ()
 }
 \end{lstlisting}
-The result value of this function is simply its last expression -- a
-\lstinline@return@ keyword is not necessary. Note that functions
-returning an explicit value always need an ``='' before their
-body or defining expression.  
+
+%----------
+%% The result value of this function is simply its last expression -- a
+%% \lstinline@return@ keyword is not necessary. Note that functions
+%% returning an explicit value always need an ``='' before their
+%% body or defining expression.  
+%----------
 
 \chapter{Programming with Actors and Messages}
 \label{chap:example-auction}
-
-Here's an example that shows an application area for which Scala is
-particularly well suited. Consider the task of implementing an
-electronic auction service. We use an Erlang-style actor process
-model to implement the participants of the auction. Actors are
-objects to which messages are sent. Every actor has a ``mailbox'' of
-its incoming messages which is represented as a queue. It can work
-sequentially through the messages in its mailbox, or search for
-messages matching some pattern.
-
+%----------
+%% Here's an example that shows an application area for which Scala is
+%% particularly well suited. Consider the task of implementing an
+%% electronic auction service. We use an Erlang-style actor process
+%% model to implement the participants of the auction. Actors are
+%% objects to which messages are sent. Every actor has a ``mailbox'' of
+%% its incoming messages which is represented as a queue. It can work
+%% sequentially through the messages in its mailbox, or search for
+%% messages matching some pattern.
+%----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
 import scala.actors.Actor
@@ -246,19 +292,22 @@ case class  AuctionConcluded(seller: Actor, client: Actor)
 case object AuctionFailed                    extends AuctionReply
 case object AuctionOver                      extends AuctionReply
 \end{lstlisting}
+%----------
+%% For every traded item there is an auctioneer actor that publishes
+%% information about the traded item, that accepts offers from clients
+%% and that communicates with the seller and winning bidder to close the
+%% transaction. We present an overview of a simple implementation
+%% here.
+%----------
 
-For every traded item there is an auctioneer actor that publishes
-information about the traded item, that accepts offers from clients
-and that communicates with the seller and winning bidder to close the
-transaction. We present an overview of a simple implementation
-here.
-
-As a first step, we define the messages that are exchanged during an
-auction. There are two abstract base classes
-\code{AuctionMessage} for messages from clients to the auction
-service, and \code{AuctionReply} for replies from the service to the
-clients.  For both base classes there exists a number of cases, which
-are defined in Figure~\ref{fig:simple-auction-msgs}.
+%----------
+%% As a first step, we define the messages that are exchanged during an
+%% auction. There are two abstract base classes
+%% \code{AuctionMessage} for messages from clients to the auction
+%% service, and \code{AuctionReply} for replies from the service to the
+%% clients.  For both base classes there exists a number of cases, which
+%% are defined in Figure~\ref{fig:simple-auction-msgs}.
+%----------
 
 \begin{lstlisting}[style=floating,label=fig:simple-auction,caption=Implementation of an Auction Service]
 class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
@@ -296,91 +345,112 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 }
 \end{lstlisting}
 
-For each base class, there are a number of {\em case classes} which
-define the format of particular messages in the class. These messages
-might well be ultimately mapped to small XML documents. We expect
-automatic tools to exist that convert between XML documents and
-internal data structures like the ones defined above.
+%----------
+%% For each base class, there are a number of {\em case classes} which
+%% define the format of particular messages in the class. These messages
+%% might well be ultimately mapped to small XML documents. We expect
+%% automatic tools to exist that convert between XML documents and
+%% internal data structures like the ones defined above.
+%----------
 
-Figure~\ref{fig:simple-auction} presents a Scala implementation of a
-class \code{Auction} for auction actors that coordinate the bidding
-on one item. Objects of this class are created by indicating
-\begin{itemize}
-\item a seller actor which needs to be notified when the auction is over,
-\item a minimal bid,
-\item the date when the auction is to be closed.
-\end{itemize}
-The behavior of the actor is defined by its \code{act} method. That method
-repeatedly selects (using \code{receiveWithin}) a message and reacts to it,
-until the auction is closed, which is signaled by a \code{TIMEOUT}
-message. Before finally stopping, it stays active for another period
-determined by the \code{timeToShutdown} constant and replies to
-further offers that the auction is closed.
+%----------
+%% Figure~\ref{fig:simple-auction} presents a Scala implementation of a
+%% class \code{Auction} for auction actors that coordinate the bidding
+%% on one item. Objects of this class are created by indicating
+%% \begin{itemize}
+%% \item a seller actor which needs to be notified when the auction is over,
+%% \item a minimal bid,
+%% \item the date when the auction is to be closed.
+%% \end{itemize}
+%% The behavior of the actor is defined by its \code{act} method. That method
+%% repeatedly selects (using \code{receiveWithin}) a message and reacts to it,
+%% until the auction is closed, which is signaled by a \code{TIMEOUT}
+%% message. Before finally stopping, it stays active for another period
+%% determined by the \code{timeToShutdown} constant and replies to
+%% further offers that the auction is closed.
+%----------
 
-Here are some further explanations of the constructs used in this
-program:
-\begin{itemize}
-\item
-The \code{receiveWithin} method of class \code{Actor} takes as
-parameters a time span given in milliseconds and a function that
-processes messages in the mailbox. The function is given by a sequence
-of cases that each specify a pattern and an action to perform for
-messages matching the pattern. The \code{receiveWithin} method selects
-the first message in the mailbox which matches one of these patterns
-and applies the corresponding action to it.
-\item
-The last case of \code{receiveWithin} is guarded by a
-\code{TIMEOUT} pattern. If no other messages are received in the meantime, this
-pattern is triggered after the time span which is passed as argument
-to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
-special message, which is triggered by the \code{Actor} implementation itself.
-\item
-Reply messages are sent using syntax of the form
-\code{destination ! SomeMessage}. \code{!} is used here as a
-binary operator with an actor and a message as arguments. This is
-equivalent in Scala to the method call
-\code{destination.!(SomeMessage)}, i.e. the invocation of
-the \code{!} method of the destination actor with the given message as
-parameter.
-\end{itemize}
-The preceding discussion gave a flavor of distributed programming in
-Scala. It might seem that Scala has a rich set of language constructs
-that support actor processes, message sending and receiving,
-programming with timeouts, etc. In fact, the opposite is true. All the
-constructs discussed above are offered as methods in the library class
-\code{Actor}. That class is itself implemented in Scala, based on the underlying 
-thread model of the host language (e.g. Java, or .NET).
-The implementation of all features of class \code{Actor} used here is
-given in Section~\ref{sec:actors}.
+%----------
+%% Here are some further explanations of the constructs used in this
+%% program:
+%% \begin{itemize}
+%% \item
+%% The \code{receiveWithin} method of class \code{Actor} takes as
+%% parameters a time span given in milliseconds and a function that
+%% processes messages in the mailbox. The function is given by a sequence
+%% of cases that each specify a pattern and an action to perform for
+%% messages matching the pattern. The \code{receiveWithin} method selects
+%% the first message in the mailbox which matches one of these patterns
+%% and applies the corresponding action to it.
+%----------
 
-The advantages of the library-based approach are relative simplicity
-of the core language and flexibility for library designers. Because
-the core language need not specify details of high-level process
-communication, it can be kept simpler and more general. Because the
-particular model of messages in a mailbox is a library module, it can
-be freely modified if a different model is needed in some
-applications.  The approach requires however that the core language is
-expressive enough to provide the necessary language abstractions in a
-convenient way. Scala has been designed with this in mind; one of its
-major design goals was that it should be flexible enough to act as a
-convenient host language for domain specific languages implemented by
-library modules. For instance, the actor communication constructs
-presented above can be regarded as one such domain specific language,
-which conceptually extends the Scala core.
 
-\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
+%----------
+%% \item
+%% The last case of \code{receiveWithin} is guarded by a
+%% \code{TIMEOUT} pattern. If no other messages are received in the meantime, this
+%% pattern is triggered after the time span which is passed as argument
+%% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
+%% special message, which is triggered by the \code{Actor} implementation itself.
+%----------
 
-The previous examples gave an impression of what can be done with
-Scala.  We now introduce its constructs one by one in a more
-systematic fashion. We start with the smallest level, expressions and
-functions.
+%----------
+%% \item
+%% Reply messages are sent using syntax of the form
+%% \code{destination ! SomeMessage}. \code{!} is used here as a
+%% binary operator with an actor and a message as arguments. This is
+%% equivalent in Scala to the method call
+%% \code{destination.!(SomeMessage)}, i.e. the invocation of
+%% the \code{!} method of the destination actor with the given message as
+%% parameter.
+%% \end{itemize}
+%----------
 
-\section{Expressions And Simple Functions}
+%----------
+%% The preceding discussion gave a flavor of distributed programming in
+%% Scala. It might seem that Scala has a rich set of language constructs
+%% that support actor processes, message sending and receiving,
+%% programming with timeouts, etc. In fact, the opposite is true. All the
+%% constructs discussed above are offered as methods in the library class
+%% \code{Actor}. That class is itself implemented in Scala, based on the underlying 
+%% thread model of the host language (e.g. Java, or .NET).
+%% The implementation of all features of class \code{Actor} used here is
+%% given in Section~\ref{sec:actors}.
+%----------
 
-A Scala system comes with an interpreter which can be seen as a fancy
-calculator. A user interacts with the calculator by typing in
-expressions. The calculator returns the evaluation results and their
-types. For example:
+%----------
+%% The advantages of the library-based approach are relative simplicity
+%% of the core language and flexibility for library designers. Because
+%% the core language need not specify details of high-level process
+%% communication, it can be kept simpler and more general. Because the
+%% particular model of messages in a mailbox is a library module, it can
+%% be freely modified if a different model is needed in some
+%% applications.  The approach requires however that the core language is
+%% expressive enough to provide the necessary language abstractions in a
+%% convenient way. Scala has been designed with this in mind; one of its
+%% major design goals was that it should be flexible enough to act as a
+%% convenient host language for domain specific languages implemented by
+%% library modules. For instance, the actor communication constructs
+%% presented above can be regarded as one such domain specific language,
+%% which conceptually extends the Scala core.
+%----------
+
+%----------
+%% \chapter{\label{chap:simple-funs}Expressions and Simple Functions}
+
+%% The previous examples gave an impression of what can be done with
+%% Scala.  We now introduce its constructs one by one in a more
+%% systematic fashion. We start with the smallest level, expressions and
+%% functions.
+
+%% \section{Expressions And Simple Functions}
+
+%% A Scala system comes with an interpreter which can be seen as a fancy
+%% calculator. A user interacts with the calculator by typing in
+%% expressions. The calculator returns the evaluation results and their
+%% types. For example:
+%----------
+
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -411,48 +481,48 @@ radius: Int
 scala> 2 * pi * radius
 unnamed4: Double = 62.83185307179586
 \end{lstlisting}
-Definitions start with the reserved word \code{def}; they introduce a
-name which stands for the expression following the \code{=} sign.  The
-interpreter will answer with the introduced name and its type.
+%% Definitions start with the reserved word \code{def}; they introduce a
+%% name which stands for the expression following the \code{=} sign.  The
+%% interpreter will answer with the introduced name and its type.
 
-Executing a definition such as \code{def x = e} will not evaluate the
-expression \code{e}.  Instead \code{e} is evaluated whenever \code{x}
-is used. Alternatively, Scala offers a value definition 
-\code{val x = e}, which does evaluate the right-hand-side \code{e} as part of the
-evaluation of the definition. If \code{x} is then used subsequently,
-it is immediately replaced by the pre-computed value of
-\code{e}, so that the expression need not be evaluated again.
+%% Executing a definition such as \code{def x = e} will not evaluate the
+%% expression \code{e}.  Instead \code{e} is evaluated whenever \code{x}
+%% is used. Alternatively, Scala offers a value definition 
+%% \code{val x = e}, which does evaluate the right-hand-side \code{e} as part of the
+%% evaluation of the definition. If \code{x} is then used subsequently,
+%% it is immediately replaced by the pre-computed value of
+%% \code{e}, so that the expression need not be evaluated again.
  
-How are expressions evaluated? An expression consisting of operators
-and operands is evaluated by repeatedly applying the following
-simplification steps.
-\begin{itemize}
-\item pick the left-most operation
-\item evaluate its operands
-\item apply the operator to the operand values.
-\end{itemize}
-A name defined by \code{def}\ is evaluated by replacing the name by the
-(unevaluated) definition's right hand side. A name defined by \code{val} is
-evaluated by replacing the name by the value of the definitions's
-right-hand side.  The evaluation process stops once we have reached a
-value. A value is some data item such as a string, a number, an array,
-or a list.
+%% How are expressions evaluated? An expression consisting of operators
+%% and operands is evaluated by repeatedly applying the following
+%% simplification steps.
+%% \begin{itemize}
+%% \item pick the left-most operation
+%% \item evaluate its operands
+%% \item apply the operator to the operand values.
+%% \end{itemize}
+%% A name defined by \code{def}\ is evaluated by replacing the name by the
+%% (unevaluated) definition's right hand side. A name defined by \code{val} is
+%% evaluated by replacing the name by the value of the definitions's
+%% right-hand side.  The evaluation process stops once we have reached a
+%% value. A value is some data item such as a string, a number, an array,
+%% or a list.
 
-\example
-Here is an evaluation of an arithmetic expression.
-\begin{lstlisting}
-$\,\,\,$   (2 * pi) * radius
-$\rightarrow$  (2 * 3.141592653589793) * radius
-$\rightarrow$  6.283185307179586 * radius
-$\rightarrow$  6.283185307179586 * 10
-$\rightarrow$  62.83185307179586
-\end{lstlisting}
-The process of stepwise simplification of expressions to values is
-called {\em reduction}.
+%% \example
+%% Here is an evaluation of an arithmetic expression.
+%% \begin{lstlisting}
+%% $\,\,\,$   (2 * pi) * radius
+%% $\rightarrow$  (2 * 3.141592653589793) * radius
+%% $\rightarrow$  6.283185307179586 * radius
+%% $\rightarrow$  6.283185307179586 * 10
+%% $\rightarrow$  62.83185307179586
+%% \end{lstlisting}
+%% The process of stepwise simplification of expressions to values is
+%% called {\em reduction}.
 
-\section{Parameters}
+%% \section{Parameters}
 
-Using \code{def}, one can also define functions with parameters. For example:
+%% Using \code{def}, one can also define functions with parameters. For example:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -473,21 +543,21 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
-Function parameters follow the function name and are always enclosed
-in parentheses.  Every parameter comes with a type, which is indicated
-following the parameter name and a colon.  At the present time, we
-only need basic numeric types such as the type \code{scala.Double} of
-double precision numbers. Scala defines {\em type aliases} for some
-standard types, so we can write numeric types as in Java. For instance
-\code{double} is a type alias of \code{scala.Double} and \code{int} is
-a type alias for \code{scala.Int}.
+%% Function parameters follow the function name and are always enclosed
+%% in parentheses.  Every parameter comes with a type, which is indicated
+%% following the parameter name and a colon.  At the present time, we
+%% only need basic numeric types such as the type \code{scala.Double} of
+%% double precision numbers. Scala defines {\em type aliases} for some
+%% standard types, so we can write numeric types as in Java. For instance
+%% \code{double} is a type alias of \code{scala.Double} and \code{int} is
+%% a type alias for \code{scala.Int}.
 
-Functions with parameters are evaluated analogously to operators in
-expressions. First, the arguments of the function are evaluated (in
-left-to-right order). Then, the function application is replaced by
-the function's right hand side, and at the same time all formal
-parameters of the function are replaced by their corresponding actual
-arguments.
+%% Functions with parameters are evaluated analogously to operators in
+%% expressions. First, the arguments of the function are evaluated (in
+%% left-to-right order). Then, the function application is replaced by
+%% the function's right hand side, and at the same time all formal
+%% parameters of the function are replaced by their corresponding actual
+%% arguments.
 
 \example\ 
  
@@ -502,10 +572,10 @@ $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
 
-The example shows that the interpreter reduces function arguments to
-values before rewriting the function application.  One could instead
-have chosen to apply the function to unreduced arguments. This would
-have yielded the following reduction sequence:
+%% The example shows that the interpreter reduces function arguments to
+%% values before rewriting the function application.  One could instead
+%% have chosen to apply the function to unreduced arguments. This would
+%% have yielded the following reduction sequence:
 \begin{lstlisting}
 $\,\,\,$   sumOfSquares(3, 2+2)
 $\rightarrow$  square(3) + square(2+2)
@@ -518,5790 +588,5790 @@ $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
 
-The second evaluation order is known as \emph{call-by-name},
-whereas the first one is known as \emph{call-by-value}.  For
-expressions that use only pure functions and that therefore can be
-reduced with the substitution model, both schemes yield the same final
-values.  
+%% The second evaluation order is known as \emph{call-by-name},
+%% whereas the first one is known as \emph{call-by-value}.  For
+%% expressions that use only pure functions and that therefore can be
+%% reduced with the substitution model, both schemes yield the same final
+%% values.  
 
-Call-by-value has the advantage that it avoids repeated evaluation of
-arguments. Call-by-name has the advantage that it avoids evaluation of
-arguments when the parameter is not used at all by the function.
-Call-by-value is usually more efficient than call-by-name, but a
-call-by-value evaluation might loop where a call-by-name evaluation
-would terminate. Consider:
-\begin{lstlisting}
-scala> def loop: Int = loop
-loop: Int
+%% Call-by-value has the advantage that it avoids repeated evaluation of
+%% arguments. Call-by-name has the advantage that it avoids evaluation of
+%% arguments when the parameter is not used at all by the function.
+%% Call-by-value is usually more efficient than call-by-name, but a
+%% call-by-value evaluation might loop where a call-by-name evaluation
+%% would terminate. Consider:
+%% \begin{lstlisting}
+%% scala> def loop: Int = loop
+%% loop: Int
 
-scala> def first(x: Int, y: Int) = x
-first: (Int,Int)Int
-\end{lstlisting}
-Then \code{first(1, loop)} reduces with call-by-name to \code{1},
-whereas the same term reduces with call-by-value repeatedly to itself,
-hence evaluation does not terminate.
-\begin{lstlisting}
-$\,\,\,$   first(1, loop)
-$\rightarrow$  first(1, loop)
-$\rightarrow$  first(1, loop)
-$\rightarrow$  ...
-\end{lstlisting}
-Scala uses call-by-value by default, but it switches to call-by-name evaluation
-if the parameter type is preceded by \code{=>}.
+%% scala> def first(x: Int, y: Int) = x
+%% first: (Int,Int)Int
+%% \end{lstlisting}
+%% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
+%% whereas the same term reduces with call-by-value repeatedly to itself,
+%% hence evaluation does not terminate.
+%% \begin{lstlisting}
+%% $\,\,\,$   first(1, loop)
+%% $\rightarrow$  first(1, loop)
+%% $\rightarrow$  first(1, loop)
+%% $\rightarrow$  ...
+%% \end{lstlisting}
+%% Scala uses call-by-value by default, but it switches to call-by-name evaluation
+%% if the parameter type is preceded by \code{=>}.
 
-\example\ 
+%% \example\ 
  
-\begin{lstlisting}
-scala> def constOne(x: Int, y: => Int) = 1
-constOne: (Int,=> Int)Int
-
-scala> constOne(1, loop)
-unnamed0: Int = 1
-
-scala> constOne(loop, 2)               // gives an infinite loop.
-^C                                     // stops execution with Ctrl-C
-\end{lstlisting}
-
-\section{Conditional Expressions}
-
-Scala's \code{if-else} lets one choose between two alternatives.  Its
-syntax is like Java's \code{if-else}. But where Java's \code{if-else}
-can be used only as an alternative of statements, Scala allows the
-same syntax to choose between two expressions. That's why Scala's
-\code{if-else} serves also as a substitute for Java's conditional
-expression \code{ ... ? ... : ...}.
-
-\example\ 
-
-\begin{lstlisting}
-scala> def abs(x: Double) = if (x >= 0) x else -x
-abs: (Double)Double
-\end{lstlisting}
-Scala's boolean expressions are similar to Java's; they are formed
-from the constants
-\code{true} and
-\code{false}, comparison operators, boolean negation \code{!} and the
-boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
-
-\section{\label{sec:sqrt}Example: Square Roots by Newton's Method}
-
-We now illustrate the language elements introduced so far in the
-construction of a more interesting program. The task is to write a
-function
-\begin{lstlisting}
-def sqrt(x: Double): Double = ...
-\end{lstlisting}
-which computes the square root of \code{x}.
-
-A common way to compute square roots is by Newton's method of
-successive approximations. One starts with an initial guess \code{y}
-(say: \code{y = 1}). One then repeatedly improves the current guess
-\code{y} by taking the average of \code{y} and \code{x/y}.  As an
-example, the next three columns indicate the guess \code{y}, the
-quotient \code{x/y}, and their average for the first approximations of
-$\sqrt 2$.
-\begin{lstlisting}
-1            2/1 = 2               1.5
-1.5          2/1.5 = 1.3333        1.4167
-1.4167       2/1.4167 = 1.4118     1.4142
-1.4142       ...                   ...
-
-$y$            $x/y$                   $(y + x/y)/2$
-\end{lstlisting}
-One can implement this algorithm in Scala by a set of small functions,
-which each represent one of the elements of the algorithm.  
-
-We first define a function for iterating from a guess to the result:
-\begin{lstlisting}
-def sqrtIter(guess: Double, x: Double): Double =
-  if (isGoodEnough(guess, x)) guess
-  else sqrtIter(improve(guess, x), x)
-\end{lstlisting}
-Note that \code{sqrtIter} calls itself recursively.  Loops in
-imperative programs can always be modeled by recursion in functional
-programs. 
-
-Note also that the definition of \code{sqrtIter} contains a return
-type, which follows the parameter section. Such return types are
-mandatory for recursive functions. For a non-recursive function, the
-return type is optional; if it is missing the type checker will
-compute it from the type of the function's right-hand side. However,
-even for non-recursive functions it is often a good idea to include a
-return type for better documentation.
-
-As a second step, we define the two functions called by
-\code{sqrtIter}: a function to \code{improve} the guess and a
-termination test \code{isGoodEnough}. Here is their definition.
-\begin{lstlisting}
-def improve(guess: Double, x: Double) =
-  (guess + x / guess) / 2
-
-def isGoodEnough(guess: Double, x: Double) =
-  abs(square(guess) - x) < 0.001
-\end{lstlisting}
-
-Finally, the \code{sqrt} function itself is defined by an application
-of \code{sqrtIter}.
-\begin{lstlisting}
-def sqrt(x: Double) = sqrtIter(1.0, x)
-\end{lstlisting}
-
-\begin{exercise} The \code{isGoodEnough} test is not very precise for small
-numbers and might lead to non-termination for very large ones (why?).
-Design a different version of \code{isGoodEnough} which does not have
-these problems.
-\end{exercise}
-
-\begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
-\end{exercise}
-
-\section{Nested Functions}
-
-The functional programming style encourages the construction of many
-small helper functions. In the last example, the implementation
-of \code{sqrt} made use of the helper functions \code{sqrtIter},
-\code{improve} and \code{isGoodEnough}. The names of these functions
-are relevant only for the implementation of \code{sqrt}. We normally
-do not want users of \code{sqrt} to access these functions directly.
-
-We can enforce this (and avoid name-space pollution) by including
-the helper functions within the calling function itself:
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double, x: Double): Double =
-    if (isGoodEnough(guess, x)) guess
-    else sqrtIter(improve(guess, x), x)
-  def improve(guess: Double, x: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double, x: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0, x)
-}
-\end{lstlisting}
-In this program, the braces \code{\{ ... \}} enclose a {\em block}.
-Blocks in Scala are themselves expressions.  Every block ends in a
-result expression which defines its value.  The result expression may
-be preceded by auxiliary definitions, which are visible only in the
-block itself.
-
-Every definition in a block must be followed by a semicolon, 
-which separates this definition from subsequent definitions or the result
-expression. However, a semicolon is inserted implicitly at the end of
-each line, unless one of the following conditions is
-true.
-\begin{enumerate}
-\item
-Either the line in question ends in a word such as a period 
-or an infix-operator which would not be legal as the end of an expression.
-\item
-Or the next line begins with a word that cannot start a expression.
-\item
-Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
-because these cannot contain multiple statements anyway.
-\end{enumerate}
-Therefore, the following are all legal:
-\begin{lstlisting}
-def f(x: Int) = x + 1;
-f(1) + f(2)
-
-def g1(x: Int) = x + 1
-g(1) + g(2)
-
-def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
-
-def h1(x) = 
-  x + 
-  y
-h1(1) * h1(2)
-
-def h2(x: Int) = (
-  x     // parentheses mandatory, otherwise a semicolon
-  + y   // would be inserted after the `x'.
-)
-h2(1) / h2(2)
-\end{lstlisting}
-Scala uses the usual block-structured scoping rules. A name defined in
-some outer block is visible also in some inner block, provided it is
-not redefined there. This rule permits us to simplify our
-\code{sqrt} example. We need not pass \code{x} around as an additional parameter of
-the nested functions, since it is always visible in them as a
-parameter of the outer function \code{sqrt}. Here is the simplified code:
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double): Double =
-    if (isGoodEnough(guess)) guess
-    else sqrtIter(improve(guess))
-  def improve(guess: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0)
-}
-\end{lstlisting}
-
-\section{Tail Recursion}
-
-Consider the following function to compute the greatest common divisor
-of two given numbers.
-
-\begin{lstlisting}
-def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
-\end{lstlisting}
-
-Using our substitution model of function evaluation, 
-\code{gcd(14, 21)} evaluates as follows:
-
-\begin{lstlisting}
-$\,\,$      gcd(14, 21)  
-$\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14)
-$\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
-$\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
-$\rightarrow\!$     gcd(14, 7)
-$\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
-$\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
-$\rightarrow\!$     gcd(7, 0)
-$\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
-$\rightarrow$ $\rightarrow$  7
-\end{lstlisting}
-
-Contrast this with the evaluation of another recursive function, 
-\code{factorial}:
-
-\begin{lstlisting}
-def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
-\end{lstlisting}
-
-The application \code{factorial(5)} rewrites as follows:
-\begin{lstlisting}
-$\,\,\,$       factorial(5)
-$\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(4)
-$\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
-$\rightarrow\ldots\rightarrow$  120
-\end{lstlisting}
-There is an important difference between the two rewrite sequences:
-The terms in the rewrite sequence of \code{gcd} have again and again
-the same form. As evaluation proceeds, their size is bounded by a
-constant. By contrast, in the evaluation of factorial we get longer
-and longer chains of operands which are then multiplied in the last
-part of the evaluation sequence.
-
-Even though actual implementations of Scala do not work by rewriting
-terms, they nevertheless should have the same space behavior as in the
-rewrite sequences. In the implementation of \code{gcd}, one notes that
-the recursive call to \code{gcd} is the last action performed in the
-evaluation of its body. One also says that \code{gcd} is
-``tail-recursive''. The final call in a tail-recursive function can be
-implemented by a jump back to the beginning of that function. The
-arguments of that call can overwrite the parameters of the current
-instantiation of \code{gcd}, so that no new stack space is needed.
-Hence, tail recursive functions are iterative processes, which can be
-executed in constant space.
-
-By contrast, the recursive call in \code{factorial} is followed by a
-multiplication.  Hence, a new stack frame is allocated for the
-recursive instance of factorial, and is deallocated after that
-instance has finished. The given formulation of the factorial function
-is not tail-recursive; it needs space proportional to its input
-parameter for its execution.
-
-More generally, if the last action of a function is a call to another
-(possibly the same) function, only a single stack frame is needed for
-both functions. Such calls are called ``tail calls''. In principle,
-tail calls can always re-use the stack frame of the calling function.
-However, some run-time environments (such as the Java VM) lack the
-primitives to make stack frame re-use for tail calls efficient.  A
-production quality Scala implementation is therefore only required to
-re-use the stack frame of a directly tail-recursive function whose
-last action is a call to itself.  Other tail calls might be optimized
-also, but one should not rely on this across implementations.
-
-\begin{exercise} Design a tail-recursive version of
-\code{factorial}.
-\end{exercise}
-
-\chapter{\label{chap:first-class-funs}First-Class Functions}
-
-A function in Scala is a ``first-class value''. Like any other value,
-it may be passed as a parameter or returned as a result.  Functions
-which take other functions as parameters or return them as results are
-called {\em higher-order} functions. This chapter introduces
-higher-order functions and shows how they provide a flexible mechanism
-for program composition.
-
-As a motivating example, consider the following three related tasks:
-\begin{enumerate}
-\item
-Write a function to sum all integers between two given numbers \code{a} and \code{b}:
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int =
-  if (a > b) 0 else a + sumInts(a + 1, b)
-\end{lstlisting}
-\item 
-Write a function to sum the squares of all integers between two given numbers 
-\code{a} and \code{b}:
-\begin{lstlisting}
-def square(x: Int): Int = x * x
-def sumSquares(a: Int, b: Int): Int =
-  if (a > b) 0 else square(a) + sumSquares(a + 1, b)
-\end{lstlisting}
-\item
-Write a function to sum the powers $2^n$ of all integers $n$ between
-two given numbers \code{a} and \code{b}:
-\begin{lstlisting}
-def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-def sumPowersOfTwo(a: Int, b: Int): Int =
-  if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
-\end{lstlisting}
-\end{enumerate}
-These functions are all instances of
-\(\sum^b_a f(n)\) for different values of $f$. 
-We can factor out the common pattern by defining a function \code{sum}:
-\begin{lstlisting}
-def sum(f: Int => Int, a: Int, b: Int): Int =
-  if (a > b) 0 else f(a) + sum(f, a + 1, b)
-\end{lstlisting}
-The type \code{Int => Int} is the type of functions that
-take arguments of type \code{Int} and return results of type
-\code{Int}. So \code{sum} is a function which takes another function as
-a parameter. In other words, \code{sum} is a {\em higher-order}
-function.
-
-Using \code{sum}, we can formulate the three summing functions as
-follows.
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum(id, a, b)
-def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
-def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
-\end{lstlisting}
-where
-\begin{lstlisting}
-def id(x: Int): Int = x
-def square(x: Int): Int = x * x
-def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-\end{lstlisting}
-
-\section{Anonymous Functions}
-
-Parameterization by functions tends to create many small functions. In
-the previous example, we defined \code{id}, \code{square} and
-\code{power} as separate functions, so that they could be 
-passed as arguments to \code{sum}.
-
-Instead of using named function definitions for these small argument
-functions, we can formulate them in a shorter way as {\em anonymous
-functions}. An anonymous function is an expression that evaluates to a
-function; the function is defined without giving it a name. As an
-example consider the anonymous square function:
-\begin{lstlisting}
-  (x: Int) => x * x
-\end{lstlisting}
-The part before the arrow `\code{=>}' are the parameters of the function,
-whereas the part following the `\code{=>}' is its body. 
-For instance, here is an anonymous function which multiples its two arguments.
-\begin{lstlisting}
-  (x: Int, y: Int) => x * y
-\end{lstlisting}
-Using anonymous functions, we can reformulate the first two summation
-functions without named auxiliary functions:
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
-def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
-\end{lstlisting}
-Often, the Scala compiler can deduce the parameter type(s) from the
-context of the anonymous function in which case they can be omitted.
-For instance, in the case of \code{sumInts} or \code{sumSquares}, one
-knows from the type of \code{sum} that the first parameter must be a
-function of type \code{Int => Int}.  Hence, the parameter type
-\code{Int} is redundant and may be omitted. If there is a single
-parameter without a type, we may also omit the parentheses around it:
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
-def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
-\end{lstlisting}
-
-Generally, the Scala term
-\code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
-defines a function which maps its parameters
-\code{x}$_1$\code{, ..., x}$_n$ to the result of the expression \code{E}
-(where \code{E} may refer to \code{x}$_1$\code{, ..., x}$_n$).  Anonymous
-functions are not essential language elements of Scala, as they can
-always be expressed in terms of named functions. Indeed, the 
-anonymous function
-\begin{lstlisting}
-(x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
-\end{lstlisting}
-is equivalent to the block
-\begin{lstlisting}
-{ def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
-\end{lstlisting}
-where \code{f} is fresh name which is used nowhere else in the program.
-We also say, anonymous functions are ``syntactic sugar''.
-
-\section{Currying}
-
-The latest formulation of the summing functions is already quite
-compact. But we can do even better. Note that
-\code{a} and \code{b} appear as parameters and arguments of every function
-but they do not seem to take part in interesting combinations. Is
-there a way to get rid of them?
-
-Let's try to rewrite \code{sum} so that it does not take the bounds
-\code{a} and \code{b} as parameters:
-\begin{lstlisting}
-def sum(f: Int => Int): (Int, Int) => Int = {
-  def sumF(a: Int, b: Int): Int =
-    if (a > b) 0 else f(a) + sumF(a + 1, b)
-  sumF
-}
-\end{lstlisting}
-In this formulation, \code{sum} is a function which returns another
-function, namely the specialized summing function \code{sumF}. This
-latter function does all the work; it takes the bounds \code{a} and
-\code{b} as parameters, applies \code{sum}'s function parameter \code{f} to all
-integers between them, and sums up the results. 
-
-Using this new formulation of \code{sum}, we can now define:
-\begin{lstlisting}
-def sumInts  =  sum(x => x)
-def sumSquares  =  sum(x => x * x)
-def sumPowersOfTwo  =  sum(powerOfTwo)
-\end{lstlisting}
-Or, equivalently, with value definitions:
-\begin{lstlisting}
-val sumInts  =  sum(x => x)
-val sumSquares  =  sum(x => x * x)
-val sumPowersOfTwo  =  sum(powerOfTwo)
-\end{lstlisting}
-
-\code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
-applied like any other function. For instance,
-\begin{lstlisting}
-scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
-unnamed0: Int = 2096513
-\end{lstlisting}
-How are function-returning functions applied? As an example, in the expression
-\begin{lstlisting}
-sum(x => x * x)(1, 10) ,
-\end{lstlisting}
-the function \code{sum} is applied to the squaring function 
-\code{(x => x * x)}. The resulting function is then 
-applied to the second argument list, \code{(1, 10)}.
-
-This notation is possible because function application associates to the left.
-That is, if $\mbox{args}_1$ and $\mbox{args}_2$ are argument lists, then 
-\bda{lcl}
-f(\mbox{args}_1)(\mbox{args}_2) & \ \ \mbox{is equivalent to}\ \ & (f(\mbox{args}_1))(\mbox{args}_2)
-\eda
-In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
-following expression:
-\code{(sum(x => x * x))(1, 10)}.
-
-The style of function-returning functions is so useful that Scala has
-special syntax for it. For instance, the next definition of \code{sum}
-is equivalent to the previous one, but is shorter:
-\begin{lstlisting}
-def sum(f: Int => Int)(a: Int, b: Int): Int =
-  if (a > b) 0 else f(a) + sum(f)(a + 1, b)
-\end{lstlisting}
-Generally, a curried function definition 
-\begin{lstlisting}
-def f (args$_1$) ... (args$_n$) = E
-\end{lstlisting}
-where $n > 1$ expands to
-\begin{lstlisting}
-def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
-\end{lstlisting}
-where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
-\begin{lstlisting}
-def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
-\end{lstlisting}
-Performing this step $n$ times yields that
-\begin{lstlisting}
-def f (args$_1$) ... (args$_n$) = E
-\end{lstlisting}
-is equivalent to
-\begin{lstlisting}
-def f = (args$_1$) => ... => (args$_n$) => E .
-\end{lstlisting}
-Or, equivalently, using a value definition:
-\begin{lstlisting}
-val f = (args$_1$) => ... => (args$_n$) => E .
-\end{lstlisting}
-This style of function definition and application is called {\em
-currying} after its promoter, Haskell B.\ Curry, a logician of the
-20th century, even though the idea goes back further to Moses
-Sch\"onfinkel and Gottlob Frege.
-
-The type of a function-returning function is expressed analogously to
-its parameter list. Taking the last formulation of \code{sum} as an example,
-the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
-This is possible because function types associate to the right. I.e.
-\begin{lstlisting}
-T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
-\end{lstlisting}
-
-
-\begin{exercise}
-1. The \code{sum} function uses a linear recursion. Can you write a
-tail-recursive one by filling in the ??'s?
-
-\begin{lstlisting}
-def sum(f: Int => Int)(a: Int, b: Int): Int = {
-  def iter(a: Int, result: Int): Int = {
-    if (??) ??
-    else iter(??, ??)
-  }
-  iter(??, ??)
-}
-\end{lstlisting}
-\end{exercise}
-
-\begin{exercise}
-Write a function \code{product} that computes the product of the
-values of functions at points over a given range.
-\end{exercise}
-
-\begin{exercise}
-Write \code{factorial} in terms of \code{product}.
-\end{exercise}
-
-\begin{exercise}
-Can you write an even more general function which generalizes both
-\code{sum} and \code{product}?
-\end{exercise}
-
-\section{Example: Finding Fixed Points of Functions}
-
-A number \code{x} is called a {\em fixed point} of a function \code{f} if
-\begin{lstlisting}
-f(x) = x .
-\end{lstlisting}
-For some functions \code{f} we can locate the fixed point by beginning
-with an initial guess and then applying \code{f} repeatedly, until the
-value does not change anymore (or the change is within a small
-tolerance). This is possible if the sequence
-\begin{lstlisting}
-x, f(x), f(f(x)), f(f(f(x))), ...
-\end{lstlisting}
-converges to fixed point of $f$. This idea is captured in
-the following ``fixed-point finding function'':
-\begin{lstlisting}
-val tolerance = 0.0001
-def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
-def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-  def iterate(guess: Double): Double = {
-    val next = f(guess)
-    if (isCloseEnough(guess, next)) next
-    else iterate(next)
-  }
-  iterate(firstGuess)
-}
-\end{lstlisting}
-We now apply this idea in a reformulation of the square root function.
-Let's start with a specification of \code{sqrt}:
-\begin{lstlisting}
-sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
-         =  $\mbox{the {\sl y} such that}$  y = x / y
-\end{lstlisting}
-Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
-This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
-\begin{lstlisting}
-def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
-\end{lstlisting}
-But if we try this, we find that the computation does not
-converge. Let's instrument the fixed point function with a print
-statement which keeps track of the current \code{guess} value:
-\begin{lstlisting}
-def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-  def iterate(guess: Double): Double = {
-    val next = f(guess)
-    println(next)
-    if (isCloseEnough(guess, next)) next
-    else iterate(next)
-  }
-  iterate(firstGuess)
-}
-\end{lstlisting}
-Then, \code{sqrt(2)} yields:
-\begin{lstlisting}
-  2.0
-  1.0
-  2.0
-  1.0
-  2.0
-  ...
-\end{lstlisting}
-One way to control such oscillations is to prevent the guess from changing too much. 
-This can be achieved by {\em averaging} successive values of the original sequence:
-\begin{lstlisting}
-scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
-sqrt: (Double)Double
-
-scala> sqrt(2.0)
-  1.5
-  1.4166666666666665
-  1.4142156862745097
-  1.4142135623746899
-  1.4142135623746899
-\end{lstlisting}
-In fact, expanding the \code{fixedPoint} function yields exactly our 
-previous definition of fixed point from Section~\ref{sec:sqrt}.
-
-The previous examples showed that the expressive power of a language
-is considerably enhanced if functions can be passed as arguments.  The
-next example shows that functions which return functions can also be
-very useful.
-
-Consider again fixed point iterations. We started with the observation
-that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
-Then we made the iteration converge by averaging successive values.
-This technique of {\em average damping} is so general that it
-can be wrapped in another function.
-\begin{lstlisting}
-def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
-\end{lstlisting}
-Using \code{averageDamp}, we can reformulate the square root function
-as follows.
-\begin{lstlisting}
-def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
-\end{lstlisting}
-This expresses the elements of the algorithm as clearly as possible.
-
-\begin{exercise} Write a function for cube roots using \code{fixedPoint} and 
-\code{averageDamp}.
-\end{exercise}
-
-\section{Summary}
-
-We have seen in the previous chapter that functions are essential
-abstractions, because they permit us to introduce general methods of
-computing as explicit, named elements in our programming language.
-The present chapter has shown that these abstractions can be combined
-by higher-order functions to create further abstractions.  As
-programmers, we should look out for opportunities to abstract and to
-reuse. The highest possible level of abstraction is not always the
-best, but it is important to know abstraction techniques, so that one
-can use abstractions where appropriate.
-
-\section{Language Elements Seen So Far}
-
-Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
-covered Scala's language elements to express expressions and types
-comprising of primitive data and functions.  The context-free syntax
-of these language elements is given below in extended Backus-Naur
-form, where `\code{|}' denotes alternatives, \code{[...]} denotes
-option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
-(0 or more occurrences).
-
-\subsection*{Characters}
-
-Scala programs are sequences of (Unicode) characters. We distinguish the
-following character sets:
-\begin{itemize}
-\item
-whitespace, such as `\code{ }', tabulator, or newline characters,
-\item
-letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
-\item
-digits \code{`0'} to `\code{9}',
-\item
-the delimiter characters
-
-\begin{lstlisting}
-.    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
-\end{lstlisting}
-
-\item
-operator characters, such as `\code{#}' `\code{+}',
-`\code{:}'. Essentially, these are printable characters which are
-in none of the character sets above.
-\end{itemize}
-
-\subsection*{Lexemes:}
-
-\begin{lstlisting}
-ident    =  letter {letter | digit}
-         |  operator { operator }
-         |  ident '_' ident
-literal  =  $\mbox{``as in Java''}$
-\end{lstlisting}
-
-Literals are as in Java. They define numbers, characters, strings, or
-boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
-\code{"he said \"hi!\""}, or \code{true}.
-
-Identifiers can be of two forms. They either start with a letter,
-which is followed by a (possibly empty) sequence of letters or
-symbols, or they start with an operator character, which is followed
-by a (possibly empty) sequence of operator characters.  Both forms of
-identifiers may contain underscore characters `\code{_}'. Furthermore,
-an underscore character may be followed by either sort of
-identifier. Hence, the following are all legal identifiers:
-\begin{lstlisting}
-x     Room10a     +     --     foldl_:     +_vector
-\end{lstlisting}
-It follows from this rule that subsequent operator-identifiers need to
-be separated by whitespace. For instance, the input
-\code{x+-y} is parsed as the three token sequence \code{x}, \code{+-},
-\code{y}. If we want to express the sum of \code{x} with the
-negated value of \code{y}, we need to add at least one space,
-e.g. \code{x+ -y}.
-
-The \verb@$@ character is reserved for compiler-generated
-identifiers; it should not be used in source programs. %$
-
-The following are reserved words, they may not be used as identifiers:
-\begin{lstlisting}
-abstract    case        catch       class       def    
-do          else        extends     false       final    
-finally     for         if          implicit    import      
-match       new         null        object      override    
-package     private     protected   requires    return      
-sealed      super       this        throw       trait
-try         true        type        val         var         
-while       with        yield
-_    :    =    =>    <-    <:    <%     >:    #    @
-\end{lstlisting}
-
-\subsection*{Types:}
-
-\begin{lstlisting}
-Type          =  SimpleType | FunctionType
-FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
-SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
-                 Boolean | Unit | String
-Types         =  Type {`,' Type}
-\end{lstlisting}
-
-Types can be:
-\begin{itemize}
-\item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
-\item the type \code{Boolean} with values \code{true} and \code{false},
-\item the type \code{Unit} with the only value \lstinline@()@,
-\item the type \code{String},
-\item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
-\end{itemize}
-
-\subsection*{Expressions:}
-
-\begin{lstlisting}
-Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
-InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
-Operator     = ident
-PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
-SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
-FunctionExpr = (Bindings | Id) '=>' Expr
-Bindings     = `(' Binding {`,' Binding} `)'
-Binding      = ident [':' Type]
-Block        = '{' {Def ';'} Expr '}'
-\end{lstlisting}
-
-Expressions can be:
-\begin{itemize}
-\item
-identifiers such as \code{x}, \code{isGoodEnough}, \code{*}, or \code{+-},
-\item
-literals, such as \code{0}, \code{1.0}, or \code{"abc"},
-\item
-field and method selections, such as \code{System.out.println},
-\item
-function applications, such as \code{sqrt(x)}, 
-\item
-operator applications, such as \code{-x} or \code{y + x},
-\item
-conditionals, such as \code{if (x < 0) -x else x},
-\item
-blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
-\item
-anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
-\end{itemize}
-
-\subsection*{Definitions:}
-
-\begin{lstlisting}
-Def          =  FunDef  |  ValDef
-FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
-ValDef       =  'val' ident [':' Type] '=' Expr
-Parameters   =  Parameter {',' Parameter}
-Parameter    =  ident ':' ['=>'] Type
-\end{lstlisting}
-Definitions can be:
-\begin{itemize}
-\item
-function definitions such as \code{def square(x: Int): Int = x * x},
-\item
-value definitions such as \code{val y = square(2)}.
-\end{itemize}
-
-\chapter{Classes and Objects}
-\label{chap:classes}
-
-Scala does not have a built-in type of rational numbers, but it is
-easy to define one, using a class. Here's a possible implementation.
-
-\begin{lstlisting}
-class Rational(n: Int, d: Int) {
-  private def gcd(x: Int, y: Int): Int = {
-    if (x == 0) y
-    else if (x < 0) gcd(-x, y)
-    else if (y < 0) -gcd(x, -y)
-    else gcd(y % x, x)
-  }
-  private val g = gcd(n, d)
-
-  val numer: Int = n/g
-  val denom: Int = d/g
-  def +(that: Rational) =
-    new Rational(numer * that.denom + that.numer * denom,
-                 denom * that.denom)
-  def -(that: Rational) =
-    new Rational(numer * that.denom - that.numer * denom, 
-                 denom * that.denom)
-  def *(that: Rational) =
-    new Rational(numer * that.numer, denom * that.denom)
-  def /(that: Rational) =
-    new Rational(numer * that.denom, denom * that.numer)
-}
-\end{lstlisting}
-This defines \code{Rational} as a class which takes two constructor
-arguments \code{n} and \code{d}, containing the number's numerator and
-denominator parts.  The class provides fields which return these parts
-as well as methods for arithmetic over rational numbers.  Each
-arithmetic method takes as parameter the right operand of the
-operation. The left operand of the operation is always the rational
-number of which the method is a member.
-
-\paragraph{Private members}
-The implementation of rational numbers defines a private method
-\code{gcd} which computes the greatest common denominator of two
-integers, as well as a private field \code{g} which contains the
-\code{gcd} of the constructor arguments. These members are inaccessible
-outside class \code{Rational}. They are used in the implementation of
-the class to eliminate common factors in the constructor arguments in
-order to ensure that numerator and denominator are always in
-normalized form.
-
-\paragraph{Creating and Accessing Objects}
-As an example of how rational numbers can be used, here's a program
-that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
-\begin{lstlisting}
-var i = 1
-var x = new Rational(0, 1)
-while (i <= 10) {
-  x += new Rational(1, i)
-  i += 1
-}
-println("" + x.numer + "/" + x.denom)
-\end{lstlisting}
-The \code{+} takes as left operand a string and as right operand a
-value of arbitrary type. It returns the result of converting its right
-operand to a string and appending it to its left operand. 
+%% \begin{lstlisting}
+%% scala> def constOne(x: Int, y: => Int) = 1
+%% constOne: (Int,=> Int)Int
+
+%% scala> constOne(1, loop)
+%% unnamed0: Int = 1
+
+%% scala> constOne(loop, 2)               // gives an infinite loop.
+%% ^C                                     // stops execution with Ctrl-C
+%% \end{lstlisting}
+
+%% \section{Conditional Expressions}
+
+%% Scala's \code{if-else} lets one choose between two alternatives.  Its
+%% syntax is like Java's \code{if-else}. But where Java's \code{if-else}
+%% can be used only as an alternative of statements, Scala allows the
+%% same syntax to choose between two expressions. That's why Scala's
+%% \code{if-else} serves also as a substitute for Java's conditional
+%% expression \code{ ... ? ... : ...}.
+
+%% \example\ 
+
+%% \begin{lstlisting}
+%% scala> def abs(x: Double) = if (x >= 0) x else -x
+%% abs: (Double)Double
+%% \end{lstlisting}
+%% Scala's boolean expressions are similar to Java's; they are formed
+%% from the constants
+%% \code{true} and
+%% \code{false}, comparison operators, boolean negation \code{!} and the
+%% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
+
+%% \section{\label{sec:sqrt}Example: Square Roots by Newton's Method}
+
+%% We now illustrate the language elements introduced so far in the
+%% construction of a more interesting program. The task is to write a
+%% function
+%% \begin{lstlisting}
+%% def sqrt(x: Double): Double = ...
+%% \end{lstlisting}
+%% which computes the square root of \code{x}.
+
+%% A common way to compute square roots is by Newton's method of
+%% successive approximations. One starts with an initial guess \code{y}
+%% (say: \code{y = 1}). One then repeatedly improves the current guess
+%% \code{y} by taking the average of \code{y} and \code{x/y}.  As an
+%% example, the next three columns indicate the guess \code{y}, the
+%% quotient \code{x/y}, and their average for the first approximations of
+%% $\sqrt 2$.
+%% \begin{lstlisting}
+%% 1            2/1 = 2               1.5
+%% 1.5          2/1.5 = 1.3333        1.4167
+%% 1.4167       2/1.4167 = 1.4118     1.4142
+%% 1.4142       ...                   ...
+
+%% $y$            $x/y$                   $(y + x/y)/2$
+%% \end{lstlisting}
+%% One can implement this algorithm in Scala by a set of small functions,
+%% which each represent one of the elements of the algorithm.  
+
+%% We first define a function for iterating from a guess to the result:
+%% \begin{lstlisting}
+%% def sqrtIter(guess: Double, x: Double): Double =
+%%   if (isGoodEnough(guess, x)) guess
+%%   else sqrtIter(improve(guess, x), x)
+%% \end{lstlisting}
+%% Note that \code{sqrtIter} calls itself recursively.  Loops in
+%% imperative programs can always be modeled by recursion in functional
+%% programs. 
+
+%% Note also that the definition of \code{sqrtIter} contains a return
+%% type, which follows the parameter section. Such return types are
+%% mandatory for recursive functions. For a non-recursive function, the
+%% return type is optional; if it is missing the type checker will
+%% compute it from the type of the function's right-hand side. However,
+%% even for non-recursive functions it is often a good idea to include a
+%% return type for better documentation.
+
+%% As a second step, we define the two functions called by
+%% \code{sqrtIter}: a function to \code{improve} the guess and a
+%% termination test \code{isGoodEnough}. Here is their definition.
+%% \begin{lstlisting}
+%% def improve(guess: Double, x: Double) =
+%%   (guess + x / guess) / 2
+
+%% def isGoodEnough(guess: Double, x: Double) =
+%%   abs(square(guess) - x) < 0.001
+%% \end{lstlisting}
+
+%% Finally, the \code{sqrt} function itself is defined by an application
+%% of \code{sqrtIter}.
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = sqrtIter(1.0, x)
+%% \end{lstlisting}
+
+%% \begin{exercise} The \code{isGoodEnough} test is not very precise for small
+%% numbers and might lead to non-termination for very large ones (why?).
+%% Design a different version of \code{isGoodEnough} which does not have
+%% these problems.
+%% \end{exercise}
+
+%% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
+%% \end{exercise}
+
+%% \section{Nested Functions}
+
+%% The functional programming style encourages the construction of many
+%% small helper functions. In the last example, the implementation
+%% of \code{sqrt} made use of the helper functions \code{sqrtIter},
+%% \code{improve} and \code{isGoodEnough}. The names of these functions
+%% are relevant only for the implementation of \code{sqrt}. We normally
+%% do not want users of \code{sqrt} to access these functions directly.
+
+%% We can enforce this (and avoid name-space pollution) by including
+%% the helper functions within the calling function itself:
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double, x: Double): Double =
+%%     if (isGoodEnough(guess, x)) guess
+%%     else sqrtIter(improve(guess, x), x)
+%%   def improve(guess: Double, x: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double, x: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0, x)
+%% }
+%% \end{lstlisting}
+%% In this program, the braces \code{\{ ... \}} enclose a {\em block}.
+%% Blocks in Scala are themselves expressions.  Every block ends in a
+%% result expression which defines its value.  The result expression may
+%% be preceded by auxiliary definitions, which are visible only in the
+%% block itself.
+
+%% Every definition in a block must be followed by a semicolon, 
+%% which separates this definition from subsequent definitions or the result
+%% expression. However, a semicolon is inserted implicitly at the end of
+%% each line, unless one of the following conditions is
+%% true.
+%% \begin{enumerate}
+%% \item
+%% Either the line in question ends in a word such as a period 
+%% or an infix-operator which would not be legal as the end of an expression.
+%% \item
+%% Or the next line begins with a word that cannot start a expression.
+%% \item
+%% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
+%% because these cannot contain multiple statements anyway.
+%% \end{enumerate}
+%% Therefore, the following are all legal:
+%% \begin{lstlisting}
+%% def f(x: Int) = x + 1;
+%% f(1) + f(2)
+
+%% def g1(x: Int) = x + 1
+%% g(1) + g(2)
+
+%% def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
+
+%% def h1(x) = 
+%%   x + 
+%%   y
+%% h1(1) * h1(2)
+
+%% def h2(x: Int) = (
+%%   x     // parentheses mandatory, otherwise a semicolon
+%%   + y   // would be inserted after the `x'.
+%% )
+%% h2(1) / h2(2)
+%% \end{lstlisting}
+%% Scala uses the usual block-structured scoping rules. A name defined in
+%% some outer block is visible also in some inner block, provided it is
+%% not redefined there. This rule permits us to simplify our
+%% \code{sqrt} example. We need not pass \code{x} around as an additional parameter of
+%% the nested functions, since it is always visible in them as a
+%% parameter of the outer function \code{sqrt}. Here is the simplified code:
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double): Double =
+%%     if (isGoodEnough(guess)) guess
+%%     else sqrtIter(improve(guess))
+%%   def improve(guess: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0)
+%% }
+%% \end{lstlisting}
+
+%% \section{Tail Recursion}
+
+%% Consider the following function to compute the greatest common divisor
+%% of two given numbers.
+
+%% \begin{lstlisting}
+%% def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+%% \end{lstlisting}
+
+%% Using our substitution model of function evaluation, 
+%% \code{gcd(14, 21)} evaluates as follows:
+
+%% \begin{lstlisting}
+%% $\,\,$      gcd(14, 21)  
+%% $\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14)
+%% $\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
+%% $\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
+%% $\rightarrow\!$     gcd(14, 7)
+%% $\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
+%% $\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
+%% $\rightarrow\!$     gcd(7, 0)
+%% $\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
+%% $\rightarrow$ $\rightarrow$  7
+%% \end{lstlisting}
+
+%% Contrast this with the evaluation of another recursive function, 
+%% \code{factorial}:
+
+%% \begin{lstlisting}
+%% def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
+%% \end{lstlisting}
+
+%% The application \code{factorial(5)} rewrites as follows:
+%% \begin{lstlisting}
+%% $\,\,\,$       factorial(5)
+%% $\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(4)
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
+%% $\rightarrow\ldots\rightarrow$  120
+%% \end{lstlisting}
+%% There is an important difference between the two rewrite sequences:
+%% The terms in the rewrite sequence of \code{gcd} have again and again
+%% the same form. As evaluation proceeds, their size is bounded by a
+%% constant. By contrast, in the evaluation of factorial we get longer
+%% and longer chains of operands which are then multiplied in the last
+%% part of the evaluation sequence.
+
+%% Even though actual implementations of Scala do not work by rewriting
+%% terms, they nevertheless should have the same space behavior as in the
+%% rewrite sequences. In the implementation of \code{gcd}, one notes that
+%% the recursive call to \code{gcd} is the last action performed in the
+%% evaluation of its body. One also says that \code{gcd} is
+%% ``tail-recursive''. The final call in a tail-recursive function can be
+%% implemented by a jump back to the beginning of that function. The
+%% arguments of that call can overwrite the parameters of the current
+%% instantiation of \code{gcd}, so that no new stack space is needed.
+%% Hence, tail recursive functions are iterative processes, which can be
+%% executed in constant space.
+
+%% By contrast, the recursive call in \code{factorial} is followed by a
+%% multiplication.  Hence, a new stack frame is allocated for the
+%% recursive instance of factorial, and is deallocated after that
+%% instance has finished. The given formulation of the factorial function
+%% is not tail-recursive; it needs space proportional to its input
+%% parameter for its execution.
+
+%% More generally, if the last action of a function is a call to another
+%% (possibly the same) function, only a single stack frame is needed for
+%% both functions. Such calls are called ``tail calls''. In principle,
+%% tail calls can always re-use the stack frame of the calling function.
+%% However, some run-time environments (such as the Java VM) lack the
+%% primitives to make stack frame re-use for tail calls efficient.  A
+%% production quality Scala implementation is therefore only required to
+%% re-use the stack frame of a directly tail-recursive function whose
+%% last action is a call to itself.  Other tail calls might be optimized
+%% also, but one should not rely on this across implementations.
+
+%% \begin{exercise} Design a tail-recursive version of
+%% \code{factorial}.
+%% \end{exercise}
+
+%% \chapter{\label{chap:first-class-funs}First-Class Functions}
+
+%% A function in Scala is a ``first-class value''. Like any other value,
+%% it may be passed as a parameter or returned as a result.  Functions
+%% which take other functions as parameters or return them as results are
+%% called {\em higher-order} functions. This chapter introduces
+%% higher-order functions and shows how they provide a flexible mechanism
+%% for program composition.
+
+%% As a motivating example, consider the following three related tasks:
+%% \begin{enumerate}
+%% \item
+%% Write a function to sum all integers between two given numbers \code{a} and \code{b}:
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int =
+%%   if (a > b) 0 else a + sumInts(a + 1, b)
+%% \end{lstlisting}
+%% \item 
+%% Write a function to sum the squares of all integers between two given numbers 
+%% \code{a} and \code{b}:
+%% \begin{lstlisting}
+%% def square(x: Int): Int = x * x
+%% def sumSquares(a: Int, b: Int): Int =
+%%   if (a > b) 0 else square(a) + sumSquares(a + 1, b)
+%% \end{lstlisting}
+%% \item
+%% Write a function to sum the powers $2^n$ of all integers $n$ between
+%% two given numbers \code{a} and \code{b}:
+%% \begin{lstlisting}
+%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+%% def sumPowersOfTwo(a: Int, b: Int): Int =
+%%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
+%% \end{lstlisting}
+%% \end{enumerate}
+%% These functions are all instances of
+%% \(\sum^b_a f(n)\) for different values of $f$. 
+%% We can factor out the common pattern by defining a function \code{sum}:
+%% \begin{lstlisting}
+%% def sum(f: Int => Int, a: Int, b: Int): Int =
+%%   if (a > b) 0 else f(a) + sum(f, a + 1, b)
+%% \end{lstlisting}
+%% The type \code{Int => Int} is the type of functions that
+%% take arguments of type \code{Int} and return results of type
+%% \code{Int}. So \code{sum} is a function which takes another function as
+%% a parameter. In other words, \code{sum} is a {\em higher-order}
+%% function.
+
+%% Using \code{sum}, we can formulate the three summing functions as
+%% follows.
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum(id, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
+%% def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
+%% \end{lstlisting}
+%% where
+%% \begin{lstlisting}
+%% def id(x: Int): Int = x
+%% def square(x: Int): Int = x * x
+%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+%% \end{lstlisting}
+
+%% \section{Anonymous Functions}
+
+%% Parameterization by functions tends to create many small functions. In
+%% the previous example, we defined \code{id}, \code{square} and
+%% \code{power} as separate functions, so that they could be 
+%% passed as arguments to \code{sum}.
+
+%% Instead of using named function definitions for these small argument
+%% functions, we can formulate them in a shorter way as {\em anonymous
+%% functions}. An anonymous function is an expression that evaluates to a
+%% function; the function is defined without giving it a name. As an
+%% example consider the anonymous square function:
+%% \begin{lstlisting}
+%%   (x: Int) => x * x
+%% \end{lstlisting}
+%% The part before the arrow `\code{=>}' are the parameters of the function,
+%% whereas the part following the `\code{=>}' is its body. 
+%% For instance, here is an anonymous function which multiples its two arguments.
+%% \begin{lstlisting}
+%%   (x: Int, y: Int) => x * y
+%% \end{lstlisting}
+%% Using anonymous functions, we can reformulate the first two summation
+%% functions without named auxiliary functions:
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
+%% \end{lstlisting}
+%% Often, the Scala compiler can deduce the parameter type(s) from the
+%% context of the anonymous function in which case they can be omitted.
+%% For instance, in the case of \code{sumInts} or \code{sumSquares}, one
+%% knows from the type of \code{sum} that the first parameter must be a
+%% function of type \code{Int => Int}.  Hence, the parameter type
+%% \code{Int} is redundant and may be omitted. If there is a single
+%% parameter without a type, we may also omit the parentheses around it:
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
+%% \end{lstlisting}
+
+%% Generally, the Scala term
+%% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
+%% defines a function which maps its parameters
+%% \code{x}$_1$\code{, ..., x}$_n$ to the result of the expression \code{E}
+%% (where \code{E} may refer to \code{x}$_1$\code{, ..., x}$_n$).  Anonymous
+%% functions are not essential language elements of Scala, as they can
+%% always be expressed in terms of named functions. Indeed, the 
+%% anonymous function
+%% \begin{lstlisting}
+%% (x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
+%% \end{lstlisting}
+%% is equivalent to the block
+%% \begin{lstlisting}
+%% { def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
+%% \end{lstlisting}
+%% where \code{f} is fresh name which is used nowhere else in the program.
+%% We also say, anonymous functions are ``syntactic sugar''.
+
+%% \section{Currying}
+
+%% The latest formulation of the summing functions is already quite
+%% compact. But we can do even better. Note that
+%% \code{a} and \code{b} appear as parameters and arguments of every function
+%% but they do not seem to take part in interesting combinations. Is
+%% there a way to get rid of them?
+
+%% Let's try to rewrite \code{sum} so that it does not take the bounds
+%% \code{a} and \code{b} as parameters:
+%% \begin{lstlisting}
+%% def sum(f: Int => Int): (Int, Int) => Int = {
+%%   def sumF(a: Int, b: Int): Int =
+%%     if (a > b) 0 else f(a) + sumF(a + 1, b)
+%%   sumF
+%% }
+%% \end{lstlisting}
+%% In this formulation, \code{sum} is a function which returns another
+%% function, namely the specialized summing function \code{sumF}. This
+%% latter function does all the work; it takes the bounds \code{a} and
+%% \code{b} as parameters, applies \code{sum}'s function parameter \code{f} to all
+%% integers between them, and sums up the results. 
+
+%% Using this new formulation of \code{sum}, we can now define:
+%% \begin{lstlisting}
+%% def sumInts  =  sum(x => x)
+%% def sumSquares  =  sum(x => x * x)
+%% def sumPowersOfTwo  =  sum(powerOfTwo)
+%% \end{lstlisting}
+%% Or, equivalently, with value definitions:
+%% \begin{lstlisting}
+%% val sumInts  =  sum(x => x)
+%% val sumSquares  =  sum(x => x * x)
+%% val sumPowersOfTwo  =  sum(powerOfTwo)
+%% \end{lstlisting}
+
+%% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
+%% applied like any other function. For instance,
+%% \begin{lstlisting}
+%% scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
+%% unnamed0: Int = 2096513
+%% \end{lstlisting}
+%% How are function-returning functions applied? As an example, in the expression
+%% \begin{lstlisting}
+%% sum(x => x * x)(1, 10) ,
+%% \end{lstlisting}
+%% the function \code{sum} is applied to the squaring function 
+%% \code{(x => x * x)}. The resulting function is then 
+%% applied to the second argument list, \code{(1, 10)}.
+
+%% This notation is possible because function application associates to the left.
+%% That is, if $\mbox{args}_1$ and $\mbox{args}_2$ are argument lists, then 
+%% \bda{lcl}
+%% f(\mbox{args}_1)(\mbox{args}_2) & \ \ \mbox{is equivalent to}\ \ & (f(\mbox{args}_1))(\mbox{args}_2)
+%% \eda
+%% In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
+%% following expression:
+%% \code{(sum(x => x * x))(1, 10)}.
+
+%% The style of function-returning functions is so useful that Scala has
+%% special syntax for it. For instance, the next definition of \code{sum}
+%% is equivalent to the previous one, but is shorter:
+%% \begin{lstlisting}
+%% def sum(f: Int => Int)(a: Int, b: Int): Int =
+%%   if (a > b) 0 else f(a) + sum(f)(a + 1, b)
+%% \end{lstlisting}
+%% Generally, a curried function definition 
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_n$) = E
+%% \end{lstlisting}
+%% where $n > 1$ expands to
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
+%% \end{lstlisting}
+%% where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
+%% \end{lstlisting}
+%% Performing this step $n$ times yields that
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_n$) = E
+%% \end{lstlisting}
+%% is equivalent to
+%% \begin{lstlisting}
+%% def f = (args$_1$) => ... => (args$_n$) => E .
+%% \end{lstlisting}
+%% Or, equivalently, using a value definition:
+%% \begin{lstlisting}
+%% val f = (args$_1$) => ... => (args$_n$) => E .
+%% \end{lstlisting}
+%% This style of function definition and application is called {\em
+%% currying} after its promoter, Haskell B.\ Curry, a logician of the
+%% 20th century, even though the idea goes back further to Moses
+%% Sch\"onfinkel and Gottlob Frege.
+
+%% The type of a function-returning function is expressed analogously to
+%% its parameter list. Taking the last formulation of \code{sum} as an example,
+%% the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
+%% This is possible because function types associate to the right. I.e.
+%% \begin{lstlisting}
+%% T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
+%% \end{lstlisting}
+
+
+%% \begin{exercise}
+%% 1. The \code{sum} function uses a linear recursion. Can you write a
+%% tail-recursive one by filling in the ??'s?
+
+%% \begin{lstlisting}
+%% def sum(f: Int => Int)(a: Int, b: Int): Int = {
+%%   def iter(a: Int, result: Int): Int = {
+%%     if (??) ??
+%%     else iter(??, ??)
+%%   }
+%%   iter(??, ??)
+%% }
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \begin{exercise}
+%% Write a function \code{product} that computes the product of the
+%% values of functions at points over a given range.
+%% \end{exercise}
+
+%% \begin{exercise}
+%% Write \code{factorial} in terms of \code{product}.
+%% \end{exercise}
+
+%% \begin{exercise}
+%% Can you write an even more general function which generalizes both
+%% \code{sum} and \code{product}?
+%% \end{exercise}
+
+%% \section{Example: Finding Fixed Points of Functions}
+
+%% A number \code{x} is called a {\em fixed point} of a function \code{f} if
+%% \begin{lstlisting}
+%% f(x) = x .
+%% \end{lstlisting}
+%% For some functions \code{f} we can locate the fixed point by beginning
+%% with an initial guess and then applying \code{f} repeatedly, until the
+%% value does not change anymore (or the change is within a small
+%% tolerance). This is possible if the sequence
+%% \begin{lstlisting}
+%% x, f(x), f(f(x)), f(f(f(x))), ...
+%% \end{lstlisting}
+%% converges to fixed point of $f$. This idea is captured in
+%% the following ``fixed-point finding function'':
+%% \begin{lstlisting}
+%% val tolerance = 0.0001
+%% def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
+%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+%%   def iterate(guess: Double): Double = {
+%%     val next = f(guess)
+%%     if (isCloseEnough(guess, next)) next
+%%     else iterate(next)
+%%   }
+%%   iterate(firstGuess)
+%% }
+%% \end{lstlisting}
+%% We now apply this idea in a reformulation of the square root function.
+%% Let's start with a specification of \code{sqrt}:
+%% \begin{lstlisting}
+%% sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
+%%          =  $\mbox{the {\sl y} such that}$  y = x / y
+%% \end{lstlisting}
+%% Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
+%% This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
+%% \begin{lstlisting}
+%% def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
+%% \end{lstlisting}
+%% But if we try this, we find that the computation does not
+%% converge. Let's instrument the fixed point function with a print
+%% statement which keeps track of the current \code{guess} value:
+%% \begin{lstlisting}
+%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+%%   def iterate(guess: Double): Double = {
+%%     val next = f(guess)
+%%     println(next)
+%%     if (isCloseEnough(guess, next)) next
+%%     else iterate(next)
+%%   }
+%%   iterate(firstGuess)
+%% }
+%% \end{lstlisting}
+%% Then, \code{sqrt(2)} yields:
+%% \begin{lstlisting}
+%%   2.0
+%%   1.0
+%%   2.0
+%%   1.0
+%%   2.0
+%%   ...
+%% \end{lstlisting}
+%% One way to control such oscillations is to prevent the guess from changing too much. 
+%% This can be achieved by {\em averaging} successive values of the original sequence:
+%% \begin{lstlisting}
+%% scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
+%% sqrt: (Double)Double
+
+%% scala> sqrt(2.0)
+%%   1.5
+%%   1.4166666666666665
+%%   1.4142156862745097
+%%   1.4142135623746899
+%%   1.4142135623746899
+%% \end{lstlisting}
+%% In fact, expanding the \code{fixedPoint} function yields exactly our 
+%% previous definition of fixed point from Section~\ref{sec:sqrt}.
+
+%% The previous examples showed that the expressive power of a language
+%% is considerably enhanced if functions can be passed as arguments.  The
+%% next example shows that functions which return functions can also be
+%% very useful.
+
+%% Consider again fixed point iterations. We started with the observation
+%% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
+%% Then we made the iteration converge by averaging successive values.
+%% This technique of {\em average damping} is so general that it
+%% can be wrapped in another function.
+%% \begin{lstlisting}
+%% def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
+%% \end{lstlisting}
+%% Using \code{averageDamp}, we can reformulate the square root function
+%% as follows.
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
+%% \end{lstlisting}
+%% This expresses the elements of the algorithm as clearly as possible.
+
+%% \begin{exercise} Write a function for cube roots using \code{fixedPoint} and 
+%% \code{averageDamp}.
+%% \end{exercise}
+
+%% \section{Summary}
+
+%% We have seen in the previous chapter that functions are essential
+%% abstractions, because they permit us to introduce general methods of
+%% computing as explicit, named elements in our programming language.
+%% The present chapter has shown that these abstractions can be combined
+%% by higher-order functions to create further abstractions.  As
+%% programmers, we should look out for opportunities to abstract and to
+%% reuse. The highest possible level of abstraction is not always the
+%% best, but it is important to know abstraction techniques, so that one
+%% can use abstractions where appropriate.
+
+%% \section{Language Elements Seen So Far}
+
+%% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
+%% covered Scala's language elements to express expressions and types
+%% comprising of primitive data and functions.  The context-free syntax
+%% of these language elements is given below in extended Backus-Naur
+%% form, where `\code{|}' denotes alternatives, \code{[...]} denotes
+%% option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
+%% (0 or more occurrences).
+
+%% \subsection*{Characters}
+
+%% Scala programs are sequences of (Unicode) characters. We distinguish the
+%% following character sets:
+%% \begin{itemize}
+%% \item
+%% whitespace, such as `\code{ }', tabulator, or newline characters,
+%% \item
+%% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
+%% \item
+%% digits \code{`0'} to `\code{9}',
+%% \item
+%% the delimiter characters
+
+%% \begin{lstlisting}
+%% .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
+%% \end{lstlisting}
+
+%% \item
+%% operator characters, such as `\code{#}' `\code{+}',
+%% `\code{:}'. Essentially, these are printable characters which are
+%% in none of the character sets above.
+%% \end{itemize}
+
+%% \subsection*{Lexemes:}
+
+%% \begin{lstlisting}
+%% ident    =  letter {letter | digit}
+%%          |  operator { operator }
+%%          |  ident '_' ident
+%% literal  =  $\mbox{``as in Java''}$
+%% \end{lstlisting}
+
+%% Literals are as in Java. They define numbers, characters, strings, or
+%% boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
+%% \code{"he said \"hi!\""}, or \code{true}.
+
+%% Identifiers can be of two forms. They either start with a letter,
+%% which is followed by a (possibly empty) sequence of letters or
+%% symbols, or they start with an operator character, which is followed
+%% by a (possibly empty) sequence of operator characters.  Both forms of
+%% identifiers may contain underscore characters `\code{_}'. Furthermore,
+%% an underscore character may be followed by either sort of
+%% identifier. Hence, the following are all legal identifiers:
+%% \begin{lstlisting}
+%% x     Room10a     +     --     foldl_:     +_vector
+%% \end{lstlisting}
+%% It follows from this rule that subsequent operator-identifiers need to
+%% be separated by whitespace. For instance, the input
+%% \code{x+-y} is parsed as the three token sequence \code{x}, \code{+-},
+%% \code{y}. If we want to express the sum of \code{x} with the
+%% negated value of \code{y}, we need to add at least one space,
+%% e.g. \code{x+ -y}.
+
+%% The \verb@$@ character is reserved for compiler-generated
+%% identifiers; it should not be used in source programs. %$
+
+%% The following are reserved words, they may not be used as identifiers:
+%% \begin{lstlisting}
+%% abstract    case        catch       class       def    
+%% do          else        extends     false       final    
+%% finally     for         if          implicit    import      
+%% match       new         null        object      override    
+%% package     private     protected   requires    return      
+%% sealed      super       this        throw       trait
+%% try         true        type        val         var         
+%% while       with        yield
+%% _    :    =    =>    <-    <:    <%     >:    #    @
+%% \end{lstlisting}
+
+%% \subsection*{Types:}
+
+%% \begin{lstlisting}
+%% Type          =  SimpleType | FunctionType
+%% FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
+%% SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
+%%                  Boolean | Unit | String
+%% Types         =  Type {`,' Type}
+%% \end{lstlisting}
+
+%% Types can be:
+%% \begin{itemize}
+%% \item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
+%% \item the type \code{Boolean} with values \code{true} and \code{false},
+%% \item the type \code{Unit} with the only value \lstinline@()@,
+%% \item the type \code{String},
+%% \item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
+%% \end{itemize}
+
+%% \subsection*{Expressions:}
+
+%% \begin{lstlisting}
+%% Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
+%% InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
+%% Operator     = ident
+%% PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
+%% SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
+%% FunctionExpr = (Bindings | Id) '=>' Expr
+%% Bindings     = `(' Binding {`,' Binding} `)'
+%% Binding      = ident [':' Type]
+%% Block        = '{' {Def ';'} Expr '}'
+%% \end{lstlisting}
+
+%% Expressions can be:
+%% \begin{itemize}
+%% \item
+%% identifiers such as \code{x}, \code{isGoodEnough}, \code{*}, or \code{+-},
+%% \item
+%% literals, such as \code{0}, \code{1.0}, or \code{"abc"},
+%% \item
+%% field and method selections, such as \code{System.out.println},
+%% \item
+%% function applications, such as \code{sqrt(x)}, 
+%% \item
+%% operator applications, such as \code{-x} or \code{y + x},
+%% \item
+%% conditionals, such as \code{if (x < 0) -x else x},
+%% \item
+%% blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
+%% \item
+%% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
+%% \end{itemize}
+
+%% \subsection*{Definitions:}
+
+%% \begin{lstlisting}
+%% Def          =  FunDef  |  ValDef
+%% FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
+%% ValDef       =  'val' ident [':' Type] '=' Expr
+%% Parameters   =  Parameter {',' Parameter}
+%% Parameter    =  ident ':' ['=>'] Type
+%% \end{lstlisting}
+%% Definitions can be:
+%% \begin{itemize}
+%% \item
+%% function definitions such as \code{def square(x: Int): Int = x * x},
+%% \item
+%% value definitions such as \code{val y = square(2)}.
+%% \end{itemize}
+
+%% \chapter{Classes and Objects}
+%% \label{chap:classes}
+
+%% Scala does not have a built-in type of rational numbers, but it is
+%% easy to define one, using a class. Here's a possible implementation.
+
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) {
+%%   private def gcd(x: Int, y: Int): Int = {
+%%     if (x == 0) y
+%%     else if (x < 0) gcd(-x, y)
+%%     else if (y < 0) -gcd(x, -y)
+%%     else gcd(y % x, x)
+%%   }
+%%   private val g = gcd(n, d)
+
+%%   val numer: Int = n/g
+%%   val denom: Int = d/g
+%%   def +(that: Rational) =
+%%     new Rational(numer * that.denom + that.numer * denom,
+%%                  denom * that.denom)
+%%   def -(that: Rational) =
+%%     new Rational(numer * that.denom - that.numer * denom, 
+%%                  denom * that.denom)
+%%   def *(that: Rational) =
+%%     new Rational(numer * that.numer, denom * that.denom)
+%%   def /(that: Rational) =
+%%     new Rational(numer * that.denom, denom * that.numer)
+%% }
+%% \end{lstlisting}
+%% This defines \code{Rational} as a class which takes two constructor
+%% arguments \code{n} and \code{d}, containing the number's numerator and
+%% denominator parts.  The class provides fields which return these parts
+%% as well as methods for arithmetic over rational numbers.  Each
+%% arithmetic method takes as parameter the right operand of the
+%% operation. The left operand of the operation is always the rational
+%% number of which the method is a member.
+
+%% \paragraph{Private members}
+%% The implementation of rational numbers defines a private method
+%% \code{gcd} which computes the greatest common denominator of two
+%% integers, as well as a private field \code{g} which contains the
+%% \code{gcd} of the constructor arguments. These members are inaccessible
+%% outside class \code{Rational}. They are used in the implementation of
+%% the class to eliminate common factors in the constructor arguments in
+%% order to ensure that numerator and denominator are always in
+%% normalized form.
+
+%% \paragraph{Creating and Accessing Objects}
+%% As an example of how rational numbers can be used, here's a program
+%% that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
+%% \begin{lstlisting}
+%% var i = 1
+%% var x = new Rational(0, 1)
+%% while (i <= 10) {
+%%   x += new Rational(1, i)
+%%   i += 1
+%% }
+%% println("" + x.numer + "/" + x.denom)
+%% \end{lstlisting}
+%% The \code{+} takes as left operand a string and as right operand a
+%% value of arbitrary type. It returns the result of converting its right
+%% operand to a string and appending it to its left operand. 
   
-\paragraph{Inheritance and Overriding}
-Every class in Scala has a superclass which it extends.  
-\comment{Excepted is
-only the root class \code{Object}, which does not have a superclass,
-and which is indirectly extended by every other class.  }
-If a class
-does not mention a superclass in its definition, the root type
-\code{scala.AnyRef} is implicitly assumed (for Java implementations,
-this type is an alias for \code{java.lang.Object}. For instance, class
-\code{Rational} could equivalently be defined as
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
-}
-\end{lstlisting}
-A class inherits all members from its superclass. It may also redefine
-(or: {\em override}) some inherited members. For instance, class
-\code{java.lang.Object} defines
-a method
-\code{toString} which returns a representation of the object as a string:
-\begin{lstlisting}
-class Object {
-  ...
-  def toString: String = ...
-}
-\end{lstlisting}
-The implementation of \code{toString} in \code{Object}
-forms a string consisting of the object's class name and a number. It
-makes sense to redefine this method for objects that are rational
-numbers:
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
-  override def toString = "" + numer + "/" + denom
-}
-\end{lstlisting}
-Note that, unlike in Java, redefining definitions need to be preceded
-by an \code{override} modifier.
-
-If class $A$ extends class $B$, then objects of type $A$ may be used
-wherever objects of type $B$ are expected. We say in this case that
-type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
-conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
-value to a variable of type \code{AnyRef}:
-\begin{lstlisting}
-var x: AnyRef = new Rational(1, 2)
-\end{lstlisting}
-
-\paragraph{Parameterless Methods}
-%Also unlike in Java, methods in Scala do not necessarily take a
-%parameter list. An example is \code{toString}; the method is invoked
-%by simply mentioning its name. For instance:
-%\begin{lstlisting}
-%val r = new Rational(1,2)
-%System.out.println(r.toString);      // prints``1/2''
-%\end{lstlisting}
-Unlike in Java, methods in Scala do not necessarily take a
-parameter list. An example is the \code{square} method below. This
-method is invoked by simply mentioning its name. 
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
-  def square = new Rational(numer*numer, denom*denom)
-}
-val r = new Rational(3, 4)
-println(r.square)           // prints``9/16''*
-\end{lstlisting}
-That is, parameterless methods are accessed just as value fields such
-as \code{numer} are. The difference between values and parameterless
-methods lies in their definition. The right-hand side of a value is
-evaluated when the object is created, and the value does not change
-afterwards. A right-hand side of a parameterless method, on the other
-hand, is evaluated each time the method is called.  The uniform access
-of fields and parameterless methods gives increased flexibility for
-the implementer of a class. Often, a field in one version of a class
-becomes a computed value in the next version. Uniform access ensures
-that clients do not have to be rewritten because of that change.
-
-\paragraph{Abstract Classes}
-
-Consider the task of writing a class for sets of integer numbers with
-two operations, \code{incl} and \code{contains}. \code{(s incl x)}
-should return a new set which contains the element \code{x} together
-with all the elements of set \code{s}. \code{(s contains x)} should
-return true if the set \code{s} contains the element \code{x}, and
-should return \code{false} otherwise. The interface of such sets is
-given by:  
-\begin{lstlisting}
-abstract class IntSet {
-  def incl(x: Int): IntSet
-  def contains(x: Int): Boolean
-}
-\end{lstlisting}
-\code{IntSet} is labeled as an \emph{abstract class}. This has two
-consequences.  First, abstract classes may have {\em deferred} members
-which are declared but which do not have an implementation. In our
-case, both \code{incl} and \code{contains} are such members. Second,
-because an abstract class might have unimplemented members, no objects
-of that class may be created using \code{new}. By contrast, an
-abstract class may be used as a base class of some other class, which
-implements the deferred members.
-
-\paragraph{Traits}
-
-Instead of \code{abstract class} one also often uses the keyword
-\code{trait} in Scala. Traits are abstract classes that are meant to
-be added to some other class. This might be because a trait adds some
-methods or fields to an unknown parent class.  For instance, a trait
-\code{Bordered} might be used to add a border to a various graphical
-components. Another usage scenario is where the trait collects
-signatures of some functionality provided by different classes, much
-in the way a Java interface would work.
-
-Since \code{IntSet} falls in this category, one can alternatively
-define it as a trait:
-\begin{lstlisting}
-trait IntSet {
-  def incl(x: Int): IntSet
-  def contains(x: Int): Boolean
-}
-\end{lstlisting}
-
-\paragraph{Implementing Abstract Classes}
-
-Let's say, we plan to implement sets as binary trees.  There are two
-possible forms of trees. A tree for the empty set, and a tree
-consisting of an integer and two subtrees. Here are their
-implementations.
-
-\begin{lstlisting}
-class EmptySet extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
-}
-\end{lstlisting}
-
-\begin{lstlisting}
-class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: Int): IntSet =
-    if (x < elem) new NonEmptySet(elem, left incl x, right)
-    else if (x > elem) new NonEmptySet(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
-Both \code{EmptySet} and \code{NonEmptySet} extend class
-\code{IntSet}.  This implies that types \code{EmptySet} and
-\code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
-
-\begin{exercise} Write methods \code{union} and \code{intersection} to form
-the union and intersection between two sets.
-\end{exercise}
-
-\begin{exercise} Add a method 
-\begin{lstlisting}
-def excl(x: Int)
-\end{lstlisting}
-to return the given set without the element \code{x}. To accomplish this,
-it is useful to also implement a test method
-\begin{lstlisting}
-def isEmpty: Boolean
-\end{lstlisting}
-for sets.
-\end{exercise}
-
-\paragraph{Dynamic Binding}
-
-Object-oriented languages (Scala included) use \emph{dynamic dispatch}
-for method invocations.  That is, the code invoked for a method call
-depends on the run-time type of the object which contains the method.
-For example, consider the expression \code{s contains 7} where
-\code{s} is a value of declared type \code{s: IntSet}. Which code for
-\code{contains} is executed depends on the type of value of \code{s} at run-time.
-If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
-This behavior is a direct consequence of our substitution model of evaluation.
-For instance,
-\begin{lstlisting}
-    (new EmptySet).contains(7) 
-
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
-
-    false
-\end{lstlisting}
-Or,
-\begin{lstlisting}
-    new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
-
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
-
-    if (1 < 7) new EmptySet contains 1
-    else if (1 > 7) new EmptySet contains 1
-    else true
-
-->  $\rewriteby{by rewriting the conditional}$
-
-    new EmptySet contains 1
-
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
-
-    false .
-\end{lstlisting}
-
-Dynamic method dispatch is analogous to higher-order function
-calls. In both cases, the identity of code to be executed is known
-only at run-time. This similarity is not just superficial. Indeed,
-Scala represents every function value as an object (see
-Section~\ref{sec:functions}).
-
-
-\paragraph{Objects}
-
-In the previous implementation of integer sets, empty sets were
-expressed with \code{new EmptySet}; so a new object was created every time
-an empty set value was required. We could have avoided unnecessary
-object creations by defining a value \code{empty} once and then using
-this value instead of every occurrence of \code{new EmptySet}. For example:
-\begin{lstlisting}
-val EmptySetVal = new EmptySet
-\end{lstlisting}
-One problem with this approach is that a value definition such as the
-one above is not a legal top-level definition in Scala; it has to be
-part of another class or object. Also, the definition of class
-\code{EmptySet} now seems a bit of an overkill -- why define a class of objects, 
-if we are only interested in a single object of this class? A more
-direct approach is to use an {\em object definition}. Here is
-a more streamlined alternative definition of the empty set:
-\begin{lstlisting}
-object EmptySet extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
-}
-\end{lstlisting}
-The syntax of an object definition follows the syntax of a class
-definition; it has an optional extends clause as well as an optional
-body. As is the case for classes, the extends clause defines inherited
-members of the object whereas the body defines overriding or new
-members.  However, an object definition defines a single object only
-it is not possible to create other objects with the same structure
-using \code{new}.  Therefore, object definitions also lack constructor
-parameters, which might be present in class definitions.
-
-Object definitions can appear anywhere in a Scala program; including
-at top-level.  Since there is no fixed execution order of top-level
-entities in Scala, one might ask exactly when the object defined by an
-object definition is created and initialized. The answer is that the
-object is created the first time one of its members is accessed. This
-strategy is called {\em lazy evaluation}.
-
-\paragraph{Standard Classes}
-
-\todo{include picture}
-
-Scala is a pure object-oriented language. This means that every value
-in Scala can be regarded as an object.  In fact, even primitive types
-such as \code{int} or \code{boolean} are not treated specially. They
-are defined as type aliases of Scala classes in module \code{Predef}:
-\begin{lstlisting}
-type boolean = scala.Boolean
-type int = scala.Int
-type long = scala.Long
-...
-\end{lstlisting}
-For efficiency, the compiler usually represents values of type
-\code{scala.Int} by 32 bit integers, values of type
-\code{scala.Boolean} by Java's booleans, etc.  But it converts these
-specialized representations to objects when required, for instance
-when a primitive \code{Int} value is passed to a function with a
-parameter of type \code{AnyRef}.  Hence, the special representation of
-primitive values is just an optimization, it does not change the
-meaning of a program.
-
-Here is a specification of class \code{Boolean}.
-\begin{lstlisting}
-package scala
-abstract class Boolean {
-  def && (x: => Boolean): Boolean
-  def || (x: => Boolean): Boolean
-  def !                 : Boolean
-
-  def == (x: Boolean)   : Boolean
-  def != (x: Boolean)   : Boolean
-  def <  (x: Boolean)   : Boolean
-  def >  (x: Boolean)   : Boolean
-  def <= (x: Boolean)   : Boolean
-  def >= (x: Boolean)   : Boolean
-}
-\end{lstlisting}
-Booleans can be defined using only classes and objects, without
-reference to a built-in type of booleans or numbers. A possible
-implementation of class \code{Boolean} is given below.  This is not
-the actual implementation in the standard Scala library. For
-efficiency reasons the standard implementation uses built-in
-booleans.
-\begin{lstlisting}
-package scala
-abstract class Boolean {
-  def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
-
-  def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
-  def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
-  def !                 : Boolean  =  ifThenElse(false, true)
-
-  def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
-  def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
-  def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
-  def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
-  def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
-  def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
-}
-case object True extends Boolean {
-  def ifThenElse(t: => Boolean, e: => Boolean) = t
-}
-case object False extends Boolean {
-  def ifThenElse(t: => Boolean, e: => Boolean) = e
-}
-\end{lstlisting}
-Here is a partial specification of class \code{Int}.
-
-\begin{lstlisting}
-package scala
-abstract class Int extends AnyVal {
-  def toLong: Long
-  def toFloat: Float
-  def toDouble: Double
-
-  def + (that: Double): Double
-  def + (that: Float): Float
-  def + (that: Long): Long
-  def + (that: Int): Int         // analogous for -, *, /, %
-
-  def << (cnt: Int): Int         // analogous for >>, >>>
-
-  def & (that: Long): Long
-  def & (that: Int): Int         // analogous for |, ^
-
-  def == (that: Double): Boolean
-  def == (that: Float): Boolean
-  def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
-}
-\end{lstlisting}
-
-Class \code{Int} can in principle also be implemented using just
-objects and classes, without reference to a built in type of
-integers. To see how, we consider a slightly simpler problem, namely
-how to implement a type \code{Nat} of natural (i.e. non-negative)
-numbers. Here is the definition of an abstract class \code{Nat}:
-\begin{lstlisting}
-abstract class Nat {
-  def isZero: Boolean
-  def predecessor: Nat
-  def successor: Nat
-  def + (that: Nat): Nat
-  def - (that: Nat): Nat
-}
-\end{lstlisting}
-To implement the operations of class \code{Nat}, we define a sub-object
-\code{Zero} and a subclass \code{Succ} (for successor). Each number
-\code{N} is represented as \code{N} applications of the \code{Succ}
-constructor to \code{Zero}:
-\[
-\underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
-\]
-The implementation of the \code{Zero} object is straightforward:
-\begin{lstlisting}
-object Zero extends Nat {
-  def isZero: Boolean = true
-  def predecessor: Nat = error("negative number")
-  def successor: Nat = new Succ(Zero)
-  def + (that: Nat): Nat = that
-  def - (that: Nat): Nat = if (that.isZero) Zero
-                           else error("negative number")
-}
-\end{lstlisting}
-
-The implementation of the predecessor and subtraction functions on
-\code{Zero} throws an \code{Error} exception, which aborts the program
-with the given error message.
-
-Here is the implementation of the successor class:
-\begin{lstlisting}
-class Succ(x: Nat) extends Nat  {
-  def isZero: Boolean = false
-  def predecessor: Nat = x
-  def successor: Nat = new Succ(this)
-  def + (that: Nat): Nat = x + that.successor
-  def - (that: Nat): Nat = if (that.isZero) this 
-                           else x - that.predecessor
-}
-\end{lstlisting}
-Note the implementation of method \code{successor}. To create the
-successor of a number, we need to pass the object itself as an
-argument to the \code{Succ} constructor.  The object itself is
-referenced by the reserved name \code{this}.   
-
-The implementations of \code{+} and \code{-} each contain a recursive
-call with the constructor argument as receiver. The recursion will
-terminate once the receiver is the \code{Zero} object (which is
-guaranteed to happen eventually because of the way numbers are formed).
-
-\begin{exercise} Write an implementation \code{Integer} of integer numbers
-The implementation should support all operations of class \code{Nat}
-while adding two methods
-\begin{lstlisting}
-def isPositive: Boolean
-def negate: Integer
-\end{lstlisting}
-The first method should return \code{true} if the number is positive. The second method should negate the number.
-Do not use any of Scala's standard numeric classes in your
-implementation. (Hint: There are two possible ways to implement
-\code{Integer}. One can either make use the existing implementation of
-\code{Nat}, representing an integer as a natural number and a sign.
-Or one can generalize the given implementation of \code{Nat} to
-\code{Integer}, using the three subclasses \code{Zero} for 0, 
-\code{Succ} for positive numbers and \code{Pred} for negative numbers.)
-\end{exercise}
-
-
-
-\subsection*{Language Elements Introduced In This Chapter}
-
-\textbf{Types:}
-\begin{lstlisting}
-Type         = ...  |  ident
-\end{lstlisting}
-
-Types can now be arbitrary identifiers which represent classes.
-
-\textbf{Expressions:}
-\begin{lstlisting}
-Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
-\end{lstlisting}
-
-An expression can now be an object creation, or
-a selection \code{E.m} of a member \code{m}
-from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
-
-\textbf{Definitions and Declarations:}
-\begin{lstlisting}
-Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
-ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
-               ['extends' Expr] [`{' {TemplateDef} `}']
-TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
-ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
-TemplateDef  = [Modifier] (Def | Dcl)
-ObjectDef    = [Modifier] Def
-Modifier     = 'private'  |  'override'
-Dcl          = FunDcl  |  ValDcl
-FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
-ValDcl       = 'val' ident ':' Type
-\end{lstlisting}
-
-A definition can now be a class, trait or object definition such as
-\begin{lstlisting}
-class C(params) extends B { defs }
-trait T extends B { defs }
-object O extends B { defs }
-\end{lstlisting}
-The definitions \code{defs} in a class, trait or object may be
-preceded by modifiers \code{private} or \code{override}.
-
-Abstract classes and traits may also contain declarations. These
-introduce {\em deferred} functions or values with their types, but do
-not give an implementation. Deferred members have to be implemented in
-subclasses before objects of an abstract class or trait can be created.
-
-\chapter{Case Classes and Pattern Matching}
-
-Say, we want to write an interpreter for arithmetic expressions.  To
-keep things simple initially, we restrict ourselves to just numbers
-and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
-\code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
-\begin{lstlisting}
-new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
-\end{lstlisting}
-Now, an evaluator of an expression like this needs to know of what
-form it is (either \code{Sum} or \code{Number}) and also needs to
-access the components of the expression.  The following
-implementation provides all necessary methods.
-\begin{lstlisting}
-abstract class Expr {
-  def isNumber: Boolean
-  def isSum: Boolean
-  def numValue: Int
-  def leftOp: Expr
-  def rightOp: Expr
-}
-class Number(n: Int) extends Expr {
-  def isNumber: Boolean = true
-  def isSum: Boolean = false
-  def numValue: Int = n
-  def leftOp: Expr = error("Number.leftOp")
-  def rightOp: Expr = error("Number.rightOp")
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def isNumber: Boolean = false
-  def isSum: Boolean = true
-  def numValue: Int = error("Sum.numValue")
-  def leftOp: Expr = e1
-  def rightOp: Expr = e2
-}
-\end{lstlisting}
-With these classification and access methods, writing an evaluator function is simple:
-\begin{lstlisting}
-def eval(e: Expr): Int = {
-  if (e.isNumber) e.numValue
-  else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
-  else error("unrecognized expression kind")
-}
-\end{lstlisting}
-However, defining all these methods in classes \code{Sum} and
-\code{Number} is rather tedious. Furthermore, the problem becomes worse 
-when we want to add new forms of expressions. For instance, consider
-adding a new expression form
-\code{Prod} for products. Not only do we have to implement a new class \code{Prod}, with all previous classification and access methods; we also have to introduce a
-new abstract method \code{isProduct} in class \code{Expr} and
-implement that method in subclasses \code{Number}, \code{Sum}, and
-\code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
-
-The promise of object-oriented programming is that such modifications
-should be unnecessary, because they can be avoided by re-using
-existing, unmodified code through inheritance. Indeed, a more
-object-oriented decomposition of our problem solves the problem.  The
-idea is to make the ``high-level'' operation \code{eval} a method of
-each expression class, instead of implementing it as a function
-outside the expression class hierarchy, as we have done
-before. Because \code{eval} is now a member of all expression nodes,
-all classification and access methods become superfluous, and the implementation is simplified considerably:
-\begin{lstlisting}
-abstract class Expr {
-  def eval: Int
-}
-class Number(n: Int) extends Expr {
-  def eval: Int = n
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval + e2.eval
-}
-\end{lstlisting}
-Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
-\begin{lstlisting}
-class Prod(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval * e2.eval
-}
-\end{lstlisting}
-
-The conclusion we can draw from this example is that object-oriented
-decomposition is the technique of choice for constructing systems that
-should be extensible with new types of data. But there is also another
-possible way we might want to extend the expression example. We might
-want to add new {\em operations} on expressions.  For instance, we might
-want to add an operation that pretty-prints an expression tree to standard output.
-
-If we have defined all classification and access methods, such an
-operation can easily be written as an external function. Here is an
-example:
-\begin{lstlisting}
-def print(e: Expr) {
-  if (e.isNumber) Console.print(e.numValue)
-  else if (e.isSum) {
-    Console.print("(")
-    print(e.leftOp)
-    Console.print("+")
-    print(e.rightOp)
-    Console.print(")")
-  } else error("unrecognized expression kind")
-}
-\end{lstlisting}
-However, if we had opted for an object-oriented decomposition of
-expressions, we would need to add a new \code{print} procedure
-to each class:
-\begin{lstlisting}
-abstract class Expr {
-  def eval: Int
-  def print
-}
-class Number(n: Int) extends Expr {
-  def eval: Int = n
-  def print { Console.print(n) }
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval + e2.eval
-  def print {
-    Console.print("(")
-    print(e1)
-    Console.print("+")
-    print(e2)
-    Console.print(")")
-  }
-}
-\end{lstlisting}
-Hence, classical object-oriented decomposition requires modification
-of all existing classes when a system is extended with new operations.
-
-As yet another way we might want to extend the interpreter, consider
-expression simplification. For instance, we might want to write a
-function which rewrites expressions of the form
-\code{a * b + a * c} to \code{a * (b + c)}. This operation requires inspection of 
-more than a single node of the expression tree at the same
-time. Hence, it cannot be implemented by a method in each expression
-kind, unless that method can also inspect other nodes. So we are
-forced to have classification and access methods in this case. This
-seems to bring us back to square one, with all the problems of
-verbosity and extensibility.
-
-Taking a closer look, one observes that the only purpose of the
-classification and access functions is to {\em reverse} the data
-construction process.  They let us determine, first, which sub-class
-of an abstract base class was used and, second, what were the
-constructor arguments. Since this situation is quite common, Scala has
-a way to automate it with case classes. 
-
-\section{Case Classes and Case Objects}
-
-{\em Case classes} and {\em case objects} are defined like a normal
-classes or objects, except that the definition is prefixed with the modifier
-\code{case}.  For instance, the definitions
-\begin{lstlisting}
-abstract class Expr
-case class Number(n: Int) extends Expr
-case class Sum(e1: Expr, e2: Expr) extends Expr
-\end{lstlisting}
-introduce \code{Number} and \code{Sum} as case classes.
-The \code{case} modifier in front of a class or object 
-definition has the following effects.
-\begin{enumerate}
-\item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
-\begin{lstlisting}
-def Number(n: Int) = new Number(n)
-def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
-\end{lstlisting}
-would be added. Hence, one can now construct expression trees a bit more concisely, as in
-\begin{lstlisting}
-Sum(Sum(Number(1), Number(2)), Number(3))
-\end{lstlisting} 
-\item Case classes and case objects 
-implicitly come with implementations of methods
-\code{toString}, \code{equals} and \code{hashCode}, which override the
-methods with the same name in class \code{AnyRef}. The implementation
-of these methods takes in each case the structure of a member of a
-case class into account. The \code{toString} method represents an
-expression tree the way it was constructed. So,
-\begin{lstlisting}
-Sum(Sum(Number(1), Number(2)), Number(3))
-\end{lstlisting} 
-would be converted to exactly that string, whereas the default
-implementation in class \code{AnyRef} would return a string consisting
-of the outermost constructor name \code{Sum} and a number.  The
-\code{equals} methods treats two case members of a case class as equal
-if they have been constructed with the same constructor and with
-arguments which are themselves pairwise equal. This also affects the
-implementation of \code{==} and \code{!=}, which are implemented in
-terms of \code{equals} in Scala. So,
-\begin{lstlisting}
-Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
-\end{lstlisting}
-will yield \code{true}. If \code{Sum} or \code{Number} were not case
-classes, the same expression would be \code{false}, since the standard
-implementation of \code{equals} in class \code{AnyRef} always treats
-objects created by different constructor calls as being different.
-The \code{hashCode} method follows the same principle as other two
-methods. It computes a hash code from the case class constructor name
-and the hash codes of the constructor arguments, instead of from the object's
-address, which is what the as the default implementation of \code{hashCode} does.
-\item 
-Case classes implicitly come with nullary accessor methods which
-retrieve the constructor arguments.
-In our example, \code{Number} would obtain an accessor method
-\begin{lstlisting}
-def n: Int
-\end{lstlisting}
-which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
-\begin{lstlisting}
-def e1: Expr, e2: Expr
-\end{lstlisting}
-Hence, if for a value \code{s} of type \code{Sum}, say, one can now
-write \code{s.e1}, to access the left operand. However, for a value
-\code{e} of type \code{Expr}, the term \code{e.e1} would be illegal
-since \code{e1} is defined in \code{Sum}; it is not a member of the
-base class \code{Expr}. 
-So, how do we determine the constructor and access constructor
-arguments for values whose static type is the base class \code{Expr}?
-This is solved by the fourth and final particularity of case classes.
-\item 
-Case classes allow the constructions of {\em patterns} which refer to
-the case class constructor.
-\end{enumerate}
-
-\section{Pattern Matching}
-
-Pattern matching is a generalization of C or Java's \code{switch}
-statement to class hierarchies. Instead of a \code{switch} statement,
-there is a standard method \code{match}, which is defined in Scala's
-root class \code{Any}, and therefore is available for all objects.
-The \code{match} method takes as argument a number of cases. 
-For instance, here is an implementation of \code{eval} using 
-pattern matching.
-\begin{lstlisting}
-def eval(e: Expr): Int = e match {
-  case Number(n) => n 
-  case Sum(l, r) => eval(l) + eval(r) 
-}
-\end{lstlisting}
-In this example, there are two cases. Each case associates a pattern
-with an expression. Patterns are matched against the selector
-values \code{e}.  The first pattern in our example,
-\code{Number(n)}, matches all values of the form \code{Number(v)}, 
-where \code{v} is an arbitrary value.  In that case, the {\em pattern
-variable} \code{n} is bound to the value \code{v}. Similarly, the
-pattern \code{Sum(l, r)} matches all selector values of form
-\code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
-\code{l} and \code{r} 
-to \code{v}$_1$ and \code{v}$_2$, respectively. 
-
-In general, patterns are built from
-\begin{itemize}
-\item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
-      are again patterns,
-\item pattern variables, e.g. \code{n}, \code{e1}, \code{e2},
-\item the ``wildcard'' pattern \code{_},
-\item literals, e.g. \code{1}, \code{true}, "abc", 
-\item constant identifiers, e.g. \code{MAXINT}, \code{EmptySet}.
-\end{itemize}
-Pattern variables always start with a lower-case letter, so that they
-can be distinguished from constant identifiers, which start with an
-upper case letter.  Each variable name may occur only once in a
-pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
-since the pattern variable \code{x} occurs twice in it.
-
-\paragraph{Meaning of Pattern Matching}
-A pattern matching expression 
-\begin{lstlisting}
-e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
-\end{lstlisting}
-matches the patterns $p_1 \commadots p_n$ in the order they
-are written against the selector value \code{e}.
-\begin{itemize}
-\item
-A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
-are of type \code{C} (or a subtype thereof) and that have been constructed with 
-\code{C}-arguments matching patterns $p_1 \commadots p_n$.
-\item 
-A variable pattern \code{x} matches any value and binds the variable
-name to that value.  
-\item 
-The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
-\item A constant pattern \code{C} matches a value which is
-equal (in terms of \code{==}) to \code{C}.
-\end{itemize}
-The pattern matching expression rewrites to the right-hand-side of the
-first case whose pattern matches the selector value. References to
-pattern variables are replaced by corresponding constructor arguments.
-If none of the patterns matches, the pattern matching expression is
-aborted with a \code{MatchError} exception.
-
-\example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
-\begin{lstlisting}
-     eval(Sum(Number(1), Number(2)))
-
-->   $\mbox{\tab\tab\rm(by rewriting the application)}$
-
-     Sum(Number(1), Number(2)) match {
-         case Number(n) => n
-         case Sum(e1, e2) => eval(e1) + eval(e2)
-     }
-
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
-
-     eval(Number(1)) + eval(Number(2))
-
-->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
-
-     Number(1) match {
-         case Number(n) => n
-         case Sum(e1, e2) => eval(e1) + eval(e2)
-     } + eval(Number(2))
-
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
-
-     1 + eval(Number(2))
-
-->$^*$ 1 + 2 -> 3
-\end{lstlisting}
-
-\paragraph{Pattern Matching and Methods}
-In the previous example, we have used pattern
-matching in a function which was defined outside the class hierarchy
-over which it matches.  Of course, it is also possible to define a
-pattern matching function in that class hierarchy itself. For
-instance, we could have defined
-\code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
-\begin{lstlisting}
-abstract class Expr { 
-  def eval: Int = this match {
-    case Number(n) => n
-    case Sum(e1, e2) => e1.eval + e2.eval 
-  } 
-}
-\end{lstlisting}
-
-\begin{exercise} Consider the following definitions representing trees
-of integers.  These definitions can be seen as an alternative
-representation of \code{IntSet}:
-\begin{lstlisting}
-abstract class IntTree
-case object EmptyTree extends IntTree
-case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
-\end{lstlisting}
-Complete the following implementations of function \code{contains} and \code{insert} for 
-\code{IntTree}'s.
-\begin{lstlisting}
-def contains(t: IntTree, v: Int): Boolean = t match { ...
-  ...
-}
-def insert(t: IntTree, v: Int): IntTree = t match { ...
-  ...
-}
-\end{lstlisting}
-\end{exercise}
-
-\paragraph{Pattern Matching Anonymous Functions}
-
-So far, case-expressions always appeared in conjunction with a
-\verb@match@ operation. But it is also possible to use
-case-expressions by themselves. A block of case-expressions such as
-\begin{lstlisting}
-{ case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
-\end{lstlisting}
-is seen by itself as a function which matches its arguments
-against the patterns $P_1 \commadots P_n$, and produces the result of
-one of $E_1 \commadots E_n$. (If no pattern matches, the function
-would throw a \code{MatchError} exception instead).
-In other words, the expression above is seen as a shorthand for the anonymous function
-\begin{lstlisting}
-(x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
-\end{lstlisting}
-where \code{x} is a fresh variable which is not used 
-otherwise in the expression.
-
-\chapter{Generic Types and Methods}
-
-Classes in Scala can have type parameters. We demonstrate the use of
-type parameters with functional stacks as an example. Say, we want to
-write a data type of stacks of integers, with methods \code{push},
-\code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
-following class hierarchy:
-\begin{lstlisting}
-abstract class IntStack {
-  def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
-  def isEmpty: Boolean
-  def top: Int
-  def pop: IntStack
-}
-class IntEmptyStack extends IntStack {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
-Of course, it would also make sense to define an abstraction for a
-stack of Strings. To do that, one could take the existing abstraction
-for \code{IntStack}, rename it to \code{StringStack} and at the same
-time rename all occurrences of type \code{Int} to \code{String}.
-
-A better way, which does not entail code duplication, is to
-parameterize the stack definitions with the element type.
-Parameterization lets us generalize from a specific instance of a
-problem to a more general one. So far, we have used parameterization
-only for values, but it is available also for types. To arrive at a
-{\em generic} version of \code{Stack}, we equip it with a type
-parameter.
-\begin{lstlisting}
-abstract class Stack[A] {
-  def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
-  def isEmpty: Boolean
-  def top: A
-  def pop: Stack[A]
-}
-class EmptyStack[A] extends Stack[A] {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
-In the definitions above, `\code{A}' is a {\em type parameter} of
-class \code{Stack} and its subclasses.  Type parameters are arbitrary
-names; they are enclosed in brackets instead of parentheses, so that
-they can be easily distinguished from value parameters.  Here is an
-example how the generic classes are used:
-\begin{lstlisting}
-val x = new EmptyStack[Int]
-val y = x.push(1).push(2)
-println(y.pop.top)
-\end{lstlisting}
-The first line creates a new empty stack of \code{Int}'s. Note the
-actual type argument \code{[Int]} which replaces the formal type
-parameter \code{A}.
-
-It is also possible to parameterize methods with types. As an example,
-here is a generic method which determines whether one stack is a
-prefix of another.
-\begin{lstlisting}
-def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
-  p.isEmpty ||
-  p.top == s.top && isPrefix[A](p.pop, s.pop)
-}
-\end{lstlisting}  
-The method parameters are called {\em polymorphic}.  Generic methods are
-also called {\em polymorphic}.  The term comes from the Greek, where it
-means ``having many forms''.  To apply a polymorphic method such as
-\code{isPrefix}, we pass type parameters as well as value parameters
-to it. For instance,
-\begin{lstlisting}
-val s1 = new EmptyStack[String].push("abc")
-val s2 = new EmptyStack[String].push("abx").push(s1.top)
-println(isPrefix[String](s1, s2))
-\end{lstlisting}
-
-\paragraph{Local Type Inference}
-Passing type parameters such as \code{[Int]} or \code{[String]} all
-the time can become tedious in applications where generic functions
-are used a lot. Quite often, the information in a type parameter is
-redundant, because the correct parameter type can also be determined
-by inspecting the function's value parameters or expected result type.
-Taking the expression \code{isPrefix[String](s1, s2)} as an
-example, we know that its value parameters are both of type
-\code{Stack[String]}, so we can deduce that the type parameter must
-be \code{String}. Scala has a fairly powerful type inferencer which
-allows one to omit type parameters to polymorphic functions and
-constructors in situations like these.  In the example above, one
-could have written \code{isPrefix(s1, s2)} and the missing type argument
-\code{[String]} would have been inserted by the type inferencer. 
-
-\section{Type Parameter Bounds}
-
-Now that we know how to make classes generic it is natural to
-generalize some of the earlier classes we have written. For instance
-class \code{IntSet} could be generalized to sets with arbitrary
-element types. Let's try. The abstract class for generic sets is easily
-written.
-\begin{lstlisting}
-abstract class Set[A] {
-  def incl(x: A): Set[A]
-  def contains(x: A): Boolean
-}
-\end{lstlisting}
-However, if we still want to implement sets as binary search trees, we
-encounter a problem. The \code{contains} and \code{incl} methods both
-compare elements using methods \code{<} and \code{>}. For
-\code{IntSet} this was OK, since type \code{Int} has these two
-methods. But for an arbitrary type parameter \code{a}, we cannot
-guarantee this. Therefore, the previous implementation of, say,
-\code{contains} would generate a compiler error.
-\begin{lstlisting}
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-          ^ < $\mbox{\sl not a member of type}$ A.
-\end{lstlisting}
-One way to solve the problem is to restrict the legal types that can
-be substituted for type \code{A} to only those types that contain methods
-\code{<} and \code{>} of the correct types. There is a trait
-\code{Ordered[A]} in the standard class library Scala which represents
-values which are comparable (via \code{<} and \code{>}) to values of
-type \code{A}. This trait is defined as follows:
-\begin{lstlisting}
-/** A class for totally ordered data. */
-trait Ordered[A] {
-
-  /** Result of comparing `this' with operand `that'.
-   *  returns `x' where
-   *  x < 0    iff    this < that
-   *  x == 0   iff    this == that
-   *  x > 0    iff    this > that
-   */
-  def compare(that: A): Int
-
-  def <  (that: A): Boolean = (this compare that) <  0
-  def >  (that: A): Boolean = (this compare that) >  0
-  def <= (that: A): Boolean = (this compare that) <= 0
-  def >= (that: A): Boolean = (this compare that) >= 0
-  def compareTo(that: A): Int = compare(that)
-}
-\end{lstlisting}
-We can enforce the comparability of a type by demanding
-that the type is a subtype of \code{Ordered}. This is done by giving an
-upper bound to the type parameter of \code{Set}:
-\begin{lstlisting}
-trait Set[A <: Ordered[A]] {
-  def incl(x: A): Set[A]
-  def contains(x: A): Boolean
-}
-\end{lstlisting}
-The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
-type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
-must be comparable to values of the same type.
-
-With this restriction, we can now implement the rest of the generic
-set abstraction as we did in the case of \code{IntSet}s before.
-
-\begin{lstlisting}
-class EmptySet[A <: Ordered[A]] extends Set[A] {
-  def contains(x: A): Boolean = false
-  def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
-}
-\end{lstlisting}
-
-\begin{lstlisting}
-class NonEmptySet[A <: Ordered[A]]
-        (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
-  def contains(x: A): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: A): Set[A] =
-    if (x < elem) new NonEmptySet(elem, left incl x, right)
-    else if (x > elem) new NonEmptySet(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
-Note that we have left out the type argument in the object creations
-\code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
-missing type arguments in constructor calls are inferred from value
-arguments and/or the expected result type.
-
-Here is an example that uses the generic set abstraction. Let's first
-create a subclass of \lstinline@Ordered@, like this:
-\begin{lstlisting}
-case class Num(value: Double) extends Ordered[Num] {
-  def compare(that: Num): Int =
-    if (this.value < that.value) -1
-    else if (this.value > that.value) 1
-    else 0
-}
-\end{lstlisting}
-Then:
-\begin{lstlisting}
-val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
-s.contains(Num(1.5))
-\end{lstlisting}
-This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
-However, the following example is in error.
-\begin{lstlisting}
-val s = new EmptySet[java.io.File]
-                    ^ java.io.File $\mbox{\sl does not conform to type}$
-                      $\mbox{\sl parameter bound}$ Ordered[java.io.File].
-\end{lstlisting}
-One probem with type parameter bounds is that they require
-forethought: if we had not declared \lstinline@Num@ a subclass of
-\lstinline@Ordered@, we would not have been able to use \lstinline@Num@
-elements in sets. By the same token, types inherited from Java, 
-such as \lstinline@Int@, \lstinline@Double@, or
-\lstinline@String@ are not subclasses of \lstinline@Ordered@, so
-values of these types cannot be used as set elements.
-
-A more flexible design, which admits elements of these types, uses
-{\em view bounds} instead of the plain type bounds we have seen so
-far. The only change this entails in the example above is in the type
-parameters:
-\begin{lstlisting}
-trait Set[A <% Ordered[A]] ...
-class EmptySet[A <% Ordered[A]] ...
-class NonEmptySet[A <% Ordered[A]] ...
-\end{lstlisting}
-View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
-A view bounded type parameter clause \lstinline@[A <% T]@ only
-specifies that the bounded type \lstinline@A@ must be {\em convertible} to
-the bound type \lstinline@T@, using an implicit conversion.
-
-The Scala library predefines implicit conversions for a number of
-types, including the primitive types and \lstinline@String@.
-Therefore, the redesign set abstraction can be instantiated with these
-types as well. More explanations on implicit conversions and view
-bounds are given in Section~\ref{sec:implicits}.
-
-\section{Variance Annotations}\label{sec:first-arrays}
-
-The combination of type parameters and subtyping poses some
-interesting questions. For instance, should \code{Stack[String]} be a
-subtype of \code{Stack[AnyRef]}? Intuitively, this seems OK, since a
-stack of \code{String}s is a special case of a stack of
-\code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
-then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
-This property is called {\em co-variant} subtyping.
-
-In Scala, generic types have by default non-variant subtyping. That
-is, with \code{Stack} defined as above, stacks with different element
-types would never be in a subtype relation. However, we can enforce
-co-variant subtyping of stacks by changing the first line of the
-definition of class \code{Stack} as follows.
-\begin{lstlisting}
-class Stack[+A] {
-\end{lstlisting}
-Prefixing a formal type parameter with a \code{+} indicates that
-subtyping is covariant in that parameter. 
-Besides \code{+}, there is also a prefix \code{-} which indicates
-contra-variant subtyping. If \code{Stack} was defined \code{class
-Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
-that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
-case of stacks would be rather surprising!).
-
-In a purely functional world, all types could be co-variant. However,
-the situation changes once we introduce mutable data. Consider the
-case of arrays in Java or .NET. Such arrays are represented in Scala
-by a generic class \code{Array}. Here is a partial definition of this
-class.
-\begin{lstlisting}
-class Array[A] {
-  def apply(index: Int): A
-  def update(index: Int, elem: A)
-}
-\end{lstlisting}
-The class above defines the way Scala arrays are seen from Scala user
-programs. The Scala compiler will map this abstraction to the
-underlying arrays of the host system in most cases where this
-possible.
-
-In Java, arrays are indeed covariant; that is, for reference types
-\code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
-\code{Array[T]} is a subtype of \code{Array[S]}. This might seem
-natural but leads to safety problems that require special runtime
-checks. Here is an example:
-\begin{lstlisting}
-val x = new Array[String](1)
-val y: Array[Any] = x
-y(0) = new Rational(1, 2)  // this is syntactic sugar for
-                           // y.update(0, new Rational(1, 2))
-\end{lstlisting}
-In the first line, a new array of strings is created. In the second
-line, this array is bound to a variable \code{y}, of type
-\code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
-\code{Array[String]} is a subtype of \code{Array[Any]}. Finally, in
-the last line a rational number is stored in the array. This is also
-OK, since type \code{Rational} is a subtype of the element type
-\code{Any} of the array \code{y}. We thus end up storing a rational
-number in an array of strings, which clearly violates type soundness. 
-
-Java solves this problem by introducing a run-time check in the third
-line which tests whether the stored element is compatible with the
-element type with which the array was created. We have seen in the
-example that this element type is not necessarily the static element
-type of the array being updated. If the test fails, an
-\code{ArrayStoreException} is raised.
-
-Scala solves this problem instead statically, by disallowing the
-second line at compile-time, because arrays in Scala have non-variant
-subtyping. This raises the question how a Scala compiler verifies that
-variance annotations are correct. If we had simply declared arrays
-co-variant, how would the potential problem have been detected?
-
-Scala uses a conservative approximation to verify soundness of
-variance annotations.  A covariant type parameter of a class may only
-appear in co-variant positions inside the class.  Among the co-variant
-positions are the types of values in the class, the result types of
-methods in the class, and type arguments to other covariant types. Not
-co-variant are types of formal method parameters. Hence, the following
-class definition would have been rejected
-\begin{lstlisting}
-class Array[+A] {
-  def apply(index: Int): A
-  def update(index: Int, elem: A)
-                               ^ $\mbox{\sl covariant type parameter}$ A
-                                 $\mbox{\sl appears in contravariant position.}$
-}
-\end{lstlisting}
-So far, so good. Intuitively, the compiler was correct in rejecting
-the \code{update} procedure in a co-variant class because \code{update}
-potentially changes state, and therefore undermines the soundness of
-co-variant subtyping. 
-
-However, there are also methods which do not mutate state, but where a
-type parameter still appears contra-variantly. An example is
-\code{push} in type \code{Stack}. Again the Scala compiler will reject
-the definition of this method for co-variant stacks.
-\begin{lstlisting}
-class Stack[+A] {
-  def push(x: A): Stack[A] =
-              ^ $\mbox{\sl covariant type parameter}$ A
-                $\mbox{\sl appears in contravariant position.}$
-\end{lstlisting}
-This is a pity, because, unlike arrays, stacks are purely functional data
-structures and therefore should enable co-variant subtyping. However,
-there is a a way to solve the problem by using a polymorphic method
-with a lower type parameter bound.
-
-\section{Lower Bounds}
-
-We have seen upper bounds for type parameters. In a type parameter
-declaration such as \code{T <: U}, the type parameter \code{T} is
-restricted to range only over subtypes of type \code{U}. Symmetrical
-to this are lower bounds in Scala. In a type parameter declaration
-\code{T >: S}, the type parameter \code{T} is restricted to range only
-over {\em supertypes} of type \code{S}. (One can also combine lower and
-upper bounds, as in \code{T >: S <: U}.)
-
-Using lower bounds, we can generalize the \code{push} method in
-\code{Stack} as follows.
-\begin{lstlisting}
-class Stack[+A] {
-  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-\end{lstlisting}
-Technically, this solves our variance problem since now the type
-parameter \code{A} appears no longer as a parameter type of method
-\code{push}. Instead, it appears as lower bound for another type
-parameter of a method, which is classified as a co-variant position.
-Hence, the Scala compiler accepts the new definition of \code{push}.
-
-In fact, we have not only solved the technical variance problem but
-also have generalized the definition of \code{push}.  Before, we were
-required to push only elements with types that conform to the declared
-element type of the stack. Now, we can push also elements of a
-supertype of this type, but the type of the returned stack will change
-accordingly. For instance, we can now push an \code{AnyRef} onto a
-stack of \code{String}s, but the resulting stack will be a stack of
-\code{AnyRef}s instead of a stack of \code{String}s!
-
-In summary, one should not hesitate to add variance annotations to
-your data structures, as this yields rich natural subtyping
-relationships. The compiler will detect potential soundness
-problems. Even if the compiler's approximation is too conservative, as
-in the case of method \code{push} of class \code{Stack}, this will
-often suggest a useful generalization of the contested method.
-
-\section{Least Types}
-
-Scala does not allow one to parameterize objects with types. That's
-why we originally defined a generic class \code{EmptyStack[A]}, even
-though a single value denoting empty stacks of arbitrary type would
-do. For co-variant stacks, however, one can use the following idiom:
-\begin{lstlisting}
-object EmptyStack extends Stack[Nothing] { ... }
-\end{lstlisting}
-The bottom type \code{Nothing} contains no value, so the type
-\code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
-contains no elements. Furthermore, \code{Nothing} is a subtype of all
-other types. Hence, for co-variant stacks, \code{Stack[Nothing]} is a
-subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
-possible to use a single empty stack object in user code. For
-instance:
-\begin{lstlisting}
-val s = EmptyStack.push("abc").push(new AnyRef())
-\end{lstlisting}
-Let's analyze the type assignment for this expression in detail.  The
-\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
-method
-\begin{lstlisting}
-push[B >: Nothing](elem: B): Stack[B] .
-\end{lstlisting}
-Local type inference will determine that the type parameter \code{B}
-should be instantiated to \code{String} in the application 
-\code{EmptyStack.push("abc")}. The result type of that application is hence
-\code{Stack[String]}, which in turn has a method
-\begin{lstlisting}
-push[B >: String](elem: B): Stack[B] .
-\end{lstlisting}
-The final part of the value definition above is the application of
-this method to \code{new AnyRef()}. Local type inference will
-determine that the type parameter \code{b} should this time be
-instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
-Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
-
-Besides \code{Nothing}, which is a subtype of every other type, there
-is also the type \code{Null}, which is a subtype of
-\code{scala.AnyRef}, and every class derived from it. The \code{null}
-literal in Scala is the only value of that type. This makes
-\code{null} compatible with every reference type, but not with a value
-type such as \code{Int}.
-
-We conclude this section with the complete improved definition of
-stacks. Stacks have now co-variant subtyping, the \code{push} method
-has been generalized, and the empty stack is represented by a single
-object.
-\begin{lstlisting}
-abstract class Stack[+A] {
-  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-  def isEmpty: Boolean
-  def top: A
-  def pop: Stack[A]
-}
-object EmptyStack extends Stack[Nothing] {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
-Many classes in the Scala library are generic. We now present two
-commonly used families of generic classes, tuples and functions. The
-discussion of another common class, lists, is deferred to the next
-chapter.
-
-\section{Tuples}
-
-Sometimes, a function needs to return more than one result. For
-instance, take the function \code{divmod} which returns the integer quotient
-and rest of two given integer arguments.  Of course, one can define a
-class to hold the two results of \code{divmod}, as in:
-\begin{lstlisting}
-case class TwoInts(first: Int, second: Int)
-def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
-\end{lstlisting}
-However, having to define a new class for every possible pair of
-result types is very tedious. In Scala one can use instead a
-generic class \lstinline@Tuple$2$@, which is defined as follows:
-\begin{lstlisting}
-package scala
-case class Tuple2[A, B](_1: A, _2: B)
-\end{lstlisting}
-With \code{Tuple2}, the \code{divmod} method can be written as follows.
-\begin{lstlisting}
-def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
-\end{lstlisting}
-As usual, type parameters to constructors can be omitted if they are
-deducible from value arguments. There exist also tuple classes for
-every other number of elements (the current Scala implementation
-limits this to tuples of some reasonable number of elements).  
-
-\comment{
-Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
-\code{Triple} for \code{Tuple3}).  With these conventions,
-\code{divmod} can equivalently be written as follows.
-\begin{lstlisting}
-def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
-\end{lstlisting}
-}
-How are elements of tuples accessed? Since tuples are case classes,
-there are two possibilities. One can either access a tuple's fields
-using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
-\begin{lstlisting}
-val xy = divmod(x, y)
-println("quotient: " + xy._1 + ", rest: " + xy._2)
-\end{lstlisting}
-Or one uses pattern matching on tuples, as in the following example:
-\begin{lstlisting}
-divmod(x, y) match {
-  case Tuple2(n, d) =>
-    println("quotient: " + n + ", rest: " + d)
-}
-\end{lstlisting}
-Note that type parameters are never used in patterns; it would have
-been illegal to write case \code{Tuple2[Int, Int](n, d)}.
-
-Tuples are so convenient that Scala defines special syntax for
-them. To form a tuple with $n$ elements $x_1 \commadots x_n$ one can
-write $(x_1 \commadots x_n)$. This is equivalent to
-\lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
-equivalently for types and for patterns. With that tuple syntax, the
-\lstinline@divmod@ example is written as follows:
-\begin{lstlisting}
-def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
-divmod(x, y) match {
-  case (n, d) => println("quotient: " + n + ", rest: " + d)
-}
-\end{lstlisting}
-\section{Functions}\label{sec:functions}
-
-Scala is a functional language in that functions are first-class
-values.  Scala is also an object-oriented language in that every value
-is an object.  It follows that functions are objects in Scala.  For
-instance, a function from type \code{String} to type \code{Int} is
-represented as an instance of the trait \code{Function1[String, Int]}.
-The \code{Function1} trait is defined as follows.
-\begin{lstlisting}
-package scala
-trait Function1[-A, +B] {
-  def apply(x: A): B
-}
-\end{lstlisting}
-Besides \code{Function1}, there are also definitions of for functions
-of all other arities (the current implementation implements this only
-up to a reasonable limit).  That is, there is one definition for each
-possible number of function parameters.  Scala's function type syntax
-~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
-for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
-T_n, S$]@~.
-
-Scala uses the same syntax $f(x)$ for function application, no matter
-whether $f$ is a method or a function object. This is made possible by
-the following convention: A function application $f(x)$ where $f$ is
-an object (as opposed to a method) is taken to be a shorthand for
-\lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
-function type is inserted automatically where this is necessary.
-
-That's also why we defined array subscripting in
-Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
-array \code{a}, the subscript operation \code{a(i)} is taken to be a
-shorthand for \code{a.apply(i)}.
-
-Functions are an example where a contra-variant type parameter
-declaration is useful. For example, consider the following code:
-\begin{lstlisting}
-val f: (AnyRef => Int)  =  x => x.hashCode()
-val g: (String => Int)  =  f
-g("abc")
-\end{lstlisting}
-It's sound to bind the value \code{g} of type \code{String => Int} to
-\code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
-do with function of type \code{String => Int} is pass it a string in
-order to obtain an integer. Clearly, the same works for function
-\code{f}: If we pass it a string (or any other object), we obtain an
-integer.  This demonstrates that function subtyping is contra-variant
-in its argument type whereas it is covariant in its result type.
-In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
-$S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
-
-\example Consider the Scala code
-\begin{lstlisting}
-val plus1: (Int => Int)  =  (x: Int) => x + 1
-plus1(2)
-\end{lstlisting}
-This is expanded into the following object code.
-\begin{lstlisting}
-val plus1: Function1[Int, Int] = new Function1[Int, Int] {
-  def apply(x: Int): Int = x + 1
-}
-plus1.apply(2)
-\end{lstlisting}
-Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
-represents an instance of an {\em anonymous class}. It combines the
-creation of a new \code{Function1} object with an implementation of 
-the \code{apply} method (which is abstract in \code{Function1}).
-Equivalently, but more verbosely, one could have used a local class:
-\begin{lstlisting}
-val plus1: Function1[Int, Int] = {
-  class Local extends Function1[Int, Int] {
-    def apply(x: Int): Int = x + 1
-  }
-  new Local: Function1[Int, Int]
-}
-plus1.apply(2)
-\end{lstlisting}
+%% \paragraph{Inheritance and Overriding}
+%% Every class in Scala has a superclass which it extends.  
+%% \comment{Excepted is
+%% only the root class \code{Object}, which does not have a superclass,
+%% and which is indirectly extended by every other class.  }
+%% If a class
+%% does not mention a superclass in its definition, the root type
+%% \code{scala.AnyRef} is implicitly assumed (for Java implementations,
+%% this type is an alias for \code{java.lang.Object}. For instance, class
+%% \code{Rational} could equivalently be defined as
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%% }
+%% \end{lstlisting}
+%% A class inherits all members from its superclass. It may also redefine
+%% (or: {\em override}) some inherited members. For instance, class
+%% \code{java.lang.Object} defines
+%% a method
+%% \code{toString} which returns a representation of the object as a string:
+%% \begin{lstlisting}
+%% class Object {
+%%   ...
+%%   def toString: String = ...
+%% }
+%% \end{lstlisting}
+%% The implementation of \code{toString} in \code{Object}
+%% forms a string consisting of the object's class name and a number. It
+%% makes sense to redefine this method for objects that are rational
+%% numbers:
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%%   override def toString = "" + numer + "/" + denom
+%% }
+%% \end{lstlisting}
+%% Note that, unlike in Java, redefining definitions need to be preceded
+%% by an \code{override} modifier.
+
+%% If class $A$ extends class $B$, then objects of type $A$ may be used
+%% wherever objects of type $B$ are expected. We say in this case that
+%% type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
+%% conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
+%% value to a variable of type \code{AnyRef}:
+%% \begin{lstlisting}
+%% var x: AnyRef = new Rational(1, 2)
+%% \end{lstlisting}
+
+%% \paragraph{Parameterless Methods}
+%% %Also unlike in Java, methods in Scala do not necessarily take a
+%% %parameter list. An example is \code{toString}; the method is invoked
+%% %by simply mentioning its name. For instance:
+%% %\begin{lstlisting}
+%% %val r = new Rational(1,2)
+%% %System.out.println(r.toString);      // prints``1/2''
+%% %\end{lstlisting}
+%% Unlike in Java, methods in Scala do not necessarily take a
+%% parameter list. An example is the \code{square} method below. This
+%% method is invoked by simply mentioning its name. 
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%%   def square = new Rational(numer*numer, denom*denom)
+%% }
+%% val r = new Rational(3, 4)
+%% println(r.square)           // prints``9/16''*
+%% \end{lstlisting}
+%% That is, parameterless methods are accessed just as value fields such
+%% as \code{numer} are. The difference between values and parameterless
+%% methods lies in their definition. The right-hand side of a value is
+%% evaluated when the object is created, and the value does not change
+%% afterwards. A right-hand side of a parameterless method, on the other
+%% hand, is evaluated each time the method is called.  The uniform access
+%% of fields and parameterless methods gives increased flexibility for
+%% the implementer of a class. Often, a field in one version of a class
+%% becomes a computed value in the next version. Uniform access ensures
+%% that clients do not have to be rewritten because of that change.
+
+%% \paragraph{Abstract Classes}
+
+%% Consider the task of writing a class for sets of integer numbers with
+%% two operations, \code{incl} and \code{contains}. \code{(s incl x)}
+%% should return a new set which contains the element \code{x} together
+%% with all the elements of set \code{s}. \code{(s contains x)} should
+%% return true if the set \code{s} contains the element \code{x}, and
+%% should return \code{false} otherwise. The interface of such sets is
+%% given by:  
+%% \begin{lstlisting}
+%% abstract class IntSet {
+%%   def incl(x: Int): IntSet
+%%   def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
+%% \code{IntSet} is labeled as an \emph{abstract class}. This has two
+%% consequences.  First, abstract classes may have {\em deferred} members
+%% which are declared but which do not have an implementation. In our
+%% case, both \code{incl} and \code{contains} are such members. Second,
+%% because an abstract class might have unimplemented members, no objects
+%% of that class may be created using \code{new}. By contrast, an
+%% abstract class may be used as a base class of some other class, which
+%% implements the deferred members.
+
+%% \paragraph{Traits}
+
+%% Instead of \code{abstract class} one also often uses the keyword
+%% \code{trait} in Scala. Traits are abstract classes that are meant to
+%% be added to some other class. This might be because a trait adds some
+%% methods or fields to an unknown parent class.  For instance, a trait
+%% \code{Bordered} might be used to add a border to a various graphical
+%% components. Another usage scenario is where the trait collects
+%% signatures of some functionality provided by different classes, much
+%% in the way a Java interface would work.
+
+%% Since \code{IntSet} falls in this category, one can alternatively
+%% define it as a trait:
+%% \begin{lstlisting}
+%% trait IntSet {
+%%   def incl(x: Int): IntSet
+%%   def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
+
+%% \paragraph{Implementing Abstract Classes}
+
+%% Let's say, we plan to implement sets as binary trees.  There are two
+%% possible forms of trees. A tree for the empty set, and a tree
+%% consisting of an integer and two subtrees. Here are their
+%% implementations.
+
+%% \begin{lstlisting}
+%% class EmptySet extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
+%% }
+%% \end{lstlisting}
+
+%% \begin{lstlisting}
+%% class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: Int): IntSet =
+%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
+%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
+%% Both \code{EmptySet} and \code{NonEmptySet} extend class
+%% \code{IntSet}.  This implies that types \code{EmptySet} and
+%% \code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
+
+%% \begin{exercise} Write methods \code{union} and \code{intersection} to form
+%% the union and intersection between two sets.
+%% \end{exercise}
+
+%% \begin{exercise} Add a method 
+%% \begin{lstlisting}
+%% def excl(x: Int)
+%% \end{lstlisting}
+%% to return the given set without the element \code{x}. To accomplish this,
+%% it is useful to also implement a test method
+%% \begin{lstlisting}
+%% def isEmpty: Boolean
+%% \end{lstlisting}
+%% for sets.
+%% \end{exercise}
+
+%% \paragraph{Dynamic Binding}
+
+%% Object-oriented languages (Scala included) use \emph{dynamic dispatch}
+%% for method invocations.  That is, the code invoked for a method call
+%% depends on the run-time type of the object which contains the method.
+%% For example, consider the expression \code{s contains 7} where
+%% \code{s} is a value of declared type \code{s: IntSet}. Which code for
+%% \code{contains} is executed depends on the type of value of \code{s} at run-time.
+%% If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
+%% This behavior is a direct consequence of our substitution model of evaluation.
+%% For instance,
+%% \begin{lstlisting}
+%%     (new EmptySet).contains(7) 
+
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+
+%%     false
+%% \end{lstlisting}
+%% Or,
+%% \begin{lstlisting}
+%%     new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
+
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
+
+%%     if (1 < 7) new EmptySet contains 1
+%%     else if (1 > 7) new EmptySet contains 1
+%%     else true
+
+%% ->  $\rewriteby{by rewriting the conditional}$
+
+%%     new EmptySet contains 1
+
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+
+%%     false .
+%% \end{lstlisting}
+
+%% Dynamic method dispatch is analogous to higher-order function
+%% calls. In both cases, the identity of code to be executed is known
+%% only at run-time. This similarity is not just superficial. Indeed,
+%% Scala represents every function value as an object (see
+%% Section~\ref{sec:functions}).
+
+
+%% \paragraph{Objects}
+
+%% In the previous implementation of integer sets, empty sets were
+%% expressed with \code{new EmptySet}; so a new object was created every time
+%% an empty set value was required. We could have avoided unnecessary
+%% object creations by defining a value \code{empty} once and then using
+%% this value instead of every occurrence of \code{new EmptySet}. For example:
+%% \begin{lstlisting}
+%% val EmptySetVal = new EmptySet
+%% \end{lstlisting}
+%% One problem with this approach is that a value definition such as the
+%% one above is not a legal top-level definition in Scala; it has to be
+%% part of another class or object. Also, the definition of class
+%% \code{EmptySet} now seems a bit of an overkill -- why define a class of objects, 
+%% if we are only interested in a single object of this class? A more
+%% direct approach is to use an {\em object definition}. Here is
+%% a more streamlined alternative definition of the empty set:
+%% \begin{lstlisting}
+%% object EmptySet extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
+%% }
+%% \end{lstlisting}
+%% The syntax of an object definition follows the syntax of a class
+%% definition; it has an optional extends clause as well as an optional
+%% body. As is the case for classes, the extends clause defines inherited
+%% members of the object whereas the body defines overriding or new
+%% members.  However, an object definition defines a single object only
+%% it is not possible to create other objects with the same structure
+%% using \code{new}.  Therefore, object definitions also lack constructor
+%% parameters, which might be present in class definitions.
+
+%% Object definitions can appear anywhere in a Scala program; including
+%% at top-level.  Since there is no fixed execution order of top-level
+%% entities in Scala, one might ask exactly when the object defined by an
+%% object definition is created and initialized. The answer is that the
+%% object is created the first time one of its members is accessed. This
+%% strategy is called {\em lazy evaluation}.
+
+%% \paragraph{Standard Classes}
+
+%% \todo{include picture}
+
+%% Scala is a pure object-oriented language. This means that every value
+%% in Scala can be regarded as an object.  In fact, even primitive types
+%% such as \code{int} or \code{boolean} are not treated specially. They
+%% are defined as type aliases of Scala classes in module \code{Predef}:
+%% \begin{lstlisting}
+%% type boolean = scala.Boolean
+%% type int = scala.Int
+%% type long = scala.Long
+%% ...
+%% \end{lstlisting}
+%% For efficiency, the compiler usually represents values of type
+%% \code{scala.Int} by 32 bit integers, values of type
+%% \code{scala.Boolean} by Java's booleans, etc.  But it converts these
+%% specialized representations to objects when required, for instance
+%% when a primitive \code{Int} value is passed to a function with a
+%% parameter of type \code{AnyRef}.  Hence, the special representation of
+%% primitive values is just an optimization, it does not change the
+%% meaning of a program.
+
+%% Here is a specification of class \code{Boolean}.
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Boolean {
+%%   def && (x: => Boolean): Boolean
+%%   def || (x: => Boolean): Boolean
+%%   def !                 : Boolean
+
+%%   def == (x: Boolean)   : Boolean
+%%   def != (x: Boolean)   : Boolean
+%%   def <  (x: Boolean)   : Boolean
+%%   def >  (x: Boolean)   : Boolean
+%%   def <= (x: Boolean)   : Boolean
+%%   def >= (x: Boolean)   : Boolean
+%% }
+%% \end{lstlisting}
+%% Booleans can be defined using only classes and objects, without
+%% reference to a built-in type of booleans or numbers. A possible
+%% implementation of class \code{Boolean} is given below.  This is not
+%% the actual implementation in the standard Scala library. For
+%% efficiency reasons the standard implementation uses built-in
+%% booleans.
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Boolean {
+%%   def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
+
+%%   def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
+%%   def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
+%%   def !                 : Boolean  =  ifThenElse(false, true)
+
+%%   def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
+%%   def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
+%%   def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
+%%   def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
+%%   def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
+%%   def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
+%% }
+%% case object True extends Boolean {
+%%   def ifThenElse(t: => Boolean, e: => Boolean) = t
+%% }
+%% case object False extends Boolean {
+%%   def ifThenElse(t: => Boolean, e: => Boolean) = e
+%% }
+%% \end{lstlisting}
+%% Here is a partial specification of class \code{Int}.
+
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Int extends AnyVal {
+%%   def toLong: Long
+%%   def toFloat: Float
+%%   def toDouble: Double
+
+%%   def + (that: Double): Double
+%%   def + (that: Float): Float
+%%   def + (that: Long): Long
+%%   def + (that: Int): Int         // analogous for -, *, /, %
+
+%%   def << (cnt: Int): Int         // analogous for >>, >>>
+
+%%   def & (that: Long): Long
+%%   def & (that: Int): Int         // analogous for |, ^
+
+%%   def == (that: Double): Boolean
+%%   def == (that: Float): Boolean
+%%   def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
+%% }
+%% \end{lstlisting}
+
+%% Class \code{Int} can in principle also be implemented using just
+%% objects and classes, without reference to a built in type of
+%% integers. To see how, we consider a slightly simpler problem, namely
+%% how to implement a type \code{Nat} of natural (i.e. non-negative)
+%% numbers. Here is the definition of an abstract class \code{Nat}:
+%% \begin{lstlisting}
+%% abstract class Nat {
+%%   def isZero: Boolean
+%%   def predecessor: Nat
+%%   def successor: Nat
+%%   def + (that: Nat): Nat
+%%   def - (that: Nat): Nat
+%% }
+%% \end{lstlisting}
+%% To implement the operations of class \code{Nat}, we define a sub-object
+%% \code{Zero} and a subclass \code{Succ} (for successor). Each number
+%% \code{N} is represented as \code{N} applications of the \code{Succ}
+%% constructor to \code{Zero}:
+%% \[
+%% \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
+%% \]
+%% The implementation of the \code{Zero} object is straightforward:
+%% \begin{lstlisting}
+%% object Zero extends Nat {
+%%   def isZero: Boolean = true
+%%   def predecessor: Nat = error("negative number")
+%%   def successor: Nat = new Succ(Zero)
+%%   def + (that: Nat): Nat = that
+%%   def - (that: Nat): Nat = if (that.isZero) Zero
+%%                            else error("negative number")
+%% }
+%% \end{lstlisting}
+
+%% The implementation of the predecessor and subtraction functions on
+%% \code{Zero} throws an \code{Error} exception, which aborts the program
+%% with the given error message.
+
+%% Here is the implementation of the successor class:
+%% \begin{lstlisting}
+%% class Succ(x: Nat) extends Nat  {
+%%   def isZero: Boolean = false
+%%   def predecessor: Nat = x
+%%   def successor: Nat = new Succ(this)
+%%   def + (that: Nat): Nat = x + that.successor
+%%   def - (that: Nat): Nat = if (that.isZero) this 
+%%                            else x - that.predecessor
+%% }
+%% \end{lstlisting}
+%% Note the implementation of method \code{successor}. To create the
+%% successor of a number, we need to pass the object itself as an
+%% argument to the \code{Succ} constructor.  The object itself is
+%% referenced by the reserved name \code{this}.   
+
+%% The implementations of \code{+} and \code{-} each contain a recursive
+%% call with the constructor argument as receiver. The recursion will
+%% terminate once the receiver is the \code{Zero} object (which is
+%% guaranteed to happen eventually because of the way numbers are formed).
+
+%% \begin{exercise} Write an implementation \code{Integer} of integer numbers
+%% The implementation should support all operations of class \code{Nat}
+%% while adding two methods
+%% \begin{lstlisting}
+%% def isPositive: Boolean
+%% def negate: Integer
+%% \end{lstlisting}
+%% The first method should return \code{true} if the number is positive. The second method should negate the number.
+%% Do not use any of Scala's standard numeric classes in your
+%% implementation. (Hint: There are two possible ways to implement
+%% \code{Integer}. One can either make use the existing implementation of
+%% \code{Nat}, representing an integer as a natural number and a sign.
+%% Or one can generalize the given implementation of \code{Nat} to
+%% \code{Integer}, using the three subclasses \code{Zero} for 0, 
+%% \code{Succ} for positive numbers and \code{Pred} for negative numbers.)
+%% \end{exercise}
+
+
+
+%% \subsection*{Language Elements Introduced In This Chapter}
+
+%% \textbf{Types:}
+%% \begin{lstlisting}
+%% Type         = ...  |  ident
+%% \end{lstlisting}
+
+%% Types can now be arbitrary identifiers which represent classes.
+
+%% \textbf{Expressions:}
+%% \begin{lstlisting}
+%% Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
+%% \end{lstlisting}
+
+%% An expression can now be an object creation, or
+%% a selection \code{E.m} of a member \code{m}
+%% from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
+
+%% \textbf{Definitions and Declarations:}
+%% \begin{lstlisting}
+%% Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
+%% ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
+%%                ['extends' Expr] [`{' {TemplateDef} `}']
+%% TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
+%% ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
+%% TemplateDef  = [Modifier] (Def | Dcl)
+%% ObjectDef    = [Modifier] Def
+%% Modifier     = 'private'  |  'override'
+%% Dcl          = FunDcl  |  ValDcl
+%% FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
+%% ValDcl       = 'val' ident ':' Type
+%% \end{lstlisting}
+
+%% A definition can now be a class, trait or object definition such as
+%% \begin{lstlisting}
+%% class C(params) extends B { defs }
+%% trait T extends B { defs }
+%% object O extends B { defs }
+%% \end{lstlisting}
+%% The definitions \code{defs} in a class, trait or object may be
+%% preceded by modifiers \code{private} or \code{override}.
+
+%% Abstract classes and traits may also contain declarations. These
+%% introduce {\em deferred} functions or values with their types, but do
+%% not give an implementation. Deferred members have to be implemented in
+%% subclasses before objects of an abstract class or trait can be created.
+
+%% \chapter{Case Classes and Pattern Matching}
+
+%% Say, we want to write an interpreter for arithmetic expressions.  To
+%% keep things simple initially, we restrict ourselves to just numbers
+%% and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
+%% \code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
+%% \begin{lstlisting}
+%% new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
+%% \end{lstlisting}
+%% Now, an evaluator of an expression like this needs to know of what
+%% form it is (either \code{Sum} or \code{Number}) and also needs to
+%% access the components of the expression.  The following
+%% implementation provides all necessary methods.
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def isNumber: Boolean
+%%   def isSum: Boolean
+%%   def numValue: Int
+%%   def leftOp: Expr
+%%   def rightOp: Expr
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def isNumber: Boolean = true
+%%   def isSum: Boolean = false
+%%   def numValue: Int = n
+%%   def leftOp: Expr = error("Number.leftOp")
+%%   def rightOp: Expr = error("Number.rightOp")
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def isNumber: Boolean = false
+%%   def isSum: Boolean = true
+%%   def numValue: Int = error("Sum.numValue")
+%%   def leftOp: Expr = e1
+%%   def rightOp: Expr = e2
+%% }
+%% \end{lstlisting}
+%% With these classification and access methods, writing an evaluator function is simple:
+%% \begin{lstlisting}
+%% def eval(e: Expr): Int = {
+%%   if (e.isNumber) e.numValue
+%%   else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
+%%   else error("unrecognized expression kind")
+%% }
+%% \end{lstlisting}
+%% However, defining all these methods in classes \code{Sum} and
+%% \code{Number} is rather tedious. Furthermore, the problem becomes worse 
+%% when we want to add new forms of expressions. For instance, consider
+%% adding a new expression form
+%% \code{Prod} for products. Not only do we have to implement a new class \code{Prod}, with all previous classification and access methods; we also have to introduce a
+%% new abstract method \code{isProduct} in class \code{Expr} and
+%% implement that method in subclasses \code{Number}, \code{Sum}, and
+%% \code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
+
+%% The promise of object-oriented programming is that such modifications
+%% should be unnecessary, because they can be avoided by re-using
+%% existing, unmodified code through inheritance. Indeed, a more
+%% object-oriented decomposition of our problem solves the problem.  The
+%% idea is to make the ``high-level'' operation \code{eval} a method of
+%% each expression class, instead of implementing it as a function
+%% outside the expression class hierarchy, as we have done
+%% before. Because \code{eval} is now a member of all expression nodes,
+%% all classification and access methods become superfluous, and the implementation is simplified considerably:
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def eval: Int
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def eval: Int = n
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval + e2.eval
+%% }
+%% \end{lstlisting}
+%% Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
+%% \begin{lstlisting}
+%% class Prod(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval * e2.eval
+%% }
+%% \end{lstlisting}
+
+%% The conclusion we can draw from this example is that object-oriented
+%% decomposition is the technique of choice for constructing systems that
+%% should be extensible with new types of data. But there is also another
+%% possible way we might want to extend the expression example. We might
+%% want to add new {\em operations} on expressions.  For instance, we might
+%% want to add an operation that pretty-prints an expression tree to standard output.
+
+%% If we have defined all classification and access methods, such an
+%% operation can easily be written as an external function. Here is an
+%% example:
+%% \begin{lstlisting}
+%% def print(e: Expr) {
+%%   if (e.isNumber) Console.print(e.numValue)
+%%   else if (e.isSum) {
+%%     Console.print("(")
+%%     print(e.leftOp)
+%%     Console.print("+")
+%%     print(e.rightOp)
+%%     Console.print(")")
+%%   } else error("unrecognized expression kind")
+%% }
+%% \end{lstlisting}
+%% However, if we had opted for an object-oriented decomposition of
+%% expressions, we would need to add a new \code{print} procedure
+%% to each class:
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def eval: Int
+%%   def print
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def eval: Int = n
+%%   def print { Console.print(n) }
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval + e2.eval
+%%   def print {
+%%     Console.print("(")
+%%     print(e1)
+%%     Console.print("+")
+%%     print(e2)
+%%     Console.print(")")
+%%   }
+%% }
+%% \end{lstlisting}
+%% Hence, classical object-oriented decomposition requires modification
+%% of all existing classes when a system is extended with new operations.
+
+%% As yet another way we might want to extend the interpreter, consider
+%% expression simplification. For instance, we might want to write a
+%% function which rewrites expressions of the form
+%% \code{a * b + a * c} to \code{a * (b + c)}. This operation requires inspection of 
+%% more than a single node of the expression tree at the same
+%% time. Hence, it cannot be implemented by a method in each expression
+%% kind, unless that method can also inspect other nodes. So we are
+%% forced to have classification and access methods in this case. This
+%% seems to bring us back to square one, with all the problems of
+%% verbosity and extensibility.
+
+%% Taking a closer look, one observes that the only purpose of the
+%% classification and access functions is to {\em reverse} the data
+%% construction process.  They let us determine, first, which sub-class
+%% of an abstract base class was used and, second, what were the
+%% constructor arguments. Since this situation is quite common, Scala has
+%% a way to automate it with case classes. 
+
+%% \section{Case Classes and Case Objects}
+
+%% {\em Case classes} and {\em case objects} are defined like a normal
+%% classes or objects, except that the definition is prefixed with the modifier
+%% \code{case}.  For instance, the definitions
+%% \begin{lstlisting}
+%% abstract class Expr
+%% case class Number(n: Int) extends Expr
+%% case class Sum(e1: Expr, e2: Expr) extends Expr
+%% \end{lstlisting}
+%% introduce \code{Number} and \code{Sum} as case classes.
+%% The \code{case} modifier in front of a class or object 
+%% definition has the following effects.
+%% \begin{enumerate}
+%% \item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
+%% \begin{lstlisting}
+%% def Number(n: Int) = new Number(n)
+%% def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
+%% \end{lstlisting}
+%% would be added. Hence, one can now construct expression trees a bit more concisely, as in
+%% \begin{lstlisting}
+%% Sum(Sum(Number(1), Number(2)), Number(3))
+%% \end{lstlisting} 
+%% \item Case classes and case objects 
+%% implicitly come with implementations of methods
+%% \code{toString}, \code{equals} and \code{hashCode}, which override the
+%% methods with the same name in class \code{AnyRef}. The implementation
+%% of these methods takes in each case the structure of a member of a
+%% case class into account. The \code{toString} method represents an
+%% expression tree the way it was constructed. So,
+%% \begin{lstlisting}
+%% Sum(Sum(Number(1), Number(2)), Number(3))
+%% \end{lstlisting} 
+%% would be converted to exactly that string, whereas the default
+%% implementation in class \code{AnyRef} would return a string consisting
+%% of the outermost constructor name \code{Sum} and a number.  The
+%% \code{equals} methods treats two case members of a case class as equal
+%% if they have been constructed with the same constructor and with
+%% arguments which are themselves pairwise equal. This also affects the
+%% implementation of \code{==} and \code{!=}, which are implemented in
+%% terms of \code{equals} in Scala. So,
+%% \begin{lstlisting}
+%% Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
+%% \end{lstlisting}
+%% will yield \code{true}. If \code{Sum} or \code{Number} were not case
+%% classes, the same expression would be \code{false}, since the standard
+%% implementation of \code{equals} in class \code{AnyRef} always treats
+%% objects created by different constructor calls as being different.
+%% The \code{hashCode} method follows the same principle as other two
+%% methods. It computes a hash code from the case class constructor name
+%% and the hash codes of the constructor arguments, instead of from the object's
+%% address, which is what the as the default implementation of \code{hashCode} does.
+%% \item 
+%% Case classes implicitly come with nullary accessor methods which
+%% retrieve the constructor arguments.
+%% In our example, \code{Number} would obtain an accessor method
+%% \begin{lstlisting}
+%% def n: Int
+%% \end{lstlisting}
+%% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
+%% \begin{lstlisting}
+%% def e1: Expr, e2: Expr
+%% \end{lstlisting}
+%% Hence, if for a value \code{s} of type \code{Sum}, say, one can now
+%% write \code{s.e1}, to access the left operand. However, for a value
+%% \code{e} of type \code{Expr}, the term \code{e.e1} would be illegal
+%% since \code{e1} is defined in \code{Sum}; it is not a member of the
+%% base class \code{Expr}. 
+%% So, how do we determine the constructor and access constructor
+%% arguments for values whose static type is the base class \code{Expr}?
+%% This is solved by the fourth and final particularity of case classes.
+%% \item 
+%% Case classes allow the constructions of {\em patterns} which refer to
+%% the case class constructor.
+%% \end{enumerate}
+
+%% \section{Pattern Matching}
+
+%% Pattern matching is a generalization of C or Java's \code{switch}
+%% statement to class hierarchies. Instead of a \code{switch} statement,
+%% there is a standard method \code{match}, which is defined in Scala's
+%% root class \code{Any}, and therefore is available for all objects.
+%% The \code{match} method takes as argument a number of cases. 
+%% For instance, here is an implementation of \code{eval} using 
+%% pattern matching.
+%% \begin{lstlisting}
+%% def eval(e: Expr): Int = e match {
+%%   case Number(n) => n 
+%%   case Sum(l, r) => eval(l) + eval(r) 
+%% }
+%% \end{lstlisting}
+%% In this example, there are two cases. Each case associates a pattern
+%% with an expression. Patterns are matched against the selector
+%% values \code{e}.  The first pattern in our example,
+%% \code{Number(n)}, matches all values of the form \code{Number(v)}, 
+%% where \code{v} is an arbitrary value.  In that case, the {\em pattern
+%% variable} \code{n} is bound to the value \code{v}. Similarly, the
+%% pattern \code{Sum(l, r)} matches all selector values of form
+%% \code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
+%% \code{l} and \code{r} 
+%% to \code{v}$_1$ and \code{v}$_2$, respectively. 
+
+%% In general, patterns are built from
+%% \begin{itemize}
+%% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
+%%       are again patterns,
+%% \item pattern variables, e.g. \code{n}, \code{e1}, \code{e2},
+%% \item the ``wildcard'' pattern \code{_},
+%% \item literals, e.g. \code{1}, \code{true}, "abc", 
+%% \item constant identifiers, e.g. \code{MAXINT}, \code{EmptySet}.
+%% \end{itemize}
+%% Pattern variables always start with a lower-case letter, so that they
+%% can be distinguished from constant identifiers, which start with an
+%% upper case letter.  Each variable name may occur only once in a
+%% pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
+%% since the pattern variable \code{x} occurs twice in it.
+
+%% \paragraph{Meaning of Pattern Matching}
+%% A pattern matching expression 
+%% \begin{lstlisting}
+%% e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
+%% \end{lstlisting}
+%% matches the patterns $p_1 \commadots p_n$ in the order they
+%% are written against the selector value \code{e}.
+%% \begin{itemize}
+%% \item
+%% A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
+%% are of type \code{C} (or a subtype thereof) and that have been constructed with 
+%% \code{C}-arguments matching patterns $p_1 \commadots p_n$.
+%% \item 
+%% A variable pattern \code{x} matches any value and binds the variable
+%% name to that value.  
+%% \item 
+%% The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
+%% \item A constant pattern \code{C} matches a value which is
+%% equal (in terms of \code{==}) to \code{C}.
+%% \end{itemize}
+%% The pattern matching expression rewrites to the right-hand-side of the
+%% first case whose pattern matches the selector value. References to
+%% pattern variables are replaced by corresponding constructor arguments.
+%% If none of the patterns matches, the pattern matching expression is
+%% aborted with a \code{MatchError} exception.
+
+%% \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
+%% \begin{lstlisting}
+%%      eval(Sum(Number(1), Number(2)))
+
+%% ->   $\mbox{\tab\tab\rm(by rewriting the application)}$
+
+%%      Sum(Number(1), Number(2)) match {
+%%          case Number(n) => n
+%%          case Sum(e1, e2) => eval(e1) + eval(e2)
+%%      }
+
+%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+
+%%      eval(Number(1)) + eval(Number(2))
+
+%% ->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
+
+%%      Number(1) match {
+%%          case Number(n) => n
+%%          case Sum(e1, e2) => eval(e1) + eval(e2)
+%%      } + eval(Number(2))
+
+%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+
+%%      1 + eval(Number(2))
+
+%% ->$^*$ 1 + 2 -> 3
+%% \end{lstlisting}
+
+%% \paragraph{Pattern Matching and Methods}
+%% In the previous example, we have used pattern
+%% matching in a function which was defined outside the class hierarchy
+%% over which it matches.  Of course, it is also possible to define a
+%% pattern matching function in that class hierarchy itself. For
+%% instance, we could have defined
+%% \code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
+%% \begin{lstlisting}
+%% abstract class Expr { 
+%%   def eval: Int = this match {
+%%     case Number(n) => n
+%%     case Sum(e1, e2) => e1.eval + e2.eval 
+%%   } 
+%% }
+%% \end{lstlisting}
+
+%% \begin{exercise} Consider the following definitions representing trees
+%% of integers.  These definitions can be seen as an alternative
+%% representation of \code{IntSet}:
+%% \begin{lstlisting}
+%% abstract class IntTree
+%% case object EmptyTree extends IntTree
+%% case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
+%% \end{lstlisting}
+%% Complete the following implementations of function \code{contains} and \code{insert} for 
+%% \code{IntTree}'s.
+%% \begin{lstlisting}
+%% def contains(t: IntTree, v: Int): Boolean = t match { ...
+%%   ...
+%% }
+%% def insert(t: IntTree, v: Int): IntTree = t match { ...
+%%   ...
+%% }
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \paragraph{Pattern Matching Anonymous Functions}
+
+%% So far, case-expressions always appeared in conjunction with a
+%% \verb@match@ operation. But it is also possible to use
+%% case-expressions by themselves. A block of case-expressions such as
+%% \begin{lstlisting}
+%% { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
+%% \end{lstlisting}
+%% is seen by itself as a function which matches its arguments
+%% against the patterns $P_1 \commadots P_n$, and produces the result of
+%% one of $E_1 \commadots E_n$. (If no pattern matches, the function
+%% would throw a \code{MatchError} exception instead).
+%% In other words, the expression above is seen as a shorthand for the anonymous function
+%% \begin{lstlisting}
+%% (x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
+%% \end{lstlisting}
+%% where \code{x} is a fresh variable which is not used 
+%% otherwise in the expression.
+
+%% \chapter{Generic Types and Methods}
+
+%% Classes in Scala can have type parameters. We demonstrate the use of
+%% type parameters with functional stacks as an example. Say, we want to
+%% write a data type of stacks of integers, with methods \code{push},
+%% \code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
+%% following class hierarchy:
+%% \begin{lstlisting}
+%% abstract class IntStack {
+%%   def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
+%%   def isEmpty: Boolean
+%%   def top: Int
+%%   def pop: IntStack
+%% }
+%% class IntEmptyStack extends IntStack {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
+%% Of course, it would also make sense to define an abstraction for a
+%% stack of Strings. To do that, one could take the existing abstraction
+%% for \code{IntStack}, rename it to \code{StringStack} and at the same
+%% time rename all occurrences of type \code{Int} to \code{String}.
+
+%% A better way, which does not entail code duplication, is to
+%% parameterize the stack definitions with the element type.
+%% Parameterization lets us generalize from a specific instance of a
+%% problem to a more general one. So far, we have used parameterization
+%% only for values, but it is available also for types. To arrive at a
+%% {\em generic} version of \code{Stack}, we equip it with a type
+%% parameter.
+%% \begin{lstlisting}
+%% abstract class Stack[A] {
+%%   def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
+%%   def isEmpty: Boolean
+%%   def top: A
+%%   def pop: Stack[A]
+%% }
+%% class EmptyStack[A] extends Stack[A] {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
+%% In the definitions above, `\code{A}' is a {\em type parameter} of
+%% class \code{Stack} and its subclasses.  Type parameters are arbitrary
+%% names; they are enclosed in brackets instead of parentheses, so that
+%% they can be easily distinguished from value parameters.  Here is an
+%% example how the generic classes are used:
+%% \begin{lstlisting}
+%% val x = new EmptyStack[Int]
+%% val y = x.push(1).push(2)
+%% println(y.pop.top)
+%% \end{lstlisting}
+%% The first line creates a new empty stack of \code{Int}'s. Note the
+%% actual type argument \code{[Int]} which replaces the formal type
+%% parameter \code{A}.
+
+%% It is also possible to parameterize methods with types. As an example,
+%% here is a generic method which determines whether one stack is a
+%% prefix of another.
+%% \begin{lstlisting}
+%% def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
+%%   p.isEmpty ||
+%%   p.top == s.top && isPrefix[A](p.pop, s.pop)
+%% }
+%% \end{lstlisting}  
+%% The method parameters are called {\em polymorphic}.  Generic methods are
+%% also called {\em polymorphic}.  The term comes from the Greek, where it
+%% means ``having many forms''.  To apply a polymorphic method such as
+%% \code{isPrefix}, we pass type parameters as well as value parameters
+%% to it. For instance,
+%% \begin{lstlisting}
+%% val s1 = new EmptyStack[String].push("abc")
+%% val s2 = new EmptyStack[String].push("abx").push(s1.top)
+%% println(isPrefix[String](s1, s2))
+%% \end{lstlisting}
+
+%% \paragraph{Local Type Inference}
+%% Passing type parameters such as \code{[Int]} or \code{[String]} all
+%% the time can become tedious in applications where generic functions
+%% are used a lot. Quite often, the information in a type parameter is
+%% redundant, because the correct parameter type can also be determined
+%% by inspecting the function's value parameters or expected result type.
+%% Taking the expression \code{isPrefix[String](s1, s2)} as an
+%% example, we know that its value parameters are both of type
+%% \code{Stack[String]}, so we can deduce that the type parameter must
+%% be \code{String}. Scala has a fairly powerful type inferencer which
+%% allows one to omit type parameters to polymorphic functions and
+%% constructors in situations like these.  In the example above, one
+%% could have written \code{isPrefix(s1, s2)} and the missing type argument
+%% \code{[String]} would have been inserted by the type inferencer. 
+
+%% \section{Type Parameter Bounds}
+
+%% Now that we know how to make classes generic it is natural to
+%% generalize some of the earlier classes we have written. For instance
+%% class \code{IntSet} could be generalized to sets with arbitrary
+%% element types. Let's try. The abstract class for generic sets is easily
+%% written.
+%% \begin{lstlisting}
+%% abstract class Set[A] {
+%%   def incl(x: A): Set[A]
+%%   def contains(x: A): Boolean
+%% }
+%% \end{lstlisting}
+%% However, if we still want to implement sets as binary search trees, we
+%% encounter a problem. The \code{contains} and \code{incl} methods both
+%% compare elements using methods \code{<} and \code{>}. For
+%% \code{IntSet} this was OK, since type \code{Int} has these two
+%% methods. But for an arbitrary type parameter \code{a}, we cannot
+%% guarantee this. Therefore, the previous implementation of, say,
+%% \code{contains} would generate a compiler error.
+%% \begin{lstlisting}
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%           ^ < $\mbox{\sl not a member of type}$ A.
+%% \end{lstlisting}
+%% One way to solve the problem is to restrict the legal types that can
+%% be substituted for type \code{A} to only those types that contain methods
+%% \code{<} and \code{>} of the correct types. There is a trait
+%% \code{Ordered[A]} in the standard class library Scala which represents
+%% values which are comparable (via \code{<} and \code{>}) to values of
+%% type \code{A}. This trait is defined as follows:
+%% \begin{lstlisting}
+%% /** A class for totally ordered data. */
+%% trait Ordered[A] {
+
+%%   /** Result of comparing `this' with operand `that'.
+%%    *  returns `x' where
+%%    *  x < 0    iff    this < that
+%%    *  x == 0   iff    this == that
+%%    *  x > 0    iff    this > that
+%%    */
+%%   def compare(that: A): Int
+
+%%   def <  (that: A): Boolean = (this compare that) <  0
+%%   def >  (that: A): Boolean = (this compare that) >  0
+%%   def <= (that: A): Boolean = (this compare that) <= 0
+%%   def >= (that: A): Boolean = (this compare that) >= 0
+%%   def compareTo(that: A): Int = compare(that)
+%% }
+%% \end{lstlisting}
+%% We can enforce the comparability of a type by demanding
+%% that the type is a subtype of \code{Ordered}. This is done by giving an
+%% upper bound to the type parameter of \code{Set}:
+%% \begin{lstlisting}
+%% trait Set[A <: Ordered[A]] {
+%%   def incl(x: A): Set[A]
+%%   def contains(x: A): Boolean
+%% }
+%% \end{lstlisting}
+%% The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
+%% type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
+%% must be comparable to values of the same type.
+
+%% With this restriction, we can now implement the rest of the generic
+%% set abstraction as we did in the case of \code{IntSet}s before.
+
+%% \begin{lstlisting}
+%% class EmptySet[A <: Ordered[A]] extends Set[A] {
+%%   def contains(x: A): Boolean = false
+%%   def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
+%% }
+%% \end{lstlisting}
+
+%% \begin{lstlisting}
+%% class NonEmptySet[A <: Ordered[A]]
+%%         (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
+%%   def contains(x: A): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: A): Set[A] =
+%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
+%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
+%% Note that we have left out the type argument in the object creations
+%% \code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
+%% missing type arguments in constructor calls are inferred from value
+%% arguments and/or the expected result type.
+
+%% Here is an example that uses the generic set abstraction. Let's first
+%% create a subclass of \lstinline@Ordered@, like this:
+%% \begin{lstlisting}
+%% case class Num(value: Double) extends Ordered[Num] {
+%%   def compare(that: Num): Int =
+%%     if (this.value < that.value) -1
+%%     else if (this.value > that.value) 1
+%%     else 0
+%% }
+%% \end{lstlisting}
+%% Then:
+%% \begin{lstlisting}
+%% val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
+%% s.contains(Num(1.5))
+%% \end{lstlisting}
+%% This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
+%% However, the following example is in error.
+%% \begin{lstlisting}
+%% val s = new EmptySet[java.io.File]
+%%                     ^ java.io.File $\mbox{\sl does not conform to type}$
+%%                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
+%% \end{lstlisting}
+%% One probem with type parameter bounds is that they require
+%% forethought: if we had not declared \lstinline@Num@ a subclass of
+%% \lstinline@Ordered@, we would not have been able to use \lstinline@Num@
+%% elements in sets. By the same token, types inherited from Java, 
+%% such as \lstinline@Int@, \lstinline@Double@, or
+%% \lstinline@String@ are not subclasses of \lstinline@Ordered@, so
+%% values of these types cannot be used as set elements.
+
+%% A more flexible design, which admits elements of these types, uses
+%% {\em view bounds} instead of the plain type bounds we have seen so
+%% far. The only change this entails in the example above is in the type
+%% parameters:
+%% \begin{lstlisting}
+%% trait Set[A <% Ordered[A]] ...
+%% class EmptySet[A <% Ordered[A]] ...
+%% class NonEmptySet[A <% Ordered[A]] ...
+%% \end{lstlisting}
+%% View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
+%% A view bounded type parameter clause \lstinline@[A <% T]@ only
+%% specifies that the bounded type \lstinline@A@ must be {\em convertible} to
+%% the bound type \lstinline@T@, using an implicit conversion.
+
+%% The Scala library predefines implicit conversions for a number of
+%% types, including the primitive types and \lstinline@String@.
+%% Therefore, the redesign set abstraction can be instantiated with these
+%% types as well. More explanations on implicit conversions and view
+%% bounds are given in Section~\ref{sec:implicits}.
+
+%% \section{Variance Annotations}\label{sec:first-arrays}
+
+%% The combination of type parameters and subtyping poses some
+%% interesting questions. For instance, should \code{Stack[String]} be a
+%% subtype of \code{Stack[AnyRef]}? Intuitively, this seems OK, since a
+%% stack of \code{String}s is a special case of a stack of
+%% \code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
+%% then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
+%% This property is called {\em co-variant} subtyping.
+
+%% In Scala, generic types have by default non-variant subtyping. That
+%% is, with \code{Stack} defined as above, stacks with different element
+%% types would never be in a subtype relation. However, we can enforce
+%% co-variant subtyping of stacks by changing the first line of the
+%% definition of class \code{Stack} as follows.
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%% \end{lstlisting}
+%% Prefixing a formal type parameter with a \code{+} indicates that
+%% subtyping is covariant in that parameter. 
+%% Besides \code{+}, there is also a prefix \code{-} which indicates
+%% contra-variant subtyping. If \code{Stack} was defined \code{class
+%% Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
+%% that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
+%% case of stacks would be rather surprising!).
+
+%% In a purely functional world, all types could be co-variant. However,
+%% the situation changes once we introduce mutable data. Consider the
+%% case of arrays in Java or .NET. Such arrays are represented in Scala
+%% by a generic class \code{Array}. Here is a partial definition of this
+%% class.
+%% \begin{lstlisting}
+%% class Array[A] {
+%%   def apply(index: Int): A
+%%   def update(index: Int, elem: A)
+%% }
+%% \end{lstlisting}
+%% The class above defines the way Scala arrays are seen from Scala user
+%% programs. The Scala compiler will map this abstraction to the
+%% underlying arrays of the host system in most cases where this
+%% possible.
+
+%% In Java, arrays are indeed covariant; that is, for reference types
+%% \code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
+%% \code{Array[T]} is a subtype of \code{Array[S]}. This might seem
+%% natural but leads to safety problems that require special runtime
+%% checks. Here is an example:
+%% \begin{lstlisting}
+%% val x = new Array[String](1)
+%% val y: Array[Any] = x
+%% y(0) = new Rational(1, 2)  // this is syntactic sugar for
+%%                            // y.update(0, new Rational(1, 2))
+%% \end{lstlisting}
+%% In the first line, a new array of strings is created. In the second
+%% line, this array is bound to a variable \code{y}, of type
+%% \code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
+%% \code{Array[String]} is a subtype of \code{Array[Any]}. Finally, in
+%% the last line a rational number is stored in the array. This is also
+%% OK, since type \code{Rational} is a subtype of the element type
+%% \code{Any} of the array \code{y}. We thus end up storing a rational
+%% number in an array of strings, which clearly violates type soundness. 
+
+%% Java solves this problem by introducing a run-time check in the third
+%% line which tests whether the stored element is compatible with the
+%% element type with which the array was created. We have seen in the
+%% example that this element type is not necessarily the static element
+%% type of the array being updated. If the test fails, an
+%% \code{ArrayStoreException} is raised.
+
+%% Scala solves this problem instead statically, by disallowing the
+%% second line at compile-time, because arrays in Scala have non-variant
+%% subtyping. This raises the question how a Scala compiler verifies that
+%% variance annotations are correct. If we had simply declared arrays
+%% co-variant, how would the potential problem have been detected?
+
+%% Scala uses a conservative approximation to verify soundness of
+%% variance annotations.  A covariant type parameter of a class may only
+%% appear in co-variant positions inside the class.  Among the co-variant
+%% positions are the types of values in the class, the result types of
+%% methods in the class, and type arguments to other covariant types. Not
+%% co-variant are types of formal method parameters. Hence, the following
+%% class definition would have been rejected
+%% \begin{lstlisting}
+%% class Array[+A] {
+%%   def apply(index: Int): A
+%%   def update(index: Int, elem: A)
+%%                                ^ $\mbox{\sl covariant type parameter}$ A
+%%                                  $\mbox{\sl appears in contravariant position.}$
+%% }
+%% \end{lstlisting}
+%% So far, so good. Intuitively, the compiler was correct in rejecting
+%% the \code{update} procedure in a co-variant class because \code{update}
+%% potentially changes state, and therefore undermines the soundness of
+%% co-variant subtyping. 
+
+%% However, there are also methods which do not mutate state, but where a
+%% type parameter still appears contra-variantly. An example is
+%% \code{push} in type \code{Stack}. Again the Scala compiler will reject
+%% the definition of this method for co-variant stacks.
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%%   def push(x: A): Stack[A] =
+%%               ^ $\mbox{\sl covariant type parameter}$ A
+%%                 $\mbox{\sl appears in contravariant position.}$
+%% \end{lstlisting}
+%% This is a pity, because, unlike arrays, stacks are purely functional data
+%% structures and therefore should enable co-variant subtyping. However,
+%% there is a a way to solve the problem by using a polymorphic method
+%% with a lower type parameter bound.
+
+%% \section{Lower Bounds}
+
+%% We have seen upper bounds for type parameters. In a type parameter
+%% declaration such as \code{T <: U}, the type parameter \code{T} is
+%% restricted to range only over subtypes of type \code{U}. Symmetrical
+%% to this are lower bounds in Scala. In a type parameter declaration
+%% \code{T >: S}, the type parameter \code{T} is restricted to range only
+%% over {\em supertypes} of type \code{S}. (One can also combine lower and
+%% upper bounds, as in \code{T >: S <: U}.)
+
+%% Using lower bounds, we can generalize the \code{push} method in
+%% \code{Stack} as follows.
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+%% \end{lstlisting}
+%% Technically, this solves our variance problem since now the type
+%% parameter \code{A} appears no longer as a parameter type of method
+%% \code{push}. Instead, it appears as lower bound for another type
+%% parameter of a method, which is classified as a co-variant position.
+%% Hence, the Scala compiler accepts the new definition of \code{push}.
+
+%% In fact, we have not only solved the technical variance problem but
+%% also have generalized the definition of \code{push}.  Before, we were
+%% required to push only elements with types that conform to the declared
+%% element type of the stack. Now, we can push also elements of a
+%% supertype of this type, but the type of the returned stack will change
+%% accordingly. For instance, we can now push an \code{AnyRef} onto a
+%% stack of \code{String}s, but the resulting stack will be a stack of
+%% \code{AnyRef}s instead of a stack of \code{String}s!
+
+%% In summary, one should not hesitate to add variance annotations to
+%% your data structures, as this yields rich natural subtyping
+%% relationships. The compiler will detect potential soundness
+%% problems. Even if the compiler's approximation is too conservative, as
+%% in the case of method \code{push} of class \code{Stack}, this will
+%% often suggest a useful generalization of the contested method.
+
+%% \section{Least Types}
+
+%% Scala does not allow one to parameterize objects with types. That's
+%% why we originally defined a generic class \code{EmptyStack[A]}, even
+%% though a single value denoting empty stacks of arbitrary type would
+%% do. For co-variant stacks, however, one can use the following idiom:
+%% \begin{lstlisting}
+%% object EmptyStack extends Stack[Nothing] { ... }
+%% \end{lstlisting}
+%% The bottom type \code{Nothing} contains no value, so the type
+%% \code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
+%% contains no elements. Furthermore, \code{Nothing} is a subtype of all
+%% other types. Hence, for co-variant stacks, \code{Stack[Nothing]} is a
+%% subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
+%% possible to use a single empty stack object in user code. For
+%% instance:
+%% \begin{lstlisting}
+%% val s = EmptyStack.push("abc").push(new AnyRef())
+%% \end{lstlisting}
+%% Let's analyze the type assignment for this expression in detail.  The
+%% \code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
+%% method
+%% \begin{lstlisting}
+%% push[B >: Nothing](elem: B): Stack[B] .
+%% \end{lstlisting}
+%% Local type inference will determine that the type parameter \code{B}
+%% should be instantiated to \code{String} in the application 
+%% \code{EmptyStack.push("abc")}. The result type of that application is hence
+%% \code{Stack[String]}, which in turn has a method
+%% \begin{lstlisting}
+%% push[B >: String](elem: B): Stack[B] .
+%% \end{lstlisting}
+%% The final part of the value definition above is the application of
+%% this method to \code{new AnyRef()}. Local type inference will
+%% determine that the type parameter \code{b} should this time be
+%% instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
+%% Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
+
+%% Besides \code{Nothing}, which is a subtype of every other type, there
+%% is also the type \code{Null}, which is a subtype of
+%% \code{scala.AnyRef}, and every class derived from it. The \code{null}
+%% literal in Scala is the only value of that type. This makes
+%% \code{null} compatible with every reference type, but not with a value
+%% type such as \code{Int}.
+
+%% We conclude this section with the complete improved definition of
+%% stacks. Stacks have now co-variant subtyping, the \code{push} method
+%% has been generalized, and the empty stack is represented by a single
+%% object.
+%% \begin{lstlisting}
+%% abstract class Stack[+A] {
+%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+%%   def isEmpty: Boolean
+%%   def top: A
+%%   def pop: Stack[A]
+%% }
+%% object EmptyStack extends Stack[Nothing] {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
+%% Many classes in the Scala library are generic. We now present two
+%% commonly used families of generic classes, tuples and functions. The
+%% discussion of another common class, lists, is deferred to the next
+%% chapter.
+
+%% \section{Tuples}
+
+%% Sometimes, a function needs to return more than one result. For
+%% instance, take the function \code{divmod} which returns the integer quotient
+%% and rest of two given integer arguments.  Of course, one can define a
+%% class to hold the two results of \code{divmod}, as in:
+%% \begin{lstlisting}
+%% case class TwoInts(first: Int, second: Int)
+%% def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
+%% \end{lstlisting}
+%% However, having to define a new class for every possible pair of
+%% result types is very tedious. In Scala one can use instead a
+%% generic class \lstinline@Tuple$2$@, which is defined as follows:
+%% \begin{lstlisting}
+%% package scala
+%% case class Tuple2[A, B](_1: A, _2: B)
+%% \end{lstlisting}
+%% With \code{Tuple2}, the \code{divmod} method can be written as follows.
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
+%% \end{lstlisting}
+%% As usual, type parameters to constructors can be omitted if they are
+%% deducible from value arguments. There exist also tuple classes for
+%% every other number of elements (the current Scala implementation
+%% limits this to tuples of some reasonable number of elements).  
+
+%% \comment{
+%% Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
+%% \code{Triple} for \code{Tuple3}).  With these conventions,
+%% \code{divmod} can equivalently be written as follows.
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
+%% \end{lstlisting}
+%% }
+%% How are elements of tuples accessed? Since tuples are case classes,
+%% there are two possibilities. One can either access a tuple's fields
+%% using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
+%% \begin{lstlisting}
+%% val xy = divmod(x, y)
+%% println("quotient: " + xy._1 + ", rest: " + xy._2)
+%% \end{lstlisting}
+%% Or one uses pattern matching on tuples, as in the following example:
+%% \begin{lstlisting}
+%% divmod(x, y) match {
+%%   case Tuple2(n, d) =>
+%%     println("quotient: " + n + ", rest: " + d)
+%% }
+%% \end{lstlisting}
+%% Note that type parameters are never used in patterns; it would have
+%% been illegal to write case \code{Tuple2[Int, Int](n, d)}.
+
+%% Tuples are so convenient that Scala defines special syntax for
+%% them. To form a tuple with $n$ elements $x_1 \commadots x_n$ one can
+%% write $(x_1 \commadots x_n)$. This is equivalent to
+%% \lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
+%% equivalently for types and for patterns. With that tuple syntax, the
+%% \lstinline@divmod@ example is written as follows:
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
+%% divmod(x, y) match {
+%%   case (n, d) => println("quotient: " + n + ", rest: " + d)
+%% }
+%% \end{lstlisting}
+%% \section{Functions}\label{sec:functions}
+
+%% Scala is a functional language in that functions are first-class
+%% values.  Scala is also an object-oriented language in that every value
+%% is an object.  It follows that functions are objects in Scala.  For
+%% instance, a function from type \code{String} to type \code{Int} is
+%% represented as an instance of the trait \code{Function1[String, Int]}.
+%% The \code{Function1} trait is defined as follows.
+%% \begin{lstlisting}
+%% package scala
+%% trait Function1[-A, +B] {
+%%   def apply(x: A): B
+%% }
+%% \end{lstlisting}
+%% Besides \code{Function1}, there are also definitions of for functions
+%% of all other arities (the current implementation implements this only
+%% up to a reasonable limit).  That is, there is one definition for each
+%% possible number of function parameters.  Scala's function type syntax
+%% ~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
+%% for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
+%% T_n, S$]@~.
+
+%% Scala uses the same syntax $f(x)$ for function application, no matter
+%% whether $f$ is a method or a function object. This is made possible by
+%% the following convention: A function application $f(x)$ where $f$ is
+%% an object (as opposed to a method) is taken to be a shorthand for
+%% \lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
+%% function type is inserted automatically where this is necessary.
+
+%% That's also why we defined array subscripting in
+%% Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
+%% array \code{a}, the subscript operation \code{a(i)} is taken to be a
+%% shorthand for \code{a.apply(i)}.
+
+%% Functions are an example where a contra-variant type parameter
+%% declaration is useful. For example, consider the following code:
+%% \begin{lstlisting}
+%% val f: (AnyRef => Int)  =  x => x.hashCode()
+%% val g: (String => Int)  =  f
+%% g("abc")
+%% \end{lstlisting}
+%% It's sound to bind the value \code{g} of type \code{String => Int} to
+%% \code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
+%% do with function of type \code{String => Int} is pass it a string in
+%% order to obtain an integer. Clearly, the same works for function
+%% \code{f}: If we pass it a string (or any other object), we obtain an
+%% integer.  This demonstrates that function subtyping is contra-variant
+%% in its argument type whereas it is covariant in its result type.
+%% In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
+%% $S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
+
+%% \example Consider the Scala code
+%% \begin{lstlisting}
+%% val plus1: (Int => Int)  =  (x: Int) => x + 1
+%% plus1(2)
+%% \end{lstlisting}
+%% This is expanded into the following object code.
+%% \begin{lstlisting}
+%% val plus1: Function1[Int, Int] = new Function1[Int, Int] {
+%%   def apply(x: Int): Int = x + 1
+%% }
+%% plus1.apply(2)
+%% \end{lstlisting}
+%% Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
+%% represents an instance of an {\em anonymous class}. It combines the
+%% creation of a new \code{Function1} object with an implementation of 
+%% the \code{apply} method (which is abstract in \code{Function1}).
+%% Equivalently, but more verbosely, one could have used a local class:
+%% \begin{lstlisting}
+%% val plus1: Function1[Int, Int] = {
+%%   class Local extends Function1[Int, Int] {
+%%     def apply(x: Int): Int = x + 1
+%%   }
+%%   new Local: Function1[Int, Int]
+%% }
+%% plus1.apply(2)
+%% \end{lstlisting}
  
-\chapter{Lists}
-
-Lists are an important data structure in many Scala programs.  
-A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
-\code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
-\begin{lstlisting}
-val fruit = List("apples", "oranges", "pears")
-val nums  = List(1, 2, 3, 4)
-val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-val empty = List()
-\end{lstlisting}
-Lists are similar to arrays in languages such as C or Java, but there
-are also three important differences. First, lists are immutable. That
-is, elements of a list cannot be changed by assignment. Second, 
-lists have a recursive structure, whereas arrays are flat. Third,
-lists support a much richer set of operations than arrays usually do.
-
-\section{Using Lists}
-
-\paragraph{The List type}
-Like arrays, lists are {\em homogeneous}. That is, the elements of a
-list all have the same type.  The type of a list with elements of type
-\code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
-\begin{lstlisting}
-val fruit: List[String]    = List("apples", "oranges", "pears")
-val nums : List[Int]       = List(1, 2, 3, 4)
-val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-val empty: List[Int]       = List()
-\end{lstlisting}
-
-\paragraph{List constructors}
-All lists are built from two more fundamental constructors, \code{Nil}
-and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
-list. The infix operator \code{::} expresses list extension. That is,
-\code{x :: xs} represents a list whose first element is \code{x},
-which is followed by (the elements of) list \code{xs}.  Hence, the
-list values above could also have been defined as follows (in fact
-their previous definition is simply syntactic sugar for the definitions below).
-\begin{lstlisting}
-val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
-val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
-val diag3  = (1 :: (0 :: (0 :: Nil))) ::
-             (0 :: (1 :: (0 :: Nil))) ::
-             (0 :: (0 :: (1 :: Nil))) :: Nil
-val empty  = Nil
-\end{lstlisting}
-The `\code{::}' operation associates to the right: \code{A :: B :: C} is
-interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
-parentheses in the definitions above. For instance, we can write
-shorter
-\begin{lstlisting}
-val nums  =  1 :: 2 :: 3 :: 4 :: Nil
-\end{lstlisting}
-
-\paragraph{Basic operations on lists}
-All operations on lists can be expressed in terms of the following three:
-
-\begin{tabular}{ll}
-\code{head}  &  returns the first element of a list,\\
-\code{tail}  &  returns the list consisting of all elements except the\\
-& first element,\\
-\code{isEmpty} & returns \code{true} iff the list is empty
-\end{tabular}
-
-These operations are defined as methods of list objects. So we invoke
-them by selecting from the list that's operated on. Examples:
-\begin{lstlisting}
-empty.isEmpty   = true
-fruit.isEmpty   = false
-fruit.head      = "apples"
-fruit.tail.head = "oranges"
-diag3.head      = List(1, 0, 0)
-\end{lstlisting}
-The \code{head} and \code{tail} methods are defined only for non-empty
-lists.  When selected from an empty list, they throw an exception.
-
-As an example of how lists can be processed, consider sorting the
-elements of a list of numbers into ascending order. One simple way to
-do so is {\em insertion sort}, which works as follows: To sort a
-non-empty list with first element \code{x} and rest \code{xs}, sort
-the remainder \code{xs} and insert the element \code{x} at the right
-position in the result. Sorting an empty list will yield the
-empty list. Expressed as Scala code:
-\begin{lstlisting}
-def isort(xs: List[Int]): List[Int] =
-  if (xs.isEmpty) Nil
-  else insert(xs.head, isort(xs.tail))
-\end{lstlisting}
-
-\begin{exercise} Provide an implementation of the missing function
-\code{insert}.
-\end{exercise}
-
-\paragraph{List patterns} In fact, \code{::} is defined as a case
-class in Scala's standard library. Hence, it is possible to decompose
-lists by pattern matching, using patterns composed from the \code{Nil}
-and \code{::} constructors. For instance, \code{isort} can be written
-alternatively as follows.
-\begin{lstlisting}
-def isort(xs: List[Int]): List[Int] = xs match {
-  case List() => List()
-  case x :: xs1 => insert(x, isort(xs1))
-}
-\end{lstlisting}
-where
-\begin{lstlisting}
-def insert(x: Int, xs: List[Int]): List[Int] = xs match {
-  case List() => List(x)
-  case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
-}
-\end{lstlisting}
-
-\section{Definition of class List I: First Order Methods}
-\label{sec:list-first-order}
-
-Lists are not built in in Scala; they are defined by an abstract class
-\code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
-In the following we present a tour through class \code{List}.
-\begin{lstlisting}
-package scala
-abstract class List[+A] {
-\end{lstlisting}
-\code{List} is an abstract class, so one cannot define elements by
-calling the empty \code{List} constructor (e.g. by
-\code{new List}).  The class has a type parameter \code{a}. It is
-co-variant in this parameter, which means that
-\code{List[S] <: List[T]} for all types \code{S} and \code{T} such that
-\code{S <: T}.  The class is situated in the package
-\code{scala}. This is a package containing the most important standard
-classes of Scala.
- \code{List} defines a number of methods, which are
-explained in the following.
-
-\paragraph{Decomposing lists}
-First, there are the three basic methods \code{isEmpty},
-\code{head}, \code{tail}. Their implementation in terms of pattern
-matching is straightforward:
-\begin{lstlisting}
-def isEmpty: Boolean = this match {
-  case Nil => true
-  case x :: xs => false
-}
-def head: A = this match {
-  case Nil => error("Nil.head")
-  case x :: xs => x
-}
-def tail: List[A] = this match {
-  case Nil => error("Nil.tail")
-  case x :: xs => xs
-}
-\end{lstlisting}
-
-The next function computes the length of a list.
-\begin{lstlisting}
-def length: Int = this match {
-  case Nil => 0
-  case x :: xs => 1 + xs.length
-}
-\end{lstlisting}
-\begin{exercise} Design a tail-recursive version of \code{length}.
-\end{exercise}
-
-The next two functions are the complements of \code{head} and
-\code{tail}.
-\begin{lstlisting}
-def last: A
-def init: List[A]
-\end{lstlisting}
-\code{xs.last} returns the last element of list \code{xs}, whereas
-\code{xs.init} returns all elements of \code{xs} except the last.
-Both functions have to traverse the entire list, and are thus less
-efficient than their \code{head} and \code{tail} analogues.
-Here is the implementation of \code{last}.
-\begin{lstlisting}
-def last: A = this match {
-  case Nil      => error("Nil.last")
-  case x :: Nil => x
-  case x :: xs  => xs.last
-}
-\end{lstlisting}
-The implementation of \code{init} is analogous.
-
-The next three functions return a prefix of the list, or a suffix, or
-both.
-\begin{lstlisting}
-def take(n: Int): List[A] =
-  if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
-
-def drop(n: Int): List[A] =
-  if (n == 0 || isEmpty) this else tail.drop(n-1)
-
-def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
-\end{lstlisting}
-\code{(xs take n)} returns the first \code{n} elements of list
-\code{xs}, or the whole list, if its length is smaller than \code{n}.
-\code{(xs drop n)} returns all elements of \code{xs} except the
-\code{n} first ones. Finally, \code{(xs split n)} returns a pair
-consisting of the lists resulting from \code{xs take n} and
-\code{xs drop n}.
-
-The next function returns an element at a given index in a list.
-It is thus analogous to array subscripting. Indices start at 0.
-\begin{lstlisting}
-def apply(n: Int): A = drop(n).head
-\end{lstlisting}
-The \code{apply} method has a special meaning in Scala. An object with
-an \code{apply} method can be applied to arguments as if it was a
-function. For instance, to pick the 3'rd element of a list \code{xs},
-one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
-expression expands into the first.
-
-With \code{take} and \code{drop}, we can extract sublists consisting
-of consecutive elements of the original list.  To extract the sublist
-$xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
-
-\begin{lstlisting}
-xs.drop(m).take(n - m)
-\end{lstlisting}
-
-\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
-Given two lists
-\begin{lstlisting}
-xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
-ys = List(y$_1$, ..., y$_n$)   ,
-\end{lstlisting}
-\code{xs zip ys} constructs the list
-\lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
-If the two lists have different lengths, the longer one of the two is
-truncated. Here is the definition of \code{zip} -- note that it is a
-polymorphic method.
-\begin{lstlisting}
-def zip[B](that: List[B]): List[(a,b)] =
-  if (this.isEmpty || that.isEmpty) Nil
-  else (this.head, that.head) :: (this.tail zip that.tail)
-\end{lstlisting}
-
-\paragraph{Consing lists.}
-Like any infix operator, \code{::}
-is also implemented as a method of an object. In this case, the object
-is the list that is extended. This is possible, because operators
-ending with a `\code{:}' character are treated specially in Scala.  
-All such operators are treated as methods of their right operand. E.g.,
-\begin{lstlisting}
-    x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
-\end{lstlisting}
-Note, however, that operands of a binary operation are in each case
-evaluated from left to right.  So, if \code{D} and \code{E} are
-expressions with possible side-effects, \code{D :: E} is translated to
-\lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
-order of operand evaluation.
-
-Another difference between operators ending in a `\code{:}' and other
-operators concerns their associativity.  Operators ending in
-`\code{:}' are right-associative, whereas other operators are
-left-associative.  E.g.,
-\begin{lstlisting}
-    x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
-\end{lstlisting}
-The definition of \code{::} as a method in
-class \code{List} is as follows:
-\begin{lstlisting}
-def ::[B >: A](x: B): List[B] = new scala.::(x, this)
-\end{lstlisting}
-Note that \code{::} is defined for all elements \code{x} of type
-\code{B} and lists of type \code{List[A]} such that the type \code{B}
-of \code{x} is a supertype of the list's element type \code{A}. The result
-is in this case a list of \code{B}'s. This
-is expressed by the type parameter \code{B} with lower bound \code{A}
-in the signature of \code{::}. 
-
-\paragraph{Concatenating lists}
-An operation similar to \code{::} is list concatenation, written
-`\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
-all elements of \code{xs}, followed by all elements of \code{ys}.
-Because it ends in a colon, \code{:::} is right-associative and is
-considered as a method of its right-hand operand. Therefore,
-\begin{lstlisting}
-xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
-                  =   zs.:::(ys).:::(xs)
-\end{lstlisting}
-Here is the implementation of the \code{:::} method:
-\begin{lstlisting}
-  def :::[B >: A](prefix: List[B]): List[B] = prefix match {
-    case Nil => this
-    case p :: ps => this.:::(ps).::(p)
-  }
-\end{lstlisting}
-
-\paragraph{Reversing lists} Another useful operation
-is list reversal. There is a method \code{reverse} in \code{List} to
-that effect. Let's try to give its implementation:
-\begin{lstlisting}
-def reverse[A](xs: List[A]): List[A] = xs match {
-  case Nil => Nil
-  case x :: xs => reverse(xs) ::: List(x)
-}
-\end{lstlisting}
-This implementation has the advantage of being simple, but it is not
-very efficient.  Indeed, one concatenation is executed for every
-element in the list. List concatenation takes time proportional to the
-length of its first operand. Therefore, the complexity of
-\code{reverse(xs)} is
-\[
-n + (n - 1) + ... + 1 = n(n+1)/2
-\]
-where $n$ is the length of \code{xs}. Can \code{reverse} be
-implemented more efficiently? We will see later that there exists
-another implementation which has only linear complexity.
-
-\section{Example: Merge sort}
-
-The insertion sort presented earlier in this chapter is simple to
-formulate, but also not very efficient. It's average complexity is
-proportional to the square of the length of the input list. We now
-design a program to sort the elements of a list which is more
-efficient than insertion sort. A good algorithm for this is {\em merge
-sort}, which works as follows.
-
-First, if the list has zero or one elements, it is already sorted, so
-one returns the list unchanged. Longer lists are split into two
-sub-lists, each containing about half the elements of the original
-list. Each sub-list is sorted by a recursive call to the sort
-function, and the resulting two sorted lists are then combined in a
-merge operation.
-
-For a general implementation of merge sort, we still have to specify
-the type of list elements to be sorted, as well as the function to be
-used for the comparison of elements. We obtain a function of maximal
-generality by passing these two items as parameters. This leads to the
-following implementation.
-\begin{lstlisting}
-def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
-  def merge(xs1: List[A], xs2: List[A]): List[A] =
-    if (xs1.isEmpty) xs2
-    else if (xs2.isEmpty) xs1
-    else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
-    else xs2.head :: merge(xs1, xs2.tail)
-  val n = xs.length/2
-  if (n == 0) xs
-  else merge(msort(less)(xs take n), msort(less)(xs drop n))
-}
-\end{lstlisting}
-The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
-length of the input list. To see why, note that splitting a list in
-two and merging two sorted lists each take time proportional to the
-length of the argument list(s). Each recursive call of \code{msort}
-halves the number of elements in its input, so there are $O(log(N))$
-consecutive recursive calls until the base case of lists of length 1
-is reached.  However, for longer lists each call spawns off two
-further calls. Adding everything up we obtain that at each of the
-$O(log(N))$ call levels, every element of the original lists takes
-part in one split operation and in one merge operation. Hence, every
-call level has a total cost proportional to $O(N)$. Since there are
-$O(log(N))$ call levels, we obtain an overall cost of
-$O(N;log(N))$. That cost does not depend on the initial distribution
-of elements in the list, so the worst case cost is the same as the
-average case cost. This makes merge sort an attractive algorithm for
-sorting lists.
-
-Here is an example how \code{msort} is used.
-\begin{lstlisting}
-msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
-\end{lstlisting}
-The definition of \code{msort} is curried, to make it easy to specialize it with particular
-comparison functions. For instance,
-\begin{lstlisting}
-
-val intSort = msort((x: Int, y: Int) => x < y)
-val reverseSort = msort((x: Int, y: Int) => x > y)
-\end{lstlisting}
-
-\section{Definition of class List II: Higher-Order Methods}
-
-The examples encountered so far show that functions over lists often
-have similar structures. We can identify several patterns of
-computation over lists, like:
-\begin{itemize}
-      \item transforming every element of a list in some way.
-      \item extracting from a list all elements satisfying a criterion.
-      \item combine the elements of a list using some operator.
-\end{itemize}
-Functional programming languages enable programmers to write general
-functions which implement patterns like this by means of higher order
-functions. We now discuss a set of commonly used higher-order
-functions, which are implemented as methods in class \code{List}.
-
-\paragraph{Mapping over lists}
-A common operation is to transform each element of a list and then
-return the lists of results.  For instance, to scale each element of a
-list by a given factor.
-\begin{lstlisting}
-def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
-  case Nil => xs
-  case x :: xs1 => x * factor :: scaleList(xs1, factor)
-}
-\end{lstlisting}
-This pattern can be generalized to the \code{map} method of class \code{List}:
-\begin{lstlisting}
-abstract class List[A] { ...
-  def map[B](f: A => B): List[B] = this match {
-    case Nil => this
-    case x :: xs => f(x) :: xs.map(f)
-  }
-\end{lstlisting}
-Using \code{map}, \code{scaleList} can be more concisely written as follows.
-\begin{lstlisting}
-def scaleList(xs: List[Double], factor: Double) =
-  xs map (x => x * factor)
-\end{lstlisting}
-
-As another example, consider the problem of returning a given column
-of a matrix which is represented as a list of rows, where each row is
-again a list. This is done by the following function \code{column}.
-
-\begin{lstlisting}
-def column[A](xs: List[List[A]], index: Int): List[A] =
-  xs map (row => row(index))
-\end{lstlisting}
-
-Closely related to \code{map} is the \code{foreach} method, which
-applies a given function to all elements of a list, but does not
-construct a list of results. The function is thus applied only for its
-side effect. \code{foreach} is defined as follows.
-\begin{lstlisting}
-  def foreach(f: A => Unit) {
-    this match {
-      case Nil => ()
-      case x :: xs => f(x); xs.foreach(f)
-    }
-  }
-\end{lstlisting}
-This function can be used for printing all elements of a list, for instance:
-\begin{lstlisting}
-  xs foreach (x => println(x))
-\end{lstlisting} 
-
-\begin{exercise} Consider a function which squares all elements of a list and
-returns a list with the results. Complete the following two equivalent
-definitions of \code{squareList}.
-
-\begin{lstlisting}
-def squareList(xs: List[Int]): List[Int] = xs match {
-  case List() => ??
-  case y :: ys => ??
-}
-def squareList(xs: List[Int]): List[Int] =
-  xs map ??
-\end{lstlisting}
-\end{exercise}
-
-\paragraph{Filtering Lists}
-Another common operation selects from a list all elements fulfilling a
-given criterion. For instance, to return a list of all positive
-elements in some given lists of integers:
-\begin{lstlisting}
-def posElems(xs: List[Int]): List[Int] = xs match {
-  case Nil => xs
-  case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
-}
-\end{lstlisting}
-This pattern is generalized to the \code{filter} method of class \code{List}:
-\begin{lstlisting}
-  def filter(p: A => Boolean): List[A] = this match {
-    case Nil => this
-    case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
-  }
-\end{lstlisting}
-Using \code{filter}, \code{posElems} can be more concisely written as
-follows.
-\begin{lstlisting}
-def posElems(xs: List[Int]): List[Int] =
-  xs filter (x => x > 0)
-\end{lstlisting}
-
-An operation related to filtering is testing whether all elements of a
-list satisfy a certain condition. Dually, one might also be interested
-in the question whether there exists an element in a list that
-satisfies a certain condition. These operations are embodied in the
-higher-order functions \code{forall} and \code{exists} of class
-\code{List}.
-\begin{lstlisting}
-def forall(p: A => Boolean): Boolean =
-  isEmpty || (p(head) && (tail forall p))
-def exists(p: A => Boolean): Boolean =
-  !isEmpty && (p(head) || (tail exists p))
-\end{lstlisting}
-To illustrate the use of \code{forall}, consider the question of whether
-a number if prime. Remember that a number $n$ is prime of it can be
-divided without remainder only by one and itself. The most direct
-translation of this definition would test that $n$ divided by all
-numbers from 2 up to and excluding itself gives a non-zero
-remainder. This list of numbers can be generated using a function
-\code{List.range} which is defined in object \code{List} as follows.
-\begin{lstlisting}
-package scala
-object List { ...
-  def range(from: Int, end: Int): List[Int] =
-    if (from >= end) Nil else from :: range(from + 1, end)
-\end{lstlisting}
-For example, \code{List.range(2, n)}
-generates the list of all integers from 2 up to and excluding $n$.
-The function \code{isPrime} can now simply be defined as follows.
-\begin{lstlisting}
-def isPrime(n: Int) =
-  List.range(2, n) forall (x => n % x != 0)
-\end{lstlisting}
-We see that the mathematical definition of prime-ness has been
-translated directly into Scala code. 
-
-Exercise: Define \code{forall} and \code{exists} in terms of \code{filter}.
-
-
-\paragraph{Folding and Reducing Lists}
-Another common operation is to combine the elements of a list with
-some operator.  For instance:
-\begin{lstlisting}
-sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
-product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
-\end{lstlisting}
-Of course, we can implement both functions with a
-recursive scheme:
-\begin{lstlisting}
-def sum(xs: List[Int]): Int = xs match {
-  case Nil => 0
-  case y :: ys => y + sum(ys)
-}
-def product(xs: List[Int]): Int = xs match {
-  case Nil => 1
-  case y :: ys => y * product(ys)
-}
-\end{lstlisting}
-But we can also use the generalization of this program scheme embodied
-in the \code{reduceLeft} method of class \code{List}.  This method
-inserts a given binary operator between adjacent elements of a given list.
-E.g.\ 
-\begin{lstlisting}
-List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
-\end{lstlisting}
-Using \code{reduceLeft}, we can make the common pattern
-in \code{sum} and \code{product} apparent:
-\begin{lstlisting}
-def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
-def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
-\end{lstlisting}
-Here is the implementation of \code{reduceLeft}.
-\begin{lstlisting}
-  def reduceLeft(op: (A, A) => A): A = this match {
-    case Nil     => error("Nil.reduceLeft")
-    case x :: xs => (xs foldLeft x)(op)
-  }
-  def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
-    case Nil => z
-    case x :: xs => (xs foldLeft op(z, x))(op)
-  }
-}
-\end{lstlisting}
-We see that the \code{reduceLeft} method is defined in terms of
-another generally useful method, \code{foldLeft}.  The latter takes as
-additional parameter an {\em accumulator} \code{z}, which is returned
-when \code{foldLeft} is applied on an empty list. That is,
-\begin{lstlisting}
-(List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
-\end{lstlisting}
-The \code{sum} and \code{product} methods can be defined alternatively
-using \code{foldLeft}:
-\begin{lstlisting}
-def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
-def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
-\end{lstlisting}
-
-\paragraph{FoldRight and ReduceRight}
-Applications of \code{foldLeft} and \code{reduceLeft} expand to
-left-leaning trees. \todo{insert pictures}.  They have duals
-\code{foldRight} and \code{reduceRight}, which produce right-leaning
-trees.
-\begin{lstlisting}
-List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
-(List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
-\end{lstlisting}
-These are defined as follows.
-\begin{lstlisting}
-  def reduceRight(op: (A, A) => A): A = this match {
-    case Nil => error("Nil.reduceRight")
-    case x :: Nil => x
-    case x :: xs => op(x, xs.reduceRight(op))
-  }
-  def foldRight[B](z: B)(op: (A, B) => B): B = this match {
-    case Nil => z
-    case x :: xs => op(x, (xs foldRight z)(op))
-  }
-\end{lstlisting}
-
-Class \code{List} defines also two symbolic abbreviations for
-\code{foldLeft} and \code{foldRight}:
-\begin{lstlisting}
-  def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
-  def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
-\end{lstlisting}
-The method names picture the left/right leaning trees of the fold
-operations by forward or backward slashes. The \code{:} points in each
-case to the list argument whereas the end of the slash points to the
-accumulator (or: zero) argument \code{z}. 
-That is, 
-\begin{lstlisting}
-(z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
-(List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
-\end{lstlisting}
-For associative and commutative operators, \code{/:} and
-\code{:\\} are equivalent (even though there may be a difference
-in efficiency).  
-%But sometimes, only one of the two operators is
-%appropriate or has the right type:
-
-\begin{exercise} Consider the problem of writing a function \code{flatten},
-which takes a list of element lists as arguments. The result of
-\code{flatten} should be the concatenation of all element lists into a
-single list. Here is an implementation of this method in terms of 
-\code{:\\}.
-\begin{lstlisting}
-def flatten[A](xs: List[List[A]]): List[A] =
-  (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
-\end{lstlisting} 
-Consider replacing the body of \lstinline@flatten@
-by 
-\begin{lstlisting}
-  ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
-\end{lstlisting}
-What would be the difference in asymptotic
-complexity between the two versions of \lstinline@flatten@?
-
-In fact \code{flatten} is predefined together with a set of other
-userful function in an object called \code{List} in the standatd Scala
-library. It can be accessed from user program by calling
-\code{List.flatten}. Note that \code{flatten} is not a method of class
-\code{List} -- it would not make sense there, since it applies only
-to lists of lists, not to all lists in general.
-\end{exercise}
-
-\paragraph{List Reversal Again} We have seen in 
-Section~\ref{sec:list-first-order} an implementation of method
-\code{reverse} whose run-time was quadratic in the length of the list
-to be reversed. We now develop a new implementation of \code{reverse},
-which has linear cost.  The idea is to use a \code{foldLeft}
-operation based on the following program scheme.
-\begin{lstlisting}
-class List[+A] { ...
-  def reverse: List[A] = (z? /: this)(op?)
-\end{lstlisting}
-It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
-try to deduce them from examples.
-\begin{lstlisting}
-  Nil
-= Nil.reverse                 // by specification
-= (z /: Nil)(op)              // by the template for reverse
-= (Nil foldLeft z)(op)        // by the definition of /:
-= z                           // by definition of foldLeft
-\end{lstlisting}
-Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
-let's study reversal of a list of length one.
-\begin{lstlisting}
-  List(x)
-= List(x).reverse             // by specification
-= (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
-= (List(x) foldLeft Nil)(op)  // by the definition of /:
-= op(Nil, x)                  // by definition of foldLeft
-\end{lstlisting}
-Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
-as \code{x :: Nil}. This suggests to take as \code{op} the
-\code{::} operator with its operands exchanged.  Hence, we arrive at
-the following implementation for \code{reverse}, which has linear complexity.
-\begin{lstlisting}
-def reverse: List[A] =
-  ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
-\end{lstlisting}
-(Remark: The type annotation of \code{Nil} is necessary 
-to make the type inferencer work.)
-
-\begin{exercise} Fill in the missing expressions to complete the following
-definitions of some basic list-manipulation operations as fold
-operations.
-\begin{lstlisting}
-def mapFun[A, B](xs: List[A], f: A => B): List[B] =
-  (xs :\ List[B]()){ ?? }
-
-def lengthFun[A](xs: List[A]): int =
-  (0 /: xs){ ?? }
-\end{lstlisting}
-\end{exercise}
-
-\paragraph{Nested Mappings}
-
-We can employ higher-order list processing functions to express many
-computations that are normally expressed as nested loops in imperative
-languages. 
-
-As an example, consider the following problem: Given a positive
-integer $n$, find all pairs of positive integers $i$ and $j$, where 
-$1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
-the pairs are
-\bda{c|lllllll}
-i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
-j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
-i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
-\eda
-
-A natural way to solve this problem consists of two steps. In a first step,
-one generates the sequence of all pairs $(i, j)$ of integers such that
-$1 \leq j < i < n$. In a second step one then filters from this sequence
-all pairs $(i, j)$ such that $i + j$ is prime.
-
-Looking at the first step in more detail, a natural way to generate
-the sequence of pairs consists of three sub-steps.  First, generate
-all integers between $1$ and $n$ for $i$.  
-\item
-Second, for each integer $i$ between $1$ and $n$, generate the list of
-pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
-combination of \code{range} and \code{map}:
-\begin{lstlisting}
-  List.range(1, i) map (x => (i, x))
-\end{lstlisting}
-Finally, combine all sublists using \code{foldRight} with \code{:::}.
-Putting everything together gives the following expression:
-\begin{lstlisting}
-List.range(1, n)
-  .map(i => List.range(1, i).map(x => (i, x)))
-  .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
-  .filter(pair => isPrime(pair._1 + pair._2))
-\end{lstlisting}
-
-\paragraph{Flattening Maps}
-The combination of mapping and then concatenating sublists 
-resulting from the map
-is so common that we there is a special method 
-for it in class \code{List}:
-\begin{lstlisting}
-abstract class List[+A] { ...
-  def flatMap[B](f: A => List[B]): List[B] = this match {
-    case Nil => Nil
-    case x :: xs => f(x) ::: (xs flatMap f)
-  }
-}
-\end{lstlisting}
-With \code{flatMap}, the pairs-whose-sum-is-prime expression 
-could have been written more concisely as follows.
-\begin{lstlisting}
-List.range(1, n)
-  .flatMap(i => List.range(1, i).map(x => (i, x)))
-  .filter(pair => isPrime(pair._1 + pair._2))
-\end{lstlisting}
-
-
-
-\section{Summary}
-
-This chapter has introduced lists as a fundamental data structure in
-programming. Since lists are immutable, they are a common data type in
-functional programming languages. They have a role comparable to
-arrays in imperative languages. However, the access patterns between
-arrays and lists are quite different. Where array accessing is always
-done by indexing, this is much less common for lists.  We have seen
-that \code{scala.List} defines a method called \code{apply} for indexing
-however this operation is much more costly than in the case of arrays
-(linear as opposed to constant time). Instead of indexing, lists are
-usually traversed recursively, where recursion steps are usually based
-on a pattern match over the traversed list. There is also a rich set of
-higher-order combinators which allow one to instantiate a set of
-predefined patterns of computations over lists.
-
-\comment{
-\bsh{Reasoning About Lists}
-
-Recall the concatenation operation for lists:
-
-\begin{lstlisting}
-class List[+A] {
-  ...
-  def ::: (that: List[A]): List[A] =
-    if (isEmpty) that
-    else head :: (tail ::: that)
-}
-\end{lstlisting}
-
-We would like to verify that concatenation is associative, with the
-empty list \code{List()} as left and right identity:
-\bda{lcl}
-   (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
-   xs ::: List()          &=& xs \gap =\ List() ::: xs
-\eda
-\emph{Q}: How can we prove statements like the one above?
-
-\emph{A}: By \emph{structural induction} over lists.
-\es
-\bsh{Reminder: Natural Induction}
-
-Recall the proof principle of \emph{natural induction}:
-
-To show a property \mathtext{P(n)} for all numbers \mathtext{n \geq b}:
-\be
-\item Show that \mathtext{P(b)} holds (\emph{base case}).
-\item For arbitrary \mathtext{n \geq b} show:
-\begin{quote}
-     if \mathtext{P(n)} holds, then \mathtext{P(n+1)} holds as well
-\end{quote}
-(\emph{induction step}).
-\ee
-%\es\bs
-\emph{Example}: Given
-\begin{lstlisting}
-def factorial(n: Int): Int =
-  if (n == 0) 1
-  else n * factorial(n-1)
-\end{lstlisting}
-show that, for all \code{n >= 4},
-\begin{lstlisting}
-   factorial(n) >= 2$^n$
-\end{lstlisting}
-\es\bs
-\Case{\code{4}}
-is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
-
-\Case{\code{n+1}} 
-We have for \code{n >= 4}:
-\begin{lstlisting}
-    \= factorial(n + 1)
- =     \> $\expl{by the second clause of factorial(*)}$
-       \> (n + 1) * factorial(n)
- >=    \> $\expl{by calculation}$
-       \> 2 * factorial(n)
- >=    \> $\expl{by the induction hypothesis}$
-       \> 2 * 2$^n$.
-\end{lstlisting}
-Note that in our proof we can freely apply reduction steps such as in (*)
-anywhere in a term.
-
-
-This works because purely functional programs do not have side
-effects; so a term is equivalent to the term it reduces to.
-
-The principle is called {\em\emph{referential transparency}}.
-\es
-\bsh{Structural Induction}
-
-The principle of structural induction is analogous to natural induction:
-
-In the case of lists, it is as follows:
-
-To prove a property \mathtext{P(xs)} for all lists \mathtext{xs},
-\be
-\item Show that \code{P(List())} holds (\emph{base case}).
-\item For arbitrary lists \mathtext{xs} and elements \mathtext{x} 
-      show:
-\begin{quote}
-     if \mathtext{P(xs)} holds, then \mathtext{P(x :: xs)} holds as well
-\end{quote}
-(\emph{induction step}).
-\ee
-
-\es
-\bsh{Example}
-
-We show \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} by structural induction
-on \code{xs}.
-
-\Case{\code{List()}}
-For the left-hand side, we have:
-\begin{lstlisting}
-    \= (List() ::: ys) ::: zs
- =     \> $\expl{by first clause of \prog{:::}}$
-       \> ys ::: zs
-\end{lstlisting}
-For the right-hand side, we have:
-\begin{lstlisting}
-    \= List() ::: (ys ::: zs)
- =     \> $\expl{by first clause of \prog{:::}}$
-       \> ys ::: zs
-\end{lstlisting}
-So the case is established.
-
-\es
-\bs
-\Case{\code{x :: xs}} 
-
-For the left-hand side, we have:
-\begin{lstlisting}
-    \= ((x :: xs) ::: ys) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> (x :: (xs ::: ys)) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> x :: ((xs ::: ys) ::: zs)
- =     \> $\expl{by the induction hypothesis}$
-       \> x :: (xs ::: (ys ::: zs))
-\end{lstlisting}
-
-For the right-hand side, we have:
-\begin{lstlisting}
-    \= (x :: xs) ::: (ys ::: zs)
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> x :: (xs ::: (ys ::: zs))
-\end{lstlisting}
-So the case (and with it the property) is established.
-
-\begin{exercise}
-Show by induction on \code{xs} that \code{xs ::: List()  =  xs}.
-\es
-\bsh{Example (2)}
-\end{exercise}
-
-As a more difficult example, consider function
-\begin{lstlisting}
-abstract class List[A] { ...
-  def reverse: List[A] = this match {
-    case List() => List()
-    case x :: xs => xs.reverse ::: List(x)
-  }
-}
-\end{lstlisting}
-We would like to prove the proposition that
-\begin{lstlisting}
-   xs.reverse.reverse  =  xs  .
-\end{lstlisting}
-We proceed by induction over \code{xs}. The base case is easy to establish:
-\begin{lstlisting}
-    \= List().reverse.reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
-       \> List().reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
-       \> List()
-\end{lstlisting}
-\es\bs
-For the induction step, we try:
-\begin{lstlisting}
-    \= (x :: xs).reverse.reverse
- =     \> $\expl{by second clause of \prog{reverse}}$
-       \> (xs.reverse ::: List(x)).reverse
-\end{lstlisting}
-There's nothing more we can do to this expression, so we turn to the right side:
-\begin{lstlisting}
-    \= x :: xs
- =     \> $\expl{by induction hypothesis}$
-       \> x :: xs.reverse.reverse
-\end{lstlisting}
-The two sides have simplified to different expressions.
-
-So we still have to show that
-\begin{lstlisting}
-  (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
-\end{lstlisting}
-Trying to prove this directly by induction does not work.
-
-Instead we have to {\em generalize} the equation to:
-\begin{lstlisting}
-  (ys ::: List(x)).reverse  =  x :: ys.reverse
-\end{lstlisting}
-\es\bs
-This equation can be proved by a second induction argument over \code{ys}.
-(See blackboard).
-
-\begin{exercise}
-Is it the case that \code{(xs drop m) at n  =  xs at (m + n)} for all 
-natural numbers \code{m}, \code{n} and all lists \code{xs}?
-\end{exercise}
-
-\es
-\bsh{Structural Induction on Trees}
-
-Structural induction is not restricted to lists; it works for arbitrary
-trees.
-
-The general induction principle is as follows.
-
-To show that property \code{P(t)} holds for all trees of a certain type,
-\begin{itemize}
-\item Show \code{P(l)} for all leaf trees \code{$l$}.
-\item For every interior node \code{t} with subtrees \code{s$_1$, ..., s$_n$}, 
-      show that \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}.
-\end{itemize} 
-
-\example Recall our definition of \code{IntSet} with 
-operations \code{contains} and \code{incl}:
-
-\begin{lstlisting}
-abstract class IntSet {
-  abstract def incl(x: Int): IntSet
-  abstract def contains(x: Int): Boolean
-}
-\end{lstlisting}
-\es\bs
-\begin{lstlisting}
-case class Empty extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
-}
-case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: Int): IntSet =
-    if (x < elem) NonEmpty(elem, left incl x, right)
-    else if (x > elem) NonEmpty(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
-(With \code{case} added, so that we can use factory methods instead of \code{new}).
-
-What does it mean to prove the correctness of this implementation?
-\es
-\bsh{Laws of IntSet}
-
-One way to state and prove the correctness of an implementation is
-to prove laws that hold for it.
-
-In the case of \code{IntSet}, three such laws would be:
-
-For all sets \code{s}, elements \code{x}, \code{y}:
-
-\begin{lstlisting}
-Empty contains x          \= =  false
-(s incl x) contains x     \> =  true
-(s incl x) contains y     \> =  s contains y         if x $\neq$ y
-\end{lstlisting}
-
-(In fact, one can show that these laws characterize the desired data
-type completely).
-
-How can we establish that these laws hold?
-
-\emph{Proposition 1}: \code{Empty contains x =  false}.
-
-\emph{Proof}: By the definition of \code{contains} in \code{Empty}.
-\es\bs
-\emph{Proposition 2}: \code{(xs incl x) contains x = true}
-
-\emph{Proof:}
-
-\Case{\code{Empty}}
-\begin{lstlisting}
-    \= (Empty incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
-       \> NonEmpty(x, Empty, Empty) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-       \> true
-\end{lstlisting}
-
-\Case{\code{NonEmpty(x, l, r)}}
-\begin{lstlisting}
-    \= (NonEmpty(x, l, r) incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-       \> NonEmpty(x, l, r) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
-       \> true
-\end{lstlisting}
-\es\bs
-\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-\begin{lstlisting}
-    \= (NonEmpty(y, l, r) incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-       \> NonEmpty(y, l, r incl x) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-       \> (r incl x) contains x
- =     \> $\expl{by the induction hypothesis}$
-       \> true
-\end{lstlisting}
-
-\Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
-
-\bigskip
-
-\emph{Proposition 3}: If \code{x $\neq$ y} then
-\code{xs incl y contains x  =  xs contains x}.
-
-\emph{Proof:} See blackboard.
-\es
-\bsh{Exercise}
-
-Say we add a \code{union} function to \code{IntSet}:
-
-\begin{lstlisting}
-class IntSet { ...
-  def union(other: IntSet): IntSet
-}
-class Expty extends IntSet { ...
-  def union(other: IntSet) = other
-}
-class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
-  def union(other: IntSet): IntSet = l union r union other incl x
-}
-\end{lstlisting}
-
-The correctness of \code{union} can be subsumed with the following
-law:
-
-\emph{Proposition 4}: 
-\code{(xs union ys) contains x  =  xs contains x || ys contains x}.
-Is that true ? What hypothesis is missing ? Show a counterexample.
-
-Show Proposition 4 using structural induction on \code{xs}.
-\es
-\comment{
-
-\emph{Proof:} By induction on \code{xs}.
-
-\Case{\code{Empty}}
-
-\Case{\code{NonEmpty(x, l, r)}}
-
-\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-
-\begin{lstlisting}
-    \= (Empty union ys) contains x 
- =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
-        \> ys contains x
- =      \> $\expl{Boolean algebra}$
-        \> false || ys contains x
- =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
-        \> (Empty contains x) || (ys contains x)
-\end{lstlisting}
-
-\begin{lstlisting}
-    \= (NonEmpty(x, l, r) union ys) contains x
- =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-        \> (l union r union ys incl x) contains x
- =      \> $\expl{by Proposition 2}$
-        \> true
- =      \> $\expl{Boolean algebra}$
-        \> true || (ys contains x)
- =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
-        \> (NonEmpty(x, l, r) contains x) || (ys contains x)
-\end{lstlisting}
-
-\begin{lstlisting}
-    \= (NonEmpty(y, l, r) union ys) contains x
- =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-        \> (l union r union ys incl y) contains x
- =      \> $\expl{by Proposition 3}$
-        \> (l union r union ys) contains x
- =      \> $\expl{by the induction hypothesis}$
-        \> ((l union r) contains x) || (ys contains x)
- =      \> $\expl{by Proposition 3}$
-        \> ((l union r incl y) contains x) || (ys contains x)
-\end{lstlisting}
-
-\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
- ... is analogous.
-
-\es
-}}
-\chapter{\label{sec:for-notation}For-Comprehensions}
-
-The last chapter demonstrated that higher-order functions such as
-\verb@map@, \verb@flatMap@, \verb@filter@ provide powerful
-constructions for dealing with lists.  But sometimes the level of
-abstraction required by these functions makes a program hard to
-understand.
-
-To help understandability, Scala has a special notation which
-simplifies common patterns of applications of higher-order functions.
-This notation builds a bridge between set-comprehensions in
-mathematics and for-loops in imperative languages such as C or
-Java. It also closely resembles the query notation of relational
-databases.
-
-As a first example, say we are given a list \code{persons} of persons
-with \code{name} and \code{age} fields.  To print the names of all
-persons in the sequence which are aged over 20, one can write:
-\begin{lstlisting}
-for (p <- persons if p.age > 20) yield p.name
-\end{lstlisting}
-This is equivalent to the following expression , which uses
-higher-order functions \code{filter} and \code{map}:
-\begin{lstlisting}
-persons filter (p => p.age > 20) map (p => p.name)
-\end{lstlisting}
-The for-comprehension looks a bit like a for-loop in imperative languages,
-except that it constructs a list of the results of all iterations.
-
-Generally, a for-comprehension is of the form
-\begin{lstlisting}
-for ( $s$ ) yield $e$
-\end{lstlisting}
-Here, $s$ is a sequence of {\em generators}, {\em definitions} and
-{\em filters}.  A {\em generator} is of the form \code{val x <- e},
-where \code{e} is a list-valued expression. It binds \code{x} to
-successive values in the list.  A {\em definition} is of the form
-\code{val x = e}. It introduces \code{x} as a name for the value of
-\code{e} in the rest of the comprehension. A {\em filter} is an
-expression \code{f} of type \code{Boolean}.  It omits from
-consideration all bindings for which \code{f} is \code{false}.  The
-sequence $s$ starts in each case with a generator.  If there are
-several generators in a sequence, later generators vary more rapidly
-than earlier ones.
-
-The sequence $s$ may also be enclosed in braces instead of
-parentheses, in which case the semicolons between generators,
-definitions and filters can be omitted.
-
-Here are two examples that show how for-comprehensions are used.
-First, let's redo an example of the previous chapter: Given a positive
-integer $n$, find all pairs of positive integers $i$ and $j$, where $1
-\leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
-this problem is solved as follows:
-\begin{lstlisting}
-for { i <- List.range(1, n)
-      j <- List.range(1, i)
-      if isPrime(i+j) } yield {i, j}
-\end{lstlisting}
-This is arguably much clearer than the solution using \code{map},
-\code{flatMap} and \code{filter} that we have developed previously.
-
-As a second example, consider computing the scalar product of two
-vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
-be written as follows.
-\begin{lstlisting}
-  sum(for ((x, y) <- xs zip ys) yield x * y)
-\end{lstlisting}
-
-\section{The N-Queens Problem}
-
-For-comprehensions are especially useful for solving combinatorial
-puzzles. An example of such a puzzle is the 8-queens problem: Given a
-standard chess-board, place 8 queens such that no queen is in check from any
-other (a queen can check another piece if they are on the same
-column, row, or diagonal). We will now develop a solution to this
-problem, generalizing it to chess-boards of arbitrary size. Hence, the
-problem is to place $n$ queens on a chess-board of size $n \times n$.
-
-To solve this problem, note that we need to place a queen in each row.
-So we could place queens in successive rows, each time checking that a
-newly placed queen is not in check from any other queens that have
-already been placed. In the course of this search, it might arrive
-that a queen to be placed in row $k$ would be in check in all fields
-of that row from queens in row $1$ to $k-1$. In that case, we need to
-abort that part of the search in order to continue with a different
-configuration of queens in columns $1$ to $k-1$.
-
-This suggests a recursive algorithm.  Assume that we have already
-generated all solutions of placing $k-1$ queens on a board of size $n
-\times n$. We can represent each such solution by a list of length
-$k-1$ of column numbers (which can range from $1$ to $n$).  We treat
-these partial solution lists as stacks, where the column number of the
-queen in row $k-1$ comes first in the list, followed by the column
-number of the queen in row $k-2$, etc. The bottom of the stack is the
-column number of the queen placed in the first row of the board.  All
-solutions together are then represented as a list of lists, with one
-element for each solution.
-
-Now, to place the $k$'the queen, we generate all possible extensions
-of each previous solution by one more queen. This yields another list
-of solution lists, this time of length $k$. We continue the process
-until we have reached solutions of the size of the chess-board $n$.
-This algorithmic idea is embodied in function \code{placeQueens} below:
-\begin{lstlisting}
-def queens(n: Int): List[List[Int]] = {
-  def placeQueens(k: Int): List[List[Int]] =
-    if (k == 0) List(List())
-    else for { queens <- placeQueens(k - 1)
-               column <- List.range(1, n + 1)
-               if isSafe(column, queens, 1) } yield column :: queens
-  placeQueens(n)
-}
-\end{lstlisting}
-
-\begin{exercise} Write the function
-\begin{lstlisting}
-  def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
-\end{lstlisting}
-which tests whether a queen in the given column \verb@col@ is safe with 
-respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
-placed and the row of the first queen in the list.
-\end{exercise}
-
-\section{Querying with For-Comprehensions}
-
-The for-notation is essentially equivalent to common operations of
-database query languages.  For instance, say we are given a 
-database \code{books}, represented as a list of books, where
-\code{Book} is defined as follows.
-\begin{lstlisting}
-case class Book(title: String, authors: List[String])
-\end{lstlisting}
-Here is a small example database:
-\begin{lstlisting}
-val books: List[Book] = List(
-  Book("Structure and Interpretation of Computer Programs",
-       List("Abelson, Harold", "Sussman, Gerald J.")),
-  Book("Principles of Compiler Design",
-       List("Aho, Alfred", "Ullman, Jeffrey")),
-  Book("Programming in Modula-2",
-       List("Wirth, Niklaus")),
-  Book("Introduction to Functional Programming"),
-       List("Bird, Richard")),
-  Book("The Java Language Specification",
-       List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
-\end{lstlisting}
-Then, to find the titles of all books whose author's last name is ``Ullman'':
-\begin{lstlisting}
-for (b <- books; a <- b.authors if a startsWith "Ullman")
-yield b.title
-\end{lstlisting}
-(Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
-to find the titles of all books that have the string ``Program'' in
-their title:
-\begin{lstlisting}
-for (b <- books if (b.title indexOf "Program") >= 0)
-yield b.title
-\end{lstlisting}
-Or, to find the names of all authors that have written at least two
-books in the database.
-\begin{lstlisting}
-for (b1 <- books; b2 <- books if b1 != b2;
-     a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
-yield a1
-\end{lstlisting}
-The last solution is not yet perfect, because authors will appear
-several times in the list of results.  We still need to remove
-duplicate authors from result lists.  This can be achieved with the
-following function.
-\begin{lstlisting}
-def removeDuplicates[A](xs: List[A]): List[A] =
-  if (xs.isEmpty) xs
-  else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
-\end{lstlisting}
-Note that the last expression in method \code{removeDuplicates}
-can be equivalently expressed using a for-comprehension.
-\begin{lstlisting}
-xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
-\end{lstlisting}
-
-\section{Translation of For-Comprehensions}
-
-Every for-comprehension can be expressed in terms of the three
-higher-order functions \code{map}, \code{flatMap} and \code{filter}.
-Here is the translation scheme, which is also used by the Scala compiler.
-\begin{itemize}
-\item
-A simple for-comprehension
-\begin{lstlisting}
-for (x <- e) yield e'
-\end{lstlisting}
-is translated to
-\begin{lstlisting}
-e.map(x => e')
-\end{lstlisting}
-\item
-A for-comprehension
-\begin{lstlisting}
-for (x <- e if f; s) yield e'
-\end{lstlisting}
-where \code{f} is a filter and \code{s} is a (possibly empty)
-sequence of generators or filters
-is translated to
-\begin{lstlisting}
-for (x <- e.filter(x => f); s) yield e'
-\end{lstlisting}
-and then translation continues with the latter expression.
-\item
-A for-comprehension
-\begin{lstlisting}
-for (x <- e; y <- e'; s) yield e''
-\end{lstlisting}
-where \code{s} is a (possibly empty)
-sequence of generators or filters
-is translated to
-\begin{lstlisting}
-e.flatMap(x => for (y <- e'; s) yield e'')
-\end{lstlisting}
-and then translation continues with the latter expression.
-\end{itemize}
-For instance, taking our "pairs of integers whose sum is prime" example:
-\begin{lstlisting}
-for { i <- range(1, n)
-      j <- range(1, i)
-      if isPrime(i+j)
-} yield {i, j}
-\end{lstlisting}
-Here is what we get when we translate this expression:
-\begin{lstlisting}
-range(1, n)
-  .flatMap(i =>
-    range(1, i)
-      .filter(j => isPrime(i+j))
-      .map(j => (i, j)))
-\end{lstlisting}
-
-Conversely, it would also be possible to express functions \code{map},
-\code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
-three functions again, this time implemented using for-comprehensions.
-\begin{lstlisting}
-object Demo {
-  def map[A, B](xs: List[A], f: A => B): List[B] =
-    for (x <- xs) yield f(x)
-
-  def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
-    for (x <- xs; y <- f(x)) yield y
-
-  def filter[A](xs: List[A], p: A => Boolean): List[A] =
-    for (x <- xs if p(x)) yield x
-}
-\end{lstlisting}
-Not surprisingly, the translation of the for-comprehension in the body of
-\code{Demo.map} will produce a call to \code{map} in class \code{List}.
-Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
-\code{flatMap} and \code{filter} in class \code{List}.
-
-\begin{exercise}
-Define the following function in terms of \code{for}.
-\begin{lstlisting}
-def flatten[A](xss: List[List[A]]): List[A] =
-  (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
-\end{lstlisting}
-\end{exercise}
-
-\begin{exercise}
-Translate
-\begin{lstlisting}
-for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
-for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
-\end{lstlisting}
-to higher-order functions.
-\end{exercise}
-
-\section{For-Loops}\label{sec:for-loops}
-
-For-comprehensions resemble for-loops in imperative languages, except
-that they produce a list of results. Sometimes, a list of results is
-not needed but we would still like the flexibility of generators and
-filters in iterations over lists. This is made possible by a variant
-of the for-comprehension syntax, which expresses for-loops:
-\begin{lstlisting}
-for ( $s$ ) $e$
-\end{lstlisting}
-This construct is the same as the standard for-comprehension syntax
-except that the keyword \code{yield} is missing. The for-loop is
-executed by executing the expression $e$ for each element generated
-from the sequence of generators and filters $s$.
-
-As an example, the following expression prints out all elements of a
-matrix represented as a list of lists:
- \begin{lstlisting}
-for (xs <- xss) {
-  for (x <- xs) print(x + "\t")
-  println()
-}
-\end{lstlisting}
-The translation of for-loops to higher-order methods of class
-\code{List} is similar to the translation of for-comprehensions, but
-is simpler. Where for-comprehensions translate to \code{map} and
-\code{flatMap}, for-loops translate in each case to \code{foreach}.
-
-\section{Generalizing For}
-
-We have seen that the translation of for-comprehensions only relies on
-the presence of methods \code{map}, \code{flatMap}, and
-\code{filter}. Therefore it is possible to apply the same notation to
-generators that produce objects other than lists; these objects only
-have to support the three key functions \code{map}, \code{flatMap},
-and \code{filter}.
-
-The standard Scala library has several other abstractions that support
-these three methods and with them support for-comprehensions. We will
-encounter some of them in the following chapters. As a programmer you
-can also use this principle to enable for-comprehensions for types you
-define -- these types just need to support methods \code{map},
-\code{flatMap}, and \code{filter}.
-
-There are many examples where this is useful: Examples are database
-interfaces, XML trees, or optional values. 
-
-One caveat: It is not assured automatically that the result
-translating a for-comprehension is well-typed. To ensure this, the
-types of \code{map}, \code{flatMap} and \code{filter} have to be
-essentially similar to the types of these methods in class \code{List}.
-
-To make this precise, assume you have a parameterized class
- \code{C[A]} for which you want to enable for-comprehensions. Then
- \code{C} should define \code{map}, \code{flatMap} and \code{filter}
- with the following types:
-\begin{lstlisting}
-def map[B](f: A => B): C[B]
-def flatMap[B](f: A => C[B]): C[B]
-def filter(p: A => Boolean): C[A]
-\end{lstlisting}
-It would be attractive to enforce these types statically in the Scala
-compiler, for instance by requiring that any type supporting
-for-comprehensions implements a standard trait with these methods
-\footnote{In the programming language Haskell, which has similar
-constructs, this abstraction is called a ``monad with zero''}.  The
-problem is that such a standard trait would have to abstract over the
-identity of the class \code{C}, for instance by taking \code{C} as a
-type parameter.  Note that this parameter would be a type constructor,
-which gets applied to {\em several different} types in the signatures of
-methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
-system is too weak to express this construct, since it can handle only
-type parameters which are fully applied types.
-
-\chapter{Mutable State}
-
-Most programs we have presented so far did not have side-effects
-\footnote{We ignore here the fact that some of our program printed to
-standard output, which technically is a side effect.}.  Therefore, the
-notion of {\em time} did not matter.  For a program that terminates,
-any sequence of actions would have led to the same result!  This is
-also reflected by the substitution model of computation, where a
-rewrite step can be applied anywhere in a term, and all rewritings
-that terminate lead to the same solution.  In fact, this {\em
-confluence} property is a deep result in $\lambda$-calculus, the
-theory underlying functional programming. 
-
-In this chapter, we introduce functions with side effects and study
-their behavior. We will see that as a consequence we have to
-fundamentally modify up the substitution model of computation which we
-employed so far.
-
-\section{Stateful Objects}
-
-We normally view the world as a set of objects, some of which have
-state that {\em changes} over time.  Normally, state is associated
-with a set of variables that can be changed in the course of a
-computation.  There is also a more abstract notion of state, which
-does not refer to particular constructs of a programming language: An
-object {\em has state} (or: {\em is stateful}) if its behavior is
-influenced by its history.
-
-For instance, a bank account object has state, because the question
-``can I withdraw 100 CHF?''
-might have different answers during the lifetime of the account.
-
-In Scala, all mutable state is ultimately built from variables.  A
-variable definition is written like a value definition, but starts
-with \verb@var@ instead of \verb@val@. For instance, the following two
-definitions introduce and initialize two variables \code{x} and
-\code{count}.
-\begin{lstlisting}
-var x: String = "abc"
-var count = 111
-\end{lstlisting}
-Like a value definition, a variable definition associates a name with
-a value. But in the case of a variable definition, this association
-may be changed later by an assignment.  Such assignments are written
-as in C or Java. Examples:
-\begin{lstlisting}
-x = "hello"
-count = count + 1
-\end{lstlisting}
-In Scala, every defined variable has to be initialized at the point of
-its definition. For instance, the statement ~\code{var x: Int;}~ is
-{\em not} regarded as a variable definition, because the initializer
-is missing\footnote{If a statement like this appears in a class, it is
-instead regarded as a variable declaration, which introduces
-abstract access methods for the variable, but does not associate these
-methods with a piece of state.}. If one does not know, or does not
-care about, the appropriate initializer, one can use a wildcard
-instead. I.e.
-\begin{lstlisting}
-val x: T = _
-\end{lstlisting}
-will initialize \code{x} to some default value (\code{null} for
-reference types, \code{false} for booleans, and the appropriate
-version of \code{0} for numeric value types).
-
-Real-world objects with state are represented in Scala by objects that
-have variables as members. For instance, here is a class that
-represents bank accounts.
-\begin{lstlisting}
-class BankAccount {
-  private var balance = 0
-  def deposit(amount: Int) {
-    if (amount > 0) balance += amount
-  }
-
-  def withdraw(amount: Int): Int =
-    if (0 < amount && amount <= balance) {
-      balance -= amount
-      balance
-    } else error("insufficient funds")
-}
-\end{lstlisting}
-The class defines a variable \code{balance} which contains the current
-balance of an account. Methods \code{deposit} and \code{withdraw}
-change the value of this variable through assignments.  Note that
-\code{balance} is \code{private} in class \code{BankAccount} -- hence
-it can not be accessed directly outside the class.
-
-To create bank-accounts, we use the usual object creation notation:
-\begin{lstlisting}
-val myAccount = new BankAccount
-\end{lstlisting}
-
-\example Here is a \code{scalaint} session that deals with bank
-accounts.
-
-\begin{lstlisting}
-scala> :l bankaccount.scala
-Loading bankaccount.scala...
-defined class BankAccount
-scala> val account = new BankAccount
-account: BankAccount = BankAccount$\Dollar$class@1797795
-scala> account deposit 50
-unnamed0: Unit = ()
-scala> account withdraw 20
-unnamed1: Int = 30
-scala> account withdraw 20
-unnamed2: Int = 10
-scala> account withdraw 15
-java.lang.Error: insufficient funds
-        at scala.Predef$\Dollar$error(Predef.scala:74)
-        at BankAccount$\Dollar$class.withdraw(<console>:14)
-        at <init>(<console>:5)
-scala> 
-\end{lstlisting}
-The example shows that applying the same operation (\code{withdraw
-20}) twice to an account yields different results. So, clearly,
-accounts are stateful objects.  
-
-\paragraph{Sameness and Change}
-Assignments pose new problems in deciding when two expressions are
-``the same''.
-If assignments are excluded, and one writes
-\begin{lstlisting}
-val x = E; val y = E
-\end{lstlisting}
-where \code{E} is some arbitrary expression,
-then \code{x} and \code{y} can reasonably be assumed to be the same.
-I.e. one could have equivalently written
-\begin{lstlisting}
-val x = E; val y = x
-\end{lstlisting}
-(This property is usually called {\em referential transparency}). But
-once we admit assignments, the two definition sequences are different.
-Consider:
-\begin{lstlisting}
-val x = new BankAccount; val y = new BankAccount
-\end{lstlisting}
-To answer the question whether \code{x} and \code{y} are the same, we
-need to be more precise what ``sameness'' means. This meaning is
-captured in the notion of {\em operational equivalence}, which,
-somewhat informally, is stated as follows.
-
-Suppose we have two definitions of \code{x} and \code{y}.
-To test whether \code{x} and \code{y} define the same value, proceed
-as follows.
-\begin{itemize}
-\item
-Execute the definitions followed by an
-arbitrary sequence \code{S} of operations that involve \code{x} and
-\code{y}. Observe the results (if any).
-\item
-Then, execute the definitions with another sequence \code{S'} which
-results from \code{S} by renaming all occurrences of \code{y} in
-\code{S} to \code{x}.
-\item
-If the results of running \code{S'} are different, then surely
-\code{x} and \code{y} are different.
-\item
-On the other hand, if all possible pairs of sequences \lstinline@{S, S'}@
-yield the same results, then \code{x} and \code{y} are the same.
-\end{itemize}
-In other words, operational equivalence regards two definitions
-\code{x} and \code{y} as defining the same value, if no possible
-experiment can distinguish between \code{x} and \code{y}. An
-experiment in this context are two version of an arbitrary program which use either
-\code{x} or \code{y}.
+%% \chapter{Lists}
+
+%% Lists are an important data structure in many Scala programs.  
+%% A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
+%% \code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
+%% \begin{lstlisting}
+%% val fruit = List("apples", "oranges", "pears")
+%% val nums  = List(1, 2, 3, 4)
+%% val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+%% val empty = List()
+%% \end{lstlisting}
+%% Lists are similar to arrays in languages such as C or Java, but there
+%% are also three important differences. First, lists are immutable. That
+%% is, elements of a list cannot be changed by assignment. Second, 
+%% lists have a recursive structure, whereas arrays are flat. Third,
+%% lists support a much richer set of operations than arrays usually do.
+
+%% \section{Using Lists}
+
+%% \paragraph{The List type}
+%% Like arrays, lists are {\em homogeneous}. That is, the elements of a
+%% list all have the same type.  The type of a list with elements of type
+%% \code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
+%% \begin{lstlisting}
+%% val fruit: List[String]    = List("apples", "oranges", "pears")
+%% val nums : List[Int]       = List(1, 2, 3, 4)
+%% val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+%% val empty: List[Int]       = List()
+%% \end{lstlisting}
+
+%% \paragraph{List constructors}
+%% All lists are built from two more fundamental constructors, \code{Nil}
+%% and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
+%% list. The infix operator \code{::} expresses list extension. That is,
+%% \code{x :: xs} represents a list whose first element is \code{x},
+%% which is followed by (the elements of) list \code{xs}.  Hence, the
+%% list values above could also have been defined as follows (in fact
+%% their previous definition is simply syntactic sugar for the definitions below).
+%% \begin{lstlisting}
+%% val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
+%% val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
+%% val diag3  = (1 :: (0 :: (0 :: Nil))) ::
+%%              (0 :: (1 :: (0 :: Nil))) ::
+%%              (0 :: (0 :: (1 :: Nil))) :: Nil
+%% val empty  = Nil
+%% \end{lstlisting}
+%% The `\code{::}' operation associates to the right: \code{A :: B :: C} is
+%% interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
+%% parentheses in the definitions above. For instance, we can write
+%% shorter
+%% \begin{lstlisting}
+%% val nums  =  1 :: 2 :: 3 :: 4 :: Nil
+%% \end{lstlisting}
+
+%% \paragraph{Basic operations on lists}
+%% All operations on lists can be expressed in terms of the following three:
+
+%% \begin{tabular}{ll}
+%% \code{head}  &  returns the first element of a list,\\
+%% \code{tail}  &  returns the list consisting of all elements except the\\
+%% & first element,\\
+%% \code{isEmpty} & returns \code{true} iff the list is empty
+%% \end{tabular}
+
+%% These operations are defined as methods of list objects. So we invoke
+%% them by selecting from the list that's operated on. Examples:
+%% \begin{lstlisting}
+%% empty.isEmpty   = true
+%% fruit.isEmpty   = false
+%% fruit.head      = "apples"
+%% fruit.tail.head = "oranges"
+%% diag3.head      = List(1, 0, 0)
+%% \end{lstlisting}
+%% The \code{head} and \code{tail} methods are defined only for non-empty
+%% lists.  When selected from an empty list, they throw an exception.
+
+%% As an example of how lists can be processed, consider sorting the
+%% elements of a list of numbers into ascending order. One simple way to
+%% do so is {\em insertion sort}, which works as follows: To sort a
+%% non-empty list with first element \code{x} and rest \code{xs}, sort
+%% the remainder \code{xs} and insert the element \code{x} at the right
+%% position in the result. Sorting an empty list will yield the
+%% empty list. Expressed as Scala code:
+%% \begin{lstlisting}
+%% def isort(xs: List[Int]): List[Int] =
+%%   if (xs.isEmpty) Nil
+%%   else insert(xs.head, isort(xs.tail))
+%% \end{lstlisting}
+
+%% \begin{exercise} Provide an implementation of the missing function
+%% \code{insert}.
+%% \end{exercise}
+
+%% \paragraph{List patterns} In fact, \code{::} is defined as a case
+%% class in Scala's standard library. Hence, it is possible to decompose
+%% lists by pattern matching, using patterns composed from the \code{Nil}
+%% and \code{::} constructors. For instance, \code{isort} can be written
+%% alternatively as follows.
+%% \begin{lstlisting}
+%% def isort(xs: List[Int]): List[Int] = xs match {
+%%   case List() => List()
+%%   case x :: xs1 => insert(x, isort(xs1))
+%% }
+%% \end{lstlisting}
+%% where
+%% \begin{lstlisting}
+%% def insert(x: Int, xs: List[Int]): List[Int] = xs match {
+%%   case List() => List(x)
+%%   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
+%% }
+%% \end{lstlisting}
+
+%% \section{Definition of class List I: First Order Methods}
+%% \label{sec:list-first-order}
+
+%% Lists are not built in in Scala; they are defined by an abstract class
+%% \code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
+%% In the following we present a tour through class \code{List}.
+%% \begin{lstlisting}
+%% package scala
+%% abstract class List[+A] {
+%% \end{lstlisting}
+%% \code{List} is an abstract class, so one cannot define elements by
+%% calling the empty \code{List} constructor (e.g. by
+%% \code{new List}).  The class has a type parameter \code{a}. It is
+%% co-variant in this parameter, which means that
+%% \code{List[S] <: List[T]} for all types \code{S} and \code{T} such that
+%% \code{S <: T}.  The class is situated in the package
+%% \code{scala}. This is a package containing the most important standard
+%% classes of Scala.
+%%  \code{List} defines a number of methods, which are
+%% explained in the following.
+
+%% \paragraph{Decomposing lists}
+%% First, there are the three basic methods \code{isEmpty},
+%% \code{head}, \code{tail}. Their implementation in terms of pattern
+%% matching is straightforward:
+%% \begin{lstlisting}
+%% def isEmpty: Boolean = this match {
+%%   case Nil => true
+%%   case x :: xs => false
+%% }
+%% def head: A = this match {
+%%   case Nil => error("Nil.head")
+%%   case x :: xs => x
+%% }
+%% def tail: List[A] = this match {
+%%   case Nil => error("Nil.tail")
+%%   case x :: xs => xs
+%% }
+%% \end{lstlisting}
+
+%% The next function computes the length of a list.
+%% \begin{lstlisting}
+%% def length: Int = this match {
+%%   case Nil => 0
+%%   case x :: xs => 1 + xs.length
+%% }
+%% \end{lstlisting}
+%% \begin{exercise} Design a tail-recursive version of \code{length}.
+%% \end{exercise}
+
+%% The next two functions are the complements of \code{head} and
+%% \code{tail}.
+%% \begin{lstlisting}
+%% def last: A
+%% def init: List[A]
+%% \end{lstlisting}
+%% \code{xs.last} returns the last element of list \code{xs}, whereas
+%% \code{xs.init} returns all elements of \code{xs} except the last.
+%% Both functions have to traverse the entire list, and are thus less
+%% efficient than their \code{head} and \code{tail} analogues.
+%% Here is the implementation of \code{last}.
+%% \begin{lstlisting}
+%% def last: A = this match {
+%%   case Nil      => error("Nil.last")
+%%   case x :: Nil => x
+%%   case x :: xs  => xs.last
+%% }
+%% \end{lstlisting}
+%% The implementation of \code{init} is analogous.
+
+%% The next three functions return a prefix of the list, or a suffix, or
+%% both.
+%% \begin{lstlisting}
+%% def take(n: Int): List[A] =
+%%   if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
+
+%% def drop(n: Int): List[A] =
+%%   if (n == 0 || isEmpty) this else tail.drop(n-1)
+
+%% def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
+%% \end{lstlisting}
+%% \code{(xs take n)} returns the first \code{n} elements of list
+%% \code{xs}, or the whole list, if its length is smaller than \code{n}.
+%% \code{(xs drop n)} returns all elements of \code{xs} except the
+%% \code{n} first ones. Finally, \code{(xs split n)} returns a pair
+%% consisting of the lists resulting from \code{xs take n} and
+%% \code{xs drop n}.
+
+%% The next function returns an element at a given index in a list.
+%% It is thus analogous to array subscripting. Indices start at 0.
+%% \begin{lstlisting}
+%% def apply(n: Int): A = drop(n).head
+%% \end{lstlisting}
+%% The \code{apply} method has a special meaning in Scala. An object with
+%% an \code{apply} method can be applied to arguments as if it was a
+%% function. For instance, to pick the 3'rd element of a list \code{xs},
+%% one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
+%% expression expands into the first.
+
+%% With \code{take} and \code{drop}, we can extract sublists consisting
+%% of consecutive elements of the original list.  To extract the sublist
+%% $xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
+
+%% \begin{lstlisting}
+%% xs.drop(m).take(n - m)
+%% \end{lstlisting}
+
+%% \paragraph{Zipping lists} The next function combines two lists into a list of pairs.
+%% Given two lists
+%% \begin{lstlisting}
+%% xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
+%% ys = List(y$_1$, ..., y$_n$)   ,
+%% \end{lstlisting}
+%% \code{xs zip ys} constructs the list
+%% \lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
+%% If the two lists have different lengths, the longer one of the two is
+%% truncated. Here is the definition of \code{zip} -- note that it is a
+%% polymorphic method.
+%% \begin{lstlisting}
+%% def zip[B](that: List[B]): List[(a,b)] =
+%%   if (this.isEmpty || that.isEmpty) Nil
+%%   else (this.head, that.head) :: (this.tail zip that.tail)
+%% \end{lstlisting}
+
+%% \paragraph{Consing lists.}
+%% Like any infix operator, \code{::}
+%% is also implemented as a method of an object. In this case, the object
+%% is the list that is extended. This is possible, because operators
+%% ending with a `\code{:}' character are treated specially in Scala.  
+%% All such operators are treated as methods of their right operand. E.g.,
+%% \begin{lstlisting}
+%%     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
+%% \end{lstlisting}
+%% Note, however, that operands of a binary operation are in each case
+%% evaluated from left to right.  So, if \code{D} and \code{E} are
+%% expressions with possible side-effects, \code{D :: E} is translated to
+%% \lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
+%% order of operand evaluation.
+
+%% Another difference between operators ending in a `\code{:}' and other
+%% operators concerns their associativity.  Operators ending in
+%% `\code{:}' are right-associative, whereas other operators are
+%% left-associative.  E.g.,
+%% \begin{lstlisting}
+%%     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
+%% \end{lstlisting}
+%% The definition of \code{::} as a method in
+%% class \code{List} is as follows:
+%% \begin{lstlisting}
+%% def ::[B >: A](x: B): List[B] = new scala.::(x, this)
+%% \end{lstlisting}
+%% Note that \code{::} is defined for all elements \code{x} of type
+%% \code{B} and lists of type \code{List[A]} such that the type \code{B}
+%% of \code{x} is a supertype of the list's element type \code{A}. The result
+%% is in this case a list of \code{B}'s. This
+%% is expressed by the type parameter \code{B} with lower bound \code{A}
+%% in the signature of \code{::}. 
+
+%% \paragraph{Concatenating lists}
+%% An operation similar to \code{::} is list concatenation, written
+%% `\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
+%% all elements of \code{xs}, followed by all elements of \code{ys}.
+%% Because it ends in a colon, \code{:::} is right-associative and is
+%% considered as a method of its right-hand operand. Therefore,
+%% \begin{lstlisting}
+%% xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
+%%                   =   zs.:::(ys).:::(xs)
+%% \end{lstlisting}
+%% Here is the implementation of the \code{:::} method:
+%% \begin{lstlisting}
+%%   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
+%%     case Nil => this
+%%     case p :: ps => this.:::(ps).::(p)
+%%   }
+%% \end{lstlisting}
+
+%% \paragraph{Reversing lists} Another useful operation
+%% is list reversal. There is a method \code{reverse} in \code{List} to
+%% that effect. Let's try to give its implementation:
+%% \begin{lstlisting}
+%% def reverse[A](xs: List[A]): List[A] = xs match {
+%%   case Nil => Nil
+%%   case x :: xs => reverse(xs) ::: List(x)
+%% }
+%% \end{lstlisting}
+%% This implementation has the advantage of being simple, but it is not
+%% very efficient.  Indeed, one concatenation is executed for every
+%% element in the list. List concatenation takes time proportional to the
+%% length of its first operand. Therefore, the complexity of
+%% \code{reverse(xs)} is
+%% \[
+%% n + (n - 1) + ... + 1 = n(n+1)/2
+%% \]
+%% where $n$ is the length of \code{xs}. Can \code{reverse} be
+%% implemented more efficiently? We will see later that there exists
+%% another implementation which has only linear complexity.
+
+%% \section{Example: Merge sort}
+
+%% The insertion sort presented earlier in this chapter is simple to
+%% formulate, but also not very efficient. It's average complexity is
+%% proportional to the square of the length of the input list. We now
+%% design a program to sort the elements of a list which is more
+%% efficient than insertion sort. A good algorithm for this is {\em merge
+%% sort}, which works as follows.
+
+%% First, if the list has zero or one elements, it is already sorted, so
+%% one returns the list unchanged. Longer lists are split into two
+%% sub-lists, each containing about half the elements of the original
+%% list. Each sub-list is sorted by a recursive call to the sort
+%% function, and the resulting two sorted lists are then combined in a
+%% merge operation.
+
+%% For a general implementation of merge sort, we still have to specify
+%% the type of list elements to be sorted, as well as the function to be
+%% used for the comparison of elements. We obtain a function of maximal
+%% generality by passing these two items as parameters. This leads to the
+%% following implementation.
+%% \begin{lstlisting}
+%% def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
+%%   def merge(xs1: List[A], xs2: List[A]): List[A] =
+%%     if (xs1.isEmpty) xs2
+%%     else if (xs2.isEmpty) xs1
+%%     else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
+%%     else xs2.head :: merge(xs1, xs2.tail)
+%%   val n = xs.length/2
+%%   if (n == 0) xs
+%%   else merge(msort(less)(xs take n), msort(less)(xs drop n))
+%% }
+%% \end{lstlisting}
+%% The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
+%% length of the input list. To see why, note that splitting a list in
+%% two and merging two sorted lists each take time proportional to the
+%% length of the argument list(s). Each recursive call of \code{msort}
+%% halves the number of elements in its input, so there are $O(log(N))$
+%% consecutive recursive calls until the base case of lists of length 1
+%% is reached.  However, for longer lists each call spawns off two
+%% further calls. Adding everything up we obtain that at each of the
+%% $O(log(N))$ call levels, every element of the original lists takes
+%% part in one split operation and in one merge operation. Hence, every
+%% call level has a total cost proportional to $O(N)$. Since there are
+%% $O(log(N))$ call levels, we obtain an overall cost of
+%% $O(N;log(N))$. That cost does not depend on the initial distribution
+%% of elements in the list, so the worst case cost is the same as the
+%% average case cost. This makes merge sort an attractive algorithm for
+%% sorting lists.
+
+%% Here is an example how \code{msort} is used.
+%% \begin{lstlisting}
+%% msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
+%% \end{lstlisting}
+%% The definition of \code{msort} is curried, to make it easy to specialize it with particular
+%% comparison functions. For instance,
+%% \begin{lstlisting}
+
+%% val intSort = msort((x: Int, y: Int) => x < y)
+%% val reverseSort = msort((x: Int, y: Int) => x > y)
+%% \end{lstlisting}
+
+%% \section{Definition of class List II: Higher-Order Methods}
+
+%% The examples encountered so far show that functions over lists often
+%% have similar structures. We can identify several patterns of
+%% computation over lists, like:
+%% \begin{itemize}
+%%       \item transforming every element of a list in some way.
+%%       \item extracting from a list all elements satisfying a criterion.
+%%       \item combine the elements of a list using some operator.
+%% \end{itemize}
+%% Functional programming languages enable programmers to write general
+%% functions which implement patterns like this by means of higher order
+%% functions. We now discuss a set of commonly used higher-order
+%% functions, which are implemented as methods in class \code{List}.
+
+%% \paragraph{Mapping over lists}
+%% A common operation is to transform each element of a list and then
+%% return the lists of results.  For instance, to scale each element of a
+%% list by a given factor.
+%% \begin{lstlisting}
+%% def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
+%%   case Nil => xs
+%%   case x :: xs1 => x * factor :: scaleList(xs1, factor)
+%% }
+%% \end{lstlisting}
+%% This pattern can be generalized to the \code{map} method of class \code{List}:
+%% \begin{lstlisting}
+%% abstract class List[A] { ...
+%%   def map[B](f: A => B): List[B] = this match {
+%%     case Nil => this
+%%     case x :: xs => f(x) :: xs.map(f)
+%%   }
+%% \end{lstlisting}
+%% Using \code{map}, \code{scaleList} can be more concisely written as follows.
+%% \begin{lstlisting}
+%% def scaleList(xs: List[Double], factor: Double) =
+%%   xs map (x => x * factor)
+%% \end{lstlisting}
+
+%% As another example, consider the problem of returning a given column
+%% of a matrix which is represented as a list of rows, where each row is
+%% again a list. This is done by the following function \code{column}.
+
+%% \begin{lstlisting}
+%% def column[A](xs: List[List[A]], index: Int): List[A] =
+%%   xs map (row => row(index))
+%% \end{lstlisting}
+
+%% Closely related to \code{map} is the \code{foreach} method, which
+%% applies a given function to all elements of a list, but does not
+%% construct a list of results. The function is thus applied only for its
+%% side effect. \code{foreach} is defined as follows.
+%% \begin{lstlisting}
+%%   def foreach(f: A => Unit) {
+%%     this match {
+%%       case Nil => ()
+%%       case x :: xs => f(x); xs.foreach(f)
+%%     }
+%%   }
+%% \end{lstlisting}
+%% This function can be used for printing all elements of a list, for instance:
+%% \begin{lstlisting}
+%%   xs foreach (x => println(x))
+%% \end{lstlisting} 
+
+%% \begin{exercise} Consider a function which squares all elements of a list and
+%% returns a list with the results. Complete the following two equivalent
+%% definitions of \code{squareList}.
+
+%% \begin{lstlisting}
+%% def squareList(xs: List[Int]): List[Int] = xs match {
+%%   case List() => ??
+%%   case y :: ys => ??
+%% }
+%% def squareList(xs: List[Int]): List[Int] =
+%%   xs map ??
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \paragraph{Filtering Lists}
+%% Another common operation selects from a list all elements fulfilling a
+%% given criterion. For instance, to return a list of all positive
+%% elements in some given lists of integers:
+%% \begin{lstlisting}
+%% def posElems(xs: List[Int]): List[Int] = xs match {
+%%   case Nil => xs
+%%   case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
+%% }
+%% \end{lstlisting}
+%% This pattern is generalized to the \code{filter} method of class \code{List}:
+%% \begin{lstlisting}
+%%   def filter(p: A => Boolean): List[A] = this match {
+%%     case Nil => this
+%%     case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
+%%   }
+%% \end{lstlisting}
+%% Using \code{filter}, \code{posElems} can be more concisely written as
+%% follows.
+%% \begin{lstlisting}
+%% def posElems(xs: List[Int]): List[Int] =
+%%   xs filter (x => x > 0)
+%% \end{lstlisting}
+
+%% An operation related to filtering is testing whether all elements of a
+%% list satisfy a certain condition. Dually, one might also be interested
+%% in the question whether there exists an element in a list that
+%% satisfies a certain condition. These operations are embodied in the
+%% higher-order functions \code{forall} and \code{exists} of class
+%% \code{List}.
+%% \begin{lstlisting}
+%% def forall(p: A => Boolean): Boolean =
+%%   isEmpty || (p(head) && (tail forall p))
+%% def exists(p: A => Boolean): Boolean =
+%%   !isEmpty && (p(head) || (tail exists p))
+%% \end{lstlisting}
+%% To illustrate the use of \code{forall}, consider the question of whether
+%% a number if prime. Remember that a number $n$ is prime of it can be
+%% divided without remainder only by one and itself. The most direct
+%% translation of this definition would test that $n$ divided by all
+%% numbers from 2 up to and excluding itself gives a non-zero
+%% remainder. This list of numbers can be generated using a function
+%% \code{List.range} which is defined in object \code{List} as follows.
+%% \begin{lstlisting}
+%% package scala
+%% object List { ...
+%%   def range(from: Int, end: Int): List[Int] =
+%%     if (from >= end) Nil else from :: range(from + 1, end)
+%% \end{lstlisting}
+%% For example, \code{List.range(2, n)}
+%% generates the list of all integers from 2 up to and excluding $n$.
+%% The function \code{isPrime} can now simply be defined as follows.
+%% \begin{lstlisting}
+%% def isPrime(n: Int) =
+%%   List.range(2, n) forall (x => n % x != 0)
+%% \end{lstlisting}
+%% We see that the mathematical definition of prime-ness has been
+%% translated directly into Scala code. 
+
+%% Exercise: Define \code{forall} and \code{exists} in terms of \code{filter}.
+
+
+%% \paragraph{Folding and Reducing Lists}
+%% Another common operation is to combine the elements of a list with
+%% some operator.  For instance:
+%% \begin{lstlisting}
+%% sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
+%% product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
+%% \end{lstlisting}
+%% Of course, we can implement both functions with a
+%% recursive scheme:
+%% \begin{lstlisting}
+%% def sum(xs: List[Int]): Int = xs match {
+%%   case Nil => 0
+%%   case y :: ys => y + sum(ys)
+%% }
+%% def product(xs: List[Int]): Int = xs match {
+%%   case Nil => 1
+%%   case y :: ys => y * product(ys)
+%% }
+%% \end{lstlisting}
+%% But we can also use the generalization of this program scheme embodied
+%% in the \code{reduceLeft} method of class \code{List}.  This method
+%% inserts a given binary operator between adjacent elements of a given list.
+%% E.g.\ 
+%% \begin{lstlisting}
+%% List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
+%% \end{lstlisting}
+%% Using \code{reduceLeft}, we can make the common pattern
+%% in \code{sum} and \code{product} apparent:
+%% \begin{lstlisting}
+%% def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
+%% def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
+%% \end{lstlisting}
+%% Here is the implementation of \code{reduceLeft}.
+%% \begin{lstlisting}
+%%   def reduceLeft(op: (A, A) => A): A = this match {
+%%     case Nil     => error("Nil.reduceLeft")
+%%     case x :: xs => (xs foldLeft x)(op)
+%%   }
+%%   def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
+%%     case Nil => z
+%%     case x :: xs => (xs foldLeft op(z, x))(op)
+%%   }
+%% }
+%% \end{lstlisting}
+%% We see that the \code{reduceLeft} method is defined in terms of
+%% another generally useful method, \code{foldLeft}.  The latter takes as
+%% additional parameter an {\em accumulator} \code{z}, which is returned
+%% when \code{foldLeft} is applied on an empty list. That is,
+%% \begin{lstlisting}
+%% (List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
+%% \end{lstlisting}
+%% The \code{sum} and \code{product} methods can be defined alternatively
+%% using \code{foldLeft}:
+%% \begin{lstlisting}
+%% def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
+%% def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
+%% \end{lstlisting}
+
+%% \paragraph{FoldRight and ReduceRight}
+%% Applications of \code{foldLeft} and \code{reduceLeft} expand to
+%% left-leaning trees. \todo{insert pictures}.  They have duals
+%% \code{foldRight} and \code{reduceRight}, which produce right-leaning
+%% trees.
+%% \begin{lstlisting}
+%% List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
+%% (List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
+%% \end{lstlisting}
+%% These are defined as follows.
+%% \begin{lstlisting}
+%%   def reduceRight(op: (A, A) => A): A = this match {
+%%     case Nil => error("Nil.reduceRight")
+%%     case x :: Nil => x
+%%     case x :: xs => op(x, xs.reduceRight(op))
+%%   }
+%%   def foldRight[B](z: B)(op: (A, B) => B): B = this match {
+%%     case Nil => z
+%%     case x :: xs => op(x, (xs foldRight z)(op))
+%%   }
+%% \end{lstlisting}
+
+%% Class \code{List} defines also two symbolic abbreviations for
+%% \code{foldLeft} and \code{foldRight}:
+%% \begin{lstlisting}
+%%   def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
+%%   def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
+%% \end{lstlisting}
+%% The method names picture the left/right leaning trees of the fold
+%% operations by forward or backward slashes. The \code{:} points in each
+%% case to the list argument whereas the end of the slash points to the
+%% accumulator (or: zero) argument \code{z}. 
+%% That is, 
+%% \begin{lstlisting}
+%% (z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
+%% (List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
+%% \end{lstlisting}
+%% For associative and commutative operators, \code{/:} and
+%% \code{:\\} are equivalent (even though there may be a difference
+%% in efficiency).  
+%% %But sometimes, only one of the two operators is
+%% %appropriate or has the right type:
+
+%% \begin{exercise} Consider the problem of writing a function \code{flatten},
+%% which takes a list of element lists as arguments. The result of
+%% \code{flatten} should be the concatenation of all element lists into a
+%% single list. Here is an implementation of this method in terms of 
+%% \code{:\\}.
+%% \begin{lstlisting}
+%% def flatten[A](xs: List[List[A]]): List[A] =
+%%   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
+%% \end{lstlisting} 
+%% Consider replacing the body of \lstinline@flatten@
+%% by 
+%% \begin{lstlisting}
+%%   ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
+%% \end{lstlisting}
+%% What would be the difference in asymptotic
+%% complexity between the two versions of \lstinline@flatten@?
+
+%% In fact \code{flatten} is predefined together with a set of other
+%% userful function in an object called \code{List} in the standatd Scala
+%% library. It can be accessed from user program by calling
+%% \code{List.flatten}. Note that \code{flatten} is not a method of class
+%% \code{List} -- it would not make sense there, since it applies only
+%% to lists of lists, not to all lists in general.
+%% \end{exercise}
+
+%% \paragraph{List Reversal Again} We have seen in 
+%% Section~\ref{sec:list-first-order} an implementation of method
+%% \code{reverse} whose run-time was quadratic in the length of the list
+%% to be reversed. We now develop a new implementation of \code{reverse},
+%% which has linear cost.  The idea is to use a \code{foldLeft}
+%% operation based on the following program scheme.
+%% \begin{lstlisting}
+%% class List[+A] { ...
+%%   def reverse: List[A] = (z? /: this)(op?)
+%% \end{lstlisting}
+%% It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
+%% try to deduce them from examples.
+%% \begin{lstlisting}
+%%   Nil
+%% = Nil.reverse                 // by specification
+%% = (z /: Nil)(op)              // by the template for reverse
+%% = (Nil foldLeft z)(op)        // by the definition of /:
+%% = z                           // by definition of foldLeft
+%% \end{lstlisting}
+%% Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
+%% let's study reversal of a list of length one.
+%% \begin{lstlisting}
+%%   List(x)
+%% = List(x).reverse             // by specification
+%% = (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
+%% = (List(x) foldLeft Nil)(op)  // by the definition of /:
+%% = op(Nil, x)                  // by definition of foldLeft
+%% \end{lstlisting}
+%% Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
+%% as \code{x :: Nil}. This suggests to take as \code{op} the
+%% \code{::} operator with its operands exchanged.  Hence, we arrive at
+%% the following implementation for \code{reverse}, which has linear complexity.
+%% \begin{lstlisting}
+%% def reverse: List[A] =
+%%   ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
+%% \end{lstlisting}
+%% (Remark: The type annotation of \code{Nil} is necessary 
+%% to make the type inferencer work.)
+
+%% \begin{exercise} Fill in the missing expressions to complete the following
+%% definitions of some basic list-manipulation operations as fold
+%% operations.
+%% \begin{lstlisting}
+%% def mapFun[A, B](xs: List[A], f: A => B): List[B] =
+%%   (xs :\ List[B]()){ ?? }
+
+%% def lengthFun[A](xs: List[A]): int =
+%%   (0 /: xs){ ?? }
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \paragraph{Nested Mappings}
+
+%% We can employ higher-order list processing functions to express many
+%% computations that are normally expressed as nested loops in imperative
+%% languages. 
+
+%% As an example, consider the following problem: Given a positive
+%% integer $n$, find all pairs of positive integers $i$ and $j$, where 
+%% $1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
+%% the pairs are
+%% \bda{c|lllllll}
+%% i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
+%% j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
+%% i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
+%% \eda
+
+%% A natural way to solve this problem consists of two steps. In a first step,
+%% one generates the sequence of all pairs $(i, j)$ of integers such that
+%% $1 \leq j < i < n$. In a second step one then filters from this sequence
+%% all pairs $(i, j)$ such that $i + j$ is prime.
+
+%% Looking at the first step in more detail, a natural way to generate
+%% the sequence of pairs consists of three sub-steps.  First, generate
+%% all integers between $1$ and $n$ for $i$.  
+%% \item
+%% Second, for each integer $i$ between $1$ and $n$, generate the list of
+%% pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
+%% combination of \code{range} and \code{map}:
+%% \begin{lstlisting}
+%%   List.range(1, i) map (x => (i, x))
+%% \end{lstlisting}
+%% Finally, combine all sublists using \code{foldRight} with \code{:::}.
+%% Putting everything together gives the following expression:
+%% \begin{lstlisting}
+%% List.range(1, n)
+%%   .map(i => List.range(1, i).map(x => (i, x)))
+%%   .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
+%%   .filter(pair => isPrime(pair._1 + pair._2))
+%% \end{lstlisting}
+
+%% \paragraph{Flattening Maps}
+%% The combination of mapping and then concatenating sublists 
+%% resulting from the map
+%% is so common that we there is a special method 
+%% for it in class \code{List}:
+%% \begin{lstlisting}
+%% abstract class List[+A] { ...
+%%   def flatMap[B](f: A => List[B]): List[B] = this match {
+%%     case Nil => Nil
+%%     case x :: xs => f(x) ::: (xs flatMap f)
+%%   }
+%% }
+%% \end{lstlisting}
+%% With \code{flatMap}, the pairs-whose-sum-is-prime expression 
+%% could have been written more concisely as follows.
+%% \begin{lstlisting}
+%% List.range(1, n)
+%%   .flatMap(i => List.range(1, i).map(x => (i, x)))
+%%   .filter(pair => isPrime(pair._1 + pair._2))
+%% \end{lstlisting}
+
+
+
+%% \section{Summary}
+
+%% This chapter has introduced lists as a fundamental data structure in
+%% programming. Since lists are immutable, they are a common data type in
+%% functional programming languages. They have a role comparable to
+%% arrays in imperative languages. However, the access patterns between
+%% arrays and lists are quite different. Where array accessing is always
+%% done by indexing, this is much less common for lists.  We have seen
+%% that \code{scala.List} defines a method called \code{apply} for indexing
+%% however this operation is much more costly than in the case of arrays
+%% (linear as opposed to constant time). Instead of indexing, lists are
+%% usually traversed recursively, where recursion steps are usually based
+%% on a pattern match over the traversed list. There is also a rich set of
+%% higher-order combinators which allow one to instantiate a set of
+%% predefined patterns of computations over lists.
+
+%% \comment{
+%% \bsh{Reasoning About Lists}
+
+%% Recall the concatenation operation for lists:
+
+%% \begin{lstlisting}
+%% class List[+A] {
+%%   ...
+%%   def ::: (that: List[A]): List[A] =
+%%     if (isEmpty) that
+%%     else head :: (tail ::: that)
+%% }
+%% \end{lstlisting}
+
+%% We would like to verify that concatenation is associative, with the
+%% empty list \code{List()} as left and right identity:
+%% \bda{lcl}
+%%    (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
+%%    xs ::: List()          &=& xs \gap =\ List() ::: xs
+%% \eda
+%% \emph{Q}: How can we prove statements like the one above?
+
+%% \emph{A}: By \emph{structural induction} over lists.
+%% \es
+%% \bsh{Reminder: Natural Induction}
+
+%% Recall the proof principle of \emph{natural induction}:
+
+%% To show a property \mathtext{P(n)} for all numbers \mathtext{n \geq b}:
+%% \be
+%% \item Show that \mathtext{P(b)} holds (\emph{base case}).
+%% \item For arbitrary \mathtext{n \geq b} show:
+%% \begin{quote}
+%%      if \mathtext{P(n)} holds, then \mathtext{P(n+1)} holds as well
+%% \end{quote}
+%% (\emph{induction step}).
+%% \ee
+%% %\es\bs
+%% \emph{Example}: Given
+%% \begin{lstlisting}
+%% def factorial(n: Int): Int =
+%%   if (n == 0) 1
+%%   else n * factorial(n-1)
+%% \end{lstlisting}
+%% show that, for all \code{n >= 4},
+%% \begin{lstlisting}
+%%    factorial(n) >= 2$^n$
+%% \end{lstlisting}
+%% \es\bs
+%% \Case{\code{4}}
+%% is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
+
+%% \Case{\code{n+1}} 
+%% We have for \code{n >= 4}:
+%% \begin{lstlisting}
+%%     \= factorial(n + 1)
+%%  =     \> $\expl{by the second clause of factorial(*)}$
+%%        \> (n + 1) * factorial(n)
+%%  >=    \> $\expl{by calculation}$
+%%        \> 2 * factorial(n)
+%%  >=    \> $\expl{by the induction hypothesis}$
+%%        \> 2 * 2$^n$.
+%% \end{lstlisting}
+%% Note that in our proof we can freely apply reduction steps such as in (*)
+%% anywhere in a term.
+
+
+%% This works because purely functional programs do not have side
+%% effects; so a term is equivalent to the term it reduces to.
+
+%% The principle is called {\em\emph{referential transparency}}.
+%% \es
+%% \bsh{Structural Induction}
+
+%% The principle of structural induction is analogous to natural induction:
+
+%% In the case of lists, it is as follows:
+
+%% To prove a property \mathtext{P(xs)} for all lists \mathtext{xs},
+%% \be
+%% \item Show that \code{P(List())} holds (\emph{base case}).
+%% \item For arbitrary lists \mathtext{xs} and elements \mathtext{x} 
+%%       show:
+%% \begin{quote}
+%%      if \mathtext{P(xs)} holds, then \mathtext{P(x :: xs)} holds as well
+%% \end{quote}
+%% (\emph{induction step}).
+%% \ee
+
+%% \es
+%% \bsh{Example}
+
+%% We show \code{(xs ::: ys) ::: zs  =  xs ::: (ys ::: zs)} by structural induction
+%% on \code{xs}.
+
+%% \Case{\code{List()}}
+%% For the left-hand side, we have:
+%% \begin{lstlisting}
+%%     \= (List() ::: ys) ::: zs
+%%  =     \> $\expl{by first clause of \prog{:::}}$
+%%        \> ys ::: zs
+%% \end{lstlisting}
+%% For the right-hand side, we have:
+%% \begin{lstlisting}
+%%     \= List() ::: (ys ::: zs)
+%%  =     \> $\expl{by first clause of \prog{:::}}$
+%%        \> ys ::: zs
+%% \end{lstlisting}
+%% So the case is established.
+
+%% \es
+%% \bs
+%% \Case{\code{x :: xs}} 
+
+%% For the left-hand side, we have:
+%% \begin{lstlisting}
+%%     \= ((x :: xs) ::: ys) ::: zs
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> (x :: (xs ::: ys)) ::: zs
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> x :: ((xs ::: ys) ::: zs)
+%%  =     \> $\expl{by the induction hypothesis}$
+%%        \> x :: (xs ::: (ys ::: zs))
+%% \end{lstlisting}
+
+%% For the right-hand side, we have:
+%% \begin{lstlisting}
+%%     \= (x :: xs) ::: (ys ::: zs)
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> x :: (xs ::: (ys ::: zs))
+%% \end{lstlisting}
+%% So the case (and with it the property) is established.
+
+%% \begin{exercise}
+%% Show by induction on \code{xs} that \code{xs ::: List()  =  xs}.
+%% \es
+%% \bsh{Example (2)}
+%% \end{exercise}
+
+%% As a more difficult example, consider function
+%% \begin{lstlisting}
+%% abstract class List[A] { ...
+%%   def reverse: List[A] = this match {
+%%     case List() => List()
+%%     case x :: xs => xs.reverse ::: List(x)
+%%   }
+%% }
+%% \end{lstlisting}
+%% We would like to prove the proposition that
+%% \begin{lstlisting}
+%%    xs.reverse.reverse  =  xs  .
+%% \end{lstlisting}
+%% We proceed by induction over \code{xs}. The base case is easy to establish:
+%% \begin{lstlisting}
+%%     \= List().reverse.reverse
+%%  =     \> $\expl{by first clause of \prog{reverse}}$
+%%        \> List().reverse
+%%  =     \> $\expl{by first clause of \prog{reverse}}$
+%%        \> List()
+%% \end{lstlisting}
+%% \es\bs
+%% For the induction step, we try:
+%% \begin{lstlisting}
+%%     \= (x :: xs).reverse.reverse
+%%  =     \> $\expl{by second clause of \prog{reverse}}$
+%%        \> (xs.reverse ::: List(x)).reverse
+%% \end{lstlisting}
+%% There's nothing more we can do to this expression, so we turn to the right side:
+%% \begin{lstlisting}
+%%     \= x :: xs
+%%  =     \> $\expl{by induction hypothesis}$
+%%        \> x :: xs.reverse.reverse
+%% \end{lstlisting}
+%% The two sides have simplified to different expressions.
+
+%% So we still have to show that
+%% \begin{lstlisting}
+%%   (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
+%% \end{lstlisting}
+%% Trying to prove this directly by induction does not work.
+
+%% Instead we have to {\em generalize} the equation to:
+%% \begin{lstlisting}
+%%   (ys ::: List(x)).reverse  =  x :: ys.reverse
+%% \end{lstlisting}
+%% \es\bs
+%% This equation can be proved by a second induction argument over \code{ys}.
+%% (See blackboard).
+
+%% \begin{exercise}
+%% Is it the case that \code{(xs drop m) at n  =  xs at (m + n)} for all 
+%% natural numbers \code{m}, \code{n} and all lists \code{xs}?
+%% \end{exercise}
+
+%% \es
+%% \bsh{Structural Induction on Trees}
+
+%% Structural induction is not restricted to lists; it works for arbitrary
+%% trees.
+
+%% The general induction principle is as follows.
+
+%% To show that property \code{P(t)} holds for all trees of a certain type,
+%% \begin{itemize}
+%% \item Show \code{P(l)} for all leaf trees \code{$l$}.
+%% \item For every interior node \code{t} with subtrees \code{s$_1$, ..., s$_n$}, 
+%%       show that \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}.
+%% \end{itemize} 
+
+%% \example Recall our definition of \code{IntSet} with 
+%% operations \code{contains} and \code{incl}:
+
+%% \begin{lstlisting}
+%% abstract class IntSet {
+%%   abstract def incl(x: Int): IntSet
+%%   abstract def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
+%% \es\bs
+%% \begin{lstlisting}
+%% case class Empty extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
+%% }
+%% case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: Int): IntSet =
+%%     if (x < elem) NonEmpty(elem, left incl x, right)
+%%     else if (x > elem) NonEmpty(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
+%% (With \code{case} added, so that we can use factory methods instead of \code{new}).
+
+%% What does it mean to prove the correctness of this implementation?
+%% \es
+%% \bsh{Laws of IntSet}
+
+%% One way to state and prove the correctness of an implementation is
+%% to prove laws that hold for it.
+
+%% In the case of \code{IntSet}, three such laws would be:
+
+%% For all sets \code{s}, elements \code{x}, \code{y}:
+
+%% \begin{lstlisting}
+%% Empty contains x          \= =  false
+%% (s incl x) contains x     \> =  true
+%% (s incl x) contains y     \> =  s contains y         if x $\neq$ y
+%% \end{lstlisting}
+
+%% (In fact, one can show that these laws characterize the desired data
+%% type completely).
+
+%% How can we establish that these laws hold?
+
+%% \emph{Proposition 1}: \code{Empty contains x =  false}.
+
+%% \emph{Proof}: By the definition of \code{contains} in \code{Empty}.
+%% \es\bs
+%% \emph{Proposition 2}: \code{(xs incl x) contains x = true}
+
+%% \emph{Proof:}
+
+%% \Case{\code{Empty}}
+%% \begin{lstlisting}
+%%     \= (Empty incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
+%%        \> NonEmpty(x, Empty, Empty) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+%%        \> true
+%% \end{lstlisting}
+
+%% \Case{\code{NonEmpty(x, l, r)}}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(x, l, r) incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+%%        \> NonEmpty(x, l, r) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
+%%        \> true
+%% \end{lstlisting}
+%% \es\bs
+%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(y, l, r) incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+%%        \> NonEmpty(y, l, r incl x) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+%%        \> (r incl x) contains x
+%%  =     \> $\expl{by the induction hypothesis}$
+%%        \> true
+%% \end{lstlisting}
+
+%% \Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
+
+%% \bigskip
+
+%% \emph{Proposition 3}: If \code{x $\neq$ y} then
+%% \code{xs incl y contains x  =  xs contains x}.
+
+%% \emph{Proof:} See blackboard.
+%% \es
+%% \bsh{Exercise}
+
+%% Say we add a \code{union} function to \code{IntSet}:
+
+%% \begin{lstlisting}
+%% class IntSet { ...
+%%   def union(other: IntSet): IntSet
+%% }
+%% class Expty extends IntSet { ...
+%%   def union(other: IntSet) = other
+%% }
+%% class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
+%%   def union(other: IntSet): IntSet = l union r union other incl x
+%% }
+%% \end{lstlisting}
+
+%% The correctness of \code{union} can be subsumed with the following
+%% law:
+
+%% \emph{Proposition 4}: 
+%% \code{(xs union ys) contains x  =  xs contains x || ys contains x}.
+%% Is that true ? What hypothesis is missing ? Show a counterexample.
+
+%% Show Proposition 4 using structural induction on \code{xs}.
+%% \es
+%% \comment{
+
+%% \emph{Proof:} By induction on \code{xs}.
+
+%% \Case{\code{Empty}}
+
+%% \Case{\code{NonEmpty(x, l, r)}}
+
+%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+
+%% \begin{lstlisting}
+%%     \= (Empty union ys) contains x 
+%%  =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
+%%         \> ys contains x
+%%  =      \> $\expl{Boolean algebra}$
+%%         \> false || ys contains x
+%%  =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
+%%         \> (Empty contains x) || (ys contains x)
+%% \end{lstlisting}
+
+%% \begin{lstlisting}
+%%     \= (NonEmpty(x, l, r) union ys) contains x
+%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+%%         \> (l union r union ys incl x) contains x
+%%  =      \> $\expl{by Proposition 2}$
+%%         \> true
+%%  =      \> $\expl{Boolean algebra}$
+%%         \> true || (ys contains x)
+%%  =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
+%%         \> (NonEmpty(x, l, r) contains x) || (ys contains x)
+%% \end{lstlisting}
+
+%% \begin{lstlisting}
+%%     \= (NonEmpty(y, l, r) union ys) contains x
+%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+%%         \> (l union r union ys incl y) contains x
+%%  =      \> $\expl{by Proposition 3}$
+%%         \> (l union r union ys) contains x
+%%  =      \> $\expl{by the induction hypothesis}$
+%%         \> ((l union r) contains x) || (ys contains x)
+%%  =      \> $\expl{by Proposition 3}$
+%%         \> ((l union r incl y) contains x) || (ys contains x)
+%% \end{lstlisting}
+
+%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+%%  ... is analogous.
+
+%% \es
+%% }}
+%% \chapter{\label{sec:for-notation}For-Comprehensions}
+
+%% The last chapter demonstrated that higher-order functions such as
+%% \verb@map@, \verb@flatMap@, \verb@filter@ provide powerful
+%% constructions for dealing with lists.  But sometimes the level of
+%% abstraction required by these functions makes a program hard to
+%% understand.
+
+%% To help understandability, Scala has a special notation which
+%% simplifies common patterns of applications of higher-order functions.
+%% This notation builds a bridge between set-comprehensions in
+%% mathematics and for-loops in imperative languages such as C or
+%% Java. It also closely resembles the query notation of relational
+%% databases.
+
+%% As a first example, say we are given a list \code{persons} of persons
+%% with \code{name} and \code{age} fields.  To print the names of all
+%% persons in the sequence which are aged over 20, one can write:
+%% \begin{lstlisting}
+%% for (p <- persons if p.age > 20) yield p.name
+%% \end{lstlisting}
+%% This is equivalent to the following expression , which uses
+%% higher-order functions \code{filter} and \code{map}:
+%% \begin{lstlisting}
+%% persons filter (p => p.age > 20) map (p => p.name)
+%% \end{lstlisting}
+%% The for-comprehension looks a bit like a for-loop in imperative languages,
+%% except that it constructs a list of the results of all iterations.
+
+%% Generally, a for-comprehension is of the form
+%% \begin{lstlisting}
+%% for ( $s$ ) yield $e$
+%% \end{lstlisting}
+%% Here, $s$ is a sequence of {\em generators}, {\em definitions} and
+%% {\em filters}.  A {\em generator} is of the form \code{val x <- e},
+%% where \code{e} is a list-valued expression. It binds \code{x} to
+%% successive values in the list.  A {\em definition} is of the form
+%% \code{val x = e}. It introduces \code{x} as a name for the value of
+%% \code{e} in the rest of the comprehension. A {\em filter} is an
+%% expression \code{f} of type \code{Boolean}.  It omits from
+%% consideration all bindings for which \code{f} is \code{false}.  The
+%% sequence $s$ starts in each case with a generator.  If there are
+%% several generators in a sequence, later generators vary more rapidly
+%% than earlier ones.
+
+%% The sequence $s$ may also be enclosed in braces instead of
+%% parentheses, in which case the semicolons between generators,
+%% definitions and filters can be omitted.
+
+%% Here are two examples that show how for-comprehensions are used.
+%% First, let's redo an example of the previous chapter: Given a positive
+%% integer $n$, find all pairs of positive integers $i$ and $j$, where $1
+%% \leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
+%% this problem is solved as follows:
+%% \begin{lstlisting}
+%% for { i <- List.range(1, n)
+%%       j <- List.range(1, i)
+%%       if isPrime(i+j) } yield {i, j}
+%% \end{lstlisting}
+%% This is arguably much clearer than the solution using \code{map},
+%% \code{flatMap} and \code{filter} that we have developed previously.
+
+%% As a second example, consider computing the scalar product of two
+%% vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
+%% be written as follows.
+%% \begin{lstlisting}
+%%   sum(for ((x, y) <- xs zip ys) yield x * y)
+%% \end{lstlisting}
+
+%% \section{The N-Queens Problem}
+
+%% For-comprehensions are especially useful for solving combinatorial
+%% puzzles. An example of such a puzzle is the 8-queens problem: Given a
+%% standard chess-board, place 8 queens such that no queen is in check from any
+%% other (a queen can check another piece if they are on the same
+%% column, row, or diagonal). We will now develop a solution to this
+%% problem, generalizing it to chess-boards of arbitrary size. Hence, the
+%% problem is to place $n$ queens on a chess-board of size $n \times n$.
+
+%% To solve this problem, note that we need to place a queen in each row.
+%% So we could place queens in successive rows, each time checking that a
+%% newly placed queen is not in check from any other queens that have
+%% already been placed. In the course of this search, it might arrive
+%% that a queen to be placed in row $k$ would be in check in all fields
+%% of that row from queens in row $1$ to $k-1$. In that case, we need to
+%% abort that part of the search in order to continue with a different
+%% configuration of queens in columns $1$ to $k-1$.
+
+%% This suggests a recursive algorithm.  Assume that we have already
+%% generated all solutions of placing $k-1$ queens on a board of size $n
+%% \times n$. We can represent each such solution by a list of length
+%% $k-1$ of column numbers (which can range from $1$ to $n$).  We treat
+%% these partial solution lists as stacks, where the column number of the
+%% queen in row $k-1$ comes first in the list, followed by the column
+%% number of the queen in row $k-2$, etc. The bottom of the stack is the
+%% column number of the queen placed in the first row of the board.  All
+%% solutions together are then represented as a list of lists, with one
+%% element for each solution.
+
+%% Now, to place the $k$'the queen, we generate all possible extensions
+%% of each previous solution by one more queen. This yields another list
+%% of solution lists, this time of length $k$. We continue the process
+%% until we have reached solutions of the size of the chess-board $n$.
+%% This algorithmic idea is embodied in function \code{placeQueens} below:
+%% \begin{lstlisting}
+%% def queens(n: Int): List[List[Int]] = {
+%%   def placeQueens(k: Int): List[List[Int]] =
+%%     if (k == 0) List(List())
+%%     else for { queens <- placeQueens(k - 1)
+%%                column <- List.range(1, n + 1)
+%%                if isSafe(column, queens, 1) } yield column :: queens
+%%   placeQueens(n)
+%% }
+%% \end{lstlisting}
+
+%% \begin{exercise} Write the function
+%% \begin{lstlisting}
+%%   def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
+%% \end{lstlisting}
+%% which tests whether a queen in the given column \verb@col@ is safe with 
+%% respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
+%% placed and the row of the first queen in the list.
+%% \end{exercise}
+
+%% \section{Querying with For-Comprehensions}
+
+%% The for-notation is essentially equivalent to common operations of
+%% database query languages.  For instance, say we are given a 
+%% database \code{books}, represented as a list of books, where
+%% \code{Book} is defined as follows.
+%% \begin{lstlisting}
+%% case class Book(title: String, authors: List[String])
+%% \end{lstlisting}
+%% Here is a small example database:
+%% \begin{lstlisting}
+%% val books: List[Book] = List(
+%%   Book("Structure and Interpretation of Computer Programs",
+%%        List("Abelson, Harold", "Sussman, Gerald J.")),
+%%   Book("Principles of Compiler Design",
+%%        List("Aho, Alfred", "Ullman, Jeffrey")),
+%%   Book("Programming in Modula-2",
+%%        List("Wirth, Niklaus")),
+%%   Book("Introduction to Functional Programming"),
+%%        List("Bird, Richard")),
+%%   Book("The Java Language Specification",
+%%        List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
+%% \end{lstlisting}
+%% Then, to find the titles of all books whose author's last name is ``Ullman'':
+%% \begin{lstlisting}
+%% for (b <- books; a <- b.authors if a startsWith "Ullman")
+%% yield b.title
+%% \end{lstlisting}
+%% (Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
+%% to find the titles of all books that have the string ``Program'' in
+%% their title:
+%% \begin{lstlisting}
+%% for (b <- books if (b.title indexOf "Program") >= 0)
+%% yield b.title
+%% \end{lstlisting}
+%% Or, to find the names of all authors that have written at least two
+%% books in the database.
+%% \begin{lstlisting}
+%% for (b1 <- books; b2 <- books if b1 != b2;
+%%      a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
+%% yield a1
+%% \end{lstlisting}
+%% The last solution is not yet perfect, because authors will appear
+%% several times in the list of results.  We still need to remove
+%% duplicate authors from result lists.  This can be achieved with the
+%% following function.
+%% \begin{lstlisting}
+%% def removeDuplicates[A](xs: List[A]): List[A] =
+%%   if (xs.isEmpty) xs
+%%   else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
+%% \end{lstlisting}
+%% Note that the last expression in method \code{removeDuplicates}
+%% can be equivalently expressed using a for-comprehension.
+%% \begin{lstlisting}
+%% xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
+%% \end{lstlisting}
+
+%% \section{Translation of For-Comprehensions}
+
+%% Every for-comprehension can be expressed in terms of the three
+%% higher-order functions \code{map}, \code{flatMap} and \code{filter}.
+%% Here is the translation scheme, which is also used by the Scala compiler.
+%% \begin{itemize}
+%% \item
+%% A simple for-comprehension
+%% \begin{lstlisting}
+%% for (x <- e) yield e'
+%% \end{lstlisting}
+%% is translated to
+%% \begin{lstlisting}
+%% e.map(x => e')
+%% \end{lstlisting}
+%% \item
+%% A for-comprehension
+%% \begin{lstlisting}
+%% for (x <- e if f; s) yield e'
+%% \end{lstlisting}
+%% where \code{f} is a filter and \code{s} is a (possibly empty)
+%% sequence of generators or filters
+%% is translated to
+%% \begin{lstlisting}
+%% for (x <- e.filter(x => f); s) yield e'
+%% \end{lstlisting}
+%% and then translation continues with the latter expression.
+%% \item
+%% A for-comprehension
+%% \begin{lstlisting}
+%% for (x <- e; y <- e'; s) yield e''
+%% \end{lstlisting}
+%% where \code{s} is a (possibly empty)
+%% sequence of generators or filters
+%% is translated to
+%% \begin{lstlisting}
+%% e.flatMap(x => for (y <- e'; s) yield e'')
+%% \end{lstlisting}
+%% and then translation continues with the latter expression.
+%% \end{itemize}
+%% For instance, taking our "pairs of integers whose sum is prime" example:
+%% \begin{lstlisting}
+%% for { i <- range(1, n)
+%%       j <- range(1, i)
+%%       if isPrime(i+j)
+%% } yield {i, j}
+%% \end{lstlisting}
+%% Here is what we get when we translate this expression:
+%% \begin{lstlisting}
+%% range(1, n)
+%%   .flatMap(i =>
+%%     range(1, i)
+%%       .filter(j => isPrime(i+j))
+%%       .map(j => (i, j)))
+%% \end{lstlisting}
+
+%% Conversely, it would also be possible to express functions \code{map},
+%% \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
+%% three functions again, this time implemented using for-comprehensions.
+%% \begin{lstlisting}
+%% object Demo {
+%%   def map[A, B](xs: List[A], f: A => B): List[B] =
+%%     for (x <- xs) yield f(x)
+
+%%   def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
+%%     for (x <- xs; y <- f(x)) yield y
+
+%%   def filter[A](xs: List[A], p: A => Boolean): List[A] =
+%%     for (x <- xs if p(x)) yield x
+%% }
+%% \end{lstlisting}
+%% Not surprisingly, the translation of the for-comprehension in the body of
+%% \code{Demo.map} will produce a call to \code{map} in class \code{List}.
+%% Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
+%% \code{flatMap} and \code{filter} in class \code{List}.
+
+%% \begin{exercise}
+%% Define the following function in terms of \code{for}.
+%% \begin{lstlisting}
+%% def flatten[A](xss: List[List[A]]): List[A] =
+%%   (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \begin{exercise}
+%% Translate
+%% \begin{lstlisting}
+%% for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
+%% for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
+%% \end{lstlisting}
+%% to higher-order functions.
+%% \end{exercise}
+
+%% \section{For-Loops}\label{sec:for-loops}
+
+%% For-comprehensions resemble for-loops in imperative languages, except
+%% that they produce a list of results. Sometimes, a list of results is
+%% not needed but we would still like the flexibility of generators and
+%% filters in iterations over lists. This is made possible by a variant
+%% of the for-comprehension syntax, which expresses for-loops:
+%% \begin{lstlisting}
+%% for ( $s$ ) $e$
+%% \end{lstlisting}
+%% This construct is the same as the standard for-comprehension syntax
+%% except that the keyword \code{yield} is missing. The for-loop is
+%% executed by executing the expression $e$ for each element generated
+%% from the sequence of generators and filters $s$.
+
+%% As an example, the following expression prints out all elements of a
+%% matrix represented as a list of lists:
+%%  \begin{lstlisting}
+%% for (xs <- xss) {
+%%   for (x <- xs) print(x + "\t")
+%%   println()
+%% }
+%% \end{lstlisting}
+%% The translation of for-loops to higher-order methods of class
+%% \code{List} is similar to the translation of for-comprehensions, but
+%% is simpler. Where for-comprehensions translate to \code{map} and
+%% \code{flatMap}, for-loops translate in each case to \code{foreach}.
+
+%% \section{Generalizing For}
+
+%% We have seen that the translation of for-comprehensions only relies on
+%% the presence of methods \code{map}, \code{flatMap}, and
+%% \code{filter}. Therefore it is possible to apply the same notation to
+%% generators that produce objects other than lists; these objects only
+%% have to support the three key functions \code{map}, \code{flatMap},
+%% and \code{filter}.
+
+%% The standard Scala library has several other abstractions that support
+%% these three methods and with them support for-comprehensions. We will
+%% encounter some of them in the following chapters. As a programmer you
+%% can also use this principle to enable for-comprehensions for types you
+%% define -- these types just need to support methods \code{map},
+%% \code{flatMap}, and \code{filter}.
+
+%% There are many examples where this is useful: Examples are database
+%% interfaces, XML trees, or optional values. 
+
+%% One caveat: It is not assured automatically that the result
+%% translating a for-comprehension is well-typed. To ensure this, the
+%% types of \code{map}, \code{flatMap} and \code{filter} have to be
+%% essentially similar to the types of these methods in class \code{List}.
+
+%% To make this precise, assume you have a parameterized class
+%%  \code{C[A]} for which you want to enable for-comprehensions. Then
+%%  \code{C} should define \code{map}, \code{flatMap} and \code{filter}
+%%  with the following types:
+%% \begin{lstlisting}
+%% def map[B](f: A => B): C[B]
+%% def flatMap[B](f: A => C[B]): C[B]
+%% def filter(p: A => Boolean): C[A]
+%% \end{lstlisting}
+%% It would be attractive to enforce these types statically in the Scala
+%% compiler, for instance by requiring that any type supporting
+%% for-comprehensions implements a standard trait with these methods
+%% \footnote{In the programming language Haskell, which has similar
+%% constructs, this abstraction is called a ``monad with zero''}.  The
+%% problem is that such a standard trait would have to abstract over the
+%% identity of the class \code{C}, for instance by taking \code{C} as a
+%% type parameter.  Note that this parameter would be a type constructor,
+%% which gets applied to {\em several different} types in the signatures of
+%% methods \code{map} and \code{flatMap}. Unfortunately, the Scala type
+%% system is too weak to express this construct, since it can handle only
+%% type parameters which are fully applied types.
+
+%% \chapter{Mutable State}
+
+%% Most programs we have presented so far did not have side-effects
+%% \footnote{We ignore here the fact that some of our program printed to
+%% standard output, which technically is a side effect.}.  Therefore, the
+%% notion of {\em time} did not matter.  For a program that terminates,
+%% any sequence of actions would have led to the same result!  This is
+%% also reflected by the substitution model of computation, where a
+%% rewrite step can be applied anywhere in a term, and all rewritings
+%% that terminate lead to the same solution.  In fact, this {\em
+%% confluence} property is a deep result in $\lambda$-calculus, the
+%% theory underlying functional programming. 
+
+%% In this chapter, we introduce functions with side effects and study
+%% their behavior. We will see that as a consequence we have to
+%% fundamentally modify up the substitution model of computation which we
+%% employed so far.
+
+%% \section{Stateful Objects}
+
+%% We normally view the world as a set of objects, some of which have
+%% state that {\em changes} over time.  Normally, state is associated
+%% with a set of variables that can be changed in the course of a
+%% computation.  There is also a more abstract notion of state, which
+%% does not refer to particular constructs of a programming language: An
+%% object {\em has state} (or: {\em is stateful}) if its behavior is
+%% influenced by its history.
+
+%% For instance, a bank account object has state, because the question
+%% ``can I withdraw 100 CHF?''
+%% might have different answers during the lifetime of the account.
+
+%% In Scala, all mutable state is ultimately built from variables.  A
+%% variable definition is written like a value definition, but starts
+%% with \verb@var@ instead of \verb@val@. For instance, the following two
+%% definitions introduce and initialize two variables \code{x} and
+%% \code{count}.
+%% \begin{lstlisting}
+%% var x: String = "abc"
+%% var count = 111
+%% \end{lstlisting}
+%% Like a value definition, a variable definition associates a name with
+%% a value. But in the case of a variable definition, this association
+%% may be changed later by an assignment.  Such assignments are written
+%% as in C or Java. Examples:
+%% \begin{lstlisting}
+%% x = "hello"
+%% count = count + 1
+%% \end{lstlisting}
+%% In Scala, every defined variable has to be initialized at the point of
+%% its definition. For instance, the statement ~\code{var x: Int;}~ is
+%% {\em not} regarded as a variable definition, because the initializer
+%% is missing\footnote{If a statement like this appears in a class, it is
+%% instead regarded as a variable declaration, which introduces
+%% abstract access methods for the variable, but does not associate these
+%% methods with a piece of state.}. If one does not know, or does not
+%% care about, the appropriate initializer, one can use a wildcard
+%% instead. I.e.
+%% \begin{lstlisting}
+%% val x: T = _
+%% \end{lstlisting}
+%% will initialize \code{x} to some default value (\code{null} for
+%% reference types, \code{false} for booleans, and the appropriate
+%% version of \code{0} for numeric value types).
+
+%% Real-world objects with state are represented in Scala by objects that
+%% have variables as members. For instance, here is a class that
+%% represents bank accounts.
+%% \begin{lstlisting}
+%% class BankAccount {
+%%   private var balance = 0
+%%   def deposit(amount: Int) {
+%%     if (amount > 0) balance += amount
+%%   }
+
+%%   def withdraw(amount: Int): Int =
+%%     if (0 < amount && amount <= balance) {
+%%       balance -= amount
+%%       balance
+%%     } else error("insufficient funds")
+%% }
+%% \end{lstlisting}
+%% The class defines a variable \code{balance} which contains the current
+%% balance of an account. Methods \code{deposit} and \code{withdraw}
+%% change the value of this variable through assignments.  Note that
+%% \code{balance} is \code{private} in class \code{BankAccount} -- hence
+%% it can not be accessed directly outside the class.
+
+%% To create bank-accounts, we use the usual object creation notation:
+%% \begin{lstlisting}
+%% val myAccount = new BankAccount
+%% \end{lstlisting}
+
+%% \example Here is a \code{scalaint} session that deals with bank
+%% accounts.
+
+%% \begin{lstlisting}
+%% scala> :l bankaccount.scala
+%% Loading bankaccount.scala...
+%% defined class BankAccount
+%% scala> val account = new BankAccount
+%% account: BankAccount = BankAccount$\Dollar$class@1797795
+%% scala> account deposit 50
+%% unnamed0: Unit = ()
+%% scala> account withdraw 20
+%% unnamed1: Int = 30
+%% scala> account withdraw 20
+%% unnamed2: Int = 10
+%% scala> account withdraw 15
+%% java.lang.Error: insufficient funds
+%%         at scala.Predef$\Dollar$error(Predef.scala:74)
+%%         at BankAccount$\Dollar$class.withdraw(<console>:14)
+%%         at <init>(<console>:5)
+%% scala> 
+%% \end{lstlisting}
+%% The example shows that applying the same operation (\code{withdraw
+%% 20}) twice to an account yields different results. So, clearly,
+%% accounts are stateful objects.  
+
+%% \paragraph{Sameness and Change}
+%% Assignments pose new problems in deciding when two expressions are
+%% ``the same''.
+%% If assignments are excluded, and one writes
+%% \begin{lstlisting}
+%% val x = E; val y = E
+%% \end{lstlisting}
+%% where \code{E} is some arbitrary expression,
+%% then \code{x} and \code{y} can reasonably be assumed to be the same.
+%% I.e. one could have equivalently written
+%% \begin{lstlisting}
+%% val x = E; val y = x
+%% \end{lstlisting}
+%% (This property is usually called {\em referential transparency}). But
+%% once we admit assignments, the two definition sequences are different.
+%% Consider:
+%% \begin{lstlisting}
+%% val x = new BankAccount; val y = new BankAccount
+%% \end{lstlisting}
+%% To answer the question whether \code{x} and \code{y} are the same, we
+%% need to be more precise what ``sameness'' means. This meaning is
+%% captured in the notion of {\em operational equivalence}, which,
+%% somewhat informally, is stated as follows.
+
+%% Suppose we have two definitions of \code{x} and \code{y}.
+%% To test whether \code{x} and \code{y} define the same value, proceed
+%% as follows.
+%% \begin{itemize}
+%% \item
+%% Execute the definitions followed by an
+%% arbitrary sequence \code{S} of operations that involve \code{x} and
+%% \code{y}. Observe the results (if any).
+%% \item
+%% Then, execute the definitions with another sequence \code{S'} which
+%% results from \code{S} by renaming all occurrences of \code{y} in
+%% \code{S} to \code{x}.
+%% \item
+%% If the results of running \code{S'} are different, then surely
+%% \code{x} and \code{y} are different.
+%% \item
+%% On the other hand, if all possible pairs of sequences \lstinline@{S, S'}@
+%% yield the same results, then \code{x} and \code{y} are the same.
+%% \end{itemize}
+%% In other words, operational equivalence regards two definitions
+%% \code{x} and \code{y} as defining the same value, if no possible
+%% experiment can distinguish between \code{x} and \code{y}. An
+%% experiment in this context are two version of an arbitrary program which use either
+%% \code{x} or \code{y}.
  
-Given this definition, let's test whether
-\begin{lstlisting}
-val x = new BankAccount; val y = new BankAccount
-\end{lstlisting}
-defines values \code{x} and \code{y} which are the same.
-Here are the definitions again, followed by a test sequence:
-
-\begin{lstlisting}
-> val x = new BankAccount
-> val y = new BankAccount
-> x deposit 30
-30
-> y withdraw 20
-java.lang.RuntimeException: insufficient funds
-\end{lstlisting}
-
-Now, rename all occurrences of \code{y} in that sequence to
-\code{x}. We get:
-\begin{lstlisting}
-> val x = new BankAccount
-> val y = new BankAccount
-> x deposit 30
-30
-> x withdraw 20
-10
-\end{lstlisting}
-Since the final results are different, we have established that
-\code{x} and \code{y} are not the same.
-On the other hand, if we define
-\begin{lstlisting}
-val x = new BankAccount; val y = x
-\end{lstlisting}
-then no sequence of operations can distinguish between \code{x} and
-\code{y}, so \code{x} and \code{y} are the same in this case.
-
-\paragraph{Assignment and the Substitution Model}
-These examples show that our previous substitution model of
-computation cannot be used anymore.  After all, under this
-model we could always replace a value name by its
-defining expression.
-For instance in
-\begin{lstlisting}
-val x = new BankAccount; val y = x
-\end{lstlisting}
-the \code{x} in the definition of \code{y} could
-be replaced by \code{new BankAccount}.
-But we have seen that this change leads to a different program.
-So the substitution model must be invalid, once we add assignments. 
-
-\section{Imperative Control Structures}
-
-Scala has the \code{while} and \code{do-while} loop constructs known
-from the C and Java languages. There is also a single branch \code{if}
-which leaves out the else-part as well as a \code{return} statement which
-aborts a function prematurely. This makes it possible to program in a
-conventional imperative style. For instance, the following function,
-which computes the \code{n}'th power of a given parameter \code{x}, is
-implemented using \code{while} and single-branch \code{if}.
-\begin{lstlisting}
-def power(x: Double, n: Int): Double = {
-  var r = 1.0
-  var i = n
-  var j = 0
-  while (j < 32) {
-    r = r * r
-    if (i < 0)
-      r *= x
-    i = i << 1
-    j += 1
-  }
-  r
-}
-\end{lstlisting}
-These imperative control constructs are in the language for
-convenience. They could have been left out, as the same constructs can
-be implemented using just functions. As an example, let's develop a
-functional implementation of the while loop. \code{whileLoop} should
-be a function that takes two parameters: a condition, of type
-\code{Boolean}, and a command, of type \code{Unit}. Both condition and
-command need to be passed by-name, so that they are evaluated
-repeatedly for each loop iteration.  This leads to the following
-definition of \code{whileLoop}.
-\begin{lstlisting}
-def whileLoop(condition: => Boolean)(command: => Unit) {
-  if (condition) {
-    command; whileLoop(condition)(command)
-  } else ()
-}
-\end{lstlisting}
-Note that \code{whileLoop} is tail recursive, so it operates in
-constant stack space.
-
-\begin{exercise} Write a function \code{repeatLoop}, which should be 
-applied as follows:
-\begin{lstlisting}
-repeatLoop { command } ( condition )
-\end{lstlisting}
-Is there also a way to obtain a loop syntax like the following?
-\begin{lstlisting}
-repeatLoop { command } until ( condition )
-\end{lstlisting}
-\end{exercise}
-
-Some other control constructs known from C and Java are missing in
-Scala: There are no \code{break} and \code{continue} jumps for loops.
-There are also no for-loops in the Java sense -- these have been
-replaced by the more general for-loop construct discussed in
-Section~\ref{sec:for-loops}.
-
-\section{Extended Example: Discrete Event Simulation}
-
-We now discuss an example that demonstrates how assignments and
-higher-order functions can be combined in interesting ways.  
-We will build a simulator for digital circuits.
-
-The example is taken from Abelson and Sussman's book
-\cite{abelson-sussman:structure}. We augment their basic (Scheme-)
-code by an object-oriented structure which allows code-reuse through
-inheritance. The example also shows how discrete event simulation programs
-in general are structured and built.
-
-We start with a little language to describe digital circuits.
-A digital circuit is built from {\em wires} and {\em function boxes}.
-Wires carry signals which are transformed by function boxes.
-We will represent signals by the booleans \code{true} and
-\code{false}.
-
-Basic function boxes (or: {\em gates}) are:
-\begin{itemize}
-\item An \emph{inverter}, which negates its signal
-\item An \emph{and-gate}, which sets its output to the conjunction of its input.
-\item An \emph{or-gate}, which sets its output to the disjunction of its
-input.
-\end{itemize}
-Other function boxes can be built by combining basic ones.
-
-Gates have {\em delays}, so an output of a gate will change only some
-time after its inputs change.
-
-\paragraph{A Language for Digital Circuits}
-
-We describe the elements of a digital circuit by the following set of
-Scala classes and functions.
-
-First, there is a class \code{Wire} for wires.
-We can construct wires as follows.
-\begin{lstlisting}
-val a = new Wire
-val b = new Wire
-val c = new Wire
-\end{lstlisting}
-Second, there are procedures
-\begin{lstlisting}
-def inverter(input: Wire, output: Wire)
-def andGate(a1: Wire, a2: Wire, output: Wire)
-def orGate(o1: Wire, o2: Wire, output: Wire)
-\end{lstlisting}
-which ``make'' the basic gates we need (as side-effects).
-More complicated function boxes can now be built from these.
-For instance, to construct a half-adder, we can define:
-\begin{lstlisting}
-  def halfAdder(a: Wire, b: Wire, s: Wire, c: Wire) {
-    val d = new Wire
-    val e = new Wire
-    orGate(a, b, d)
-    andGate(a, b, c)
-    inverter(c, e)
-    andGate(d, e, s)
-  }
-\end{lstlisting}
-This abstraction can itself be used, for instance in defining a full
-adder:
-\begin{lstlisting}
-  def fullAdder(a: Wire, b: Wire, cin: Wire, sum: Wire, cout: Wire) {
-    val s = new Wire
-    val c1 = new Wire
-    val c2 = new Wire
-    halfAdder(a, cin, s, c1)
-    halfAdder(b, s, sum, c2)
-    orGate(c1, c2, cout)
-  }
-\end{lstlisting}
-Class \code{Wire} and functions \code{inverter}, \code{andGate}, and
-\code{orGate} represent thus a little language in which users can
-define digital circuits.  We now give implementations of this class
-and these functions, which allow one to simulate circuits.
-These implementations are based on a simple and general API for
-discrete event simulation.
-
-\paragraph{The Simulation API}
-
-Discrete event simulation performs user-defined \emph{actions} at
-specified \emph{times}.  
-An {\em action} is represented as a function which takes no parameters and
-returns a \code{Unit} result:
-\begin{lstlisting}
-type Action = () => Unit
-\end{lstlisting}
-The \emph{time} is simulated; it is not the actual ``wall-clock'' time.
-
-A concrete simulation will be done inside an object which inherits
-from the abstract \code{Simulation} class. This class has the following
-signature:
-
-\begin{lstlisting}
-abstract class Simulation {
-  def currentTime: Int
-  def afterDelay(delay: Int, action: => Action)
-  def run()
-}
-\end{lstlisting}
-Here,
-\code{currentTime} returns the current simulated time as an integer
-number,
-\code{afterDelay} schedules an action to be performed at a specified
-delay after \code{currentTime}, and
-\code{run} runs the simulation until there are no further actions to be 
-performed.
-
-\paragraph{The Wire Class}
-A wire needs to support three basic actions.
-\begin{itemize}
-\item[]
-\code{getSignal: Boolean}~~ returns the current signal on the wire.
-\item[]
-\code{setSignal(sig: Boolean)}~~ sets the wire's signal to \code{sig}.
-\item[]
-\code{addAction(p: Action)}~~ attaches the specified procedure
-\code{p} to the {\em actions} of the wire. All attached action
-procedures will be executed every time the signal of a wire changes.
-\end{itemize}
-Here is an implementation of the \code{Wire} class:
-\begin{lstlisting}
-class Wire {
-  private var sigVal = false
-  private var actions: List[Action] = List()
-  def getSignal = sigVal
-  def setSignal(s: Boolean) =
-    if (s != sigVal) {
-      sigVal = s
-      actions.foreach(action => action())
-    }
-  def addAction(a: Action) {
-    actions = a :: actions; a()
-  }
-}
-\end{lstlisting}
-Two private variables make up the state of a wire.  The variable
-\code{sigVal} represents the current signal, and the variable
-\code{actions} represents the action procedures currently attached to
-the wire.
-
-\paragraph{The Inverter Class}
-We implement an inverter by installing an action on its input wire,
-namely the action which puts the negated input signal onto the output
-signal.  The action needs to take effect at \code{InverterDelay}
-simulated time units after the input changes. This suggests the 
-following implementation:
-\begin{lstlisting}
-def inverter(input: Wire, output: Wire) {
-  def invertAction() {
-    val inputSig = input.getSignal
-    afterDelay(InverterDelay) { output setSignal !inputSig }
-  }
-  input addAction invertAction
-}
-\end{lstlisting}
-
-\paragraph{The And-Gate Class}
-And-gates are implemented analogously to inverters.  The action of an
-\code{andGate} is to output the conjunction of its input signals.
-This should happen at \code{AndGateDelay} simulated time units after
-any one of its two inputs changes. Hence, the following implementation:
-\begin{lstlisting}
-def andGate(a1: Wire, a2: Wire, output: Wire) {
-  def andAction() {
-    val a1Sig = a1.getSignal
-    val a2Sig = a2.getSignal
-    afterDelay(AndGateDelay) { output setSignal (a1Sig & a2Sig) }
-  }
-  a1 addAction andAction
-  a2 addAction andAction
-}
-\end{lstlisting}
-
-\begin{exercise} Write the implementation of \code{orGate}.
-\end{exercise}
-
-\begin{exercise} Another way is to define an or-gate by a combination of
-inverters and and gates. Define a function \code{orGate} in terms of
-\code{andGate} and \code{inverter}. What is the delay time of this function?
-\end{exercise}
-
-\paragraph{The Simulation Class}
-
-Now, we just need to implement class \code{Simulation}, and we are
-done.  The idea is that we maintain inside a \code{Simulation} object
-an \emph{agenda} of actions to perform.  The agenda is represented as
-a list of pairs of actions and the times they need to be run.  The
-agenda list is sorted, so that earlier actions come before later ones.
-\begin{lstlisting} 
-abstract class Simulation {
-  case class WorkItem(time: Int, action: Action)
-  private type Agenda = List[WorkItem]
-  private var agenda: Agenda = List()
-\end{lstlisting}
-There is also a private variable \code{curtime} to keep track of the
-current simulated time.
-\begin{lstlisting}
-  private var curtime = 0
-\end{lstlisting}
-An application of the method \code{afterDelay(delay, block)} 
-inserts the element \lstinline@WorkItem(currentTime + delay, () => block)@
-into the \code{agenda} list at the appropriate place.
-\begin{lstlisting}
-private def insert(ag: Agenda, item: WorkItem): Agenda =
-  if (ag.isEmpty || item.time < ag.head.time) item :: ag
-  else ag.head :: insert(ag.tail, item)
-
-def afterDelay(delay: Int)(block: => Unit) {
-  val item = WorkItem(currentTime + delay, () => block)
-  agenda = insert(agenda, item)
-}
-\end{lstlisting}
-An application of the \code{run} method removes successive elements
-from the \code{agenda} and performs their actions.
-It continues until the agenda is empty:
-\begin{lstlisting}
-private def next() {
-  agenda match {
-    case WorkItem(time, action) :: rest =>
-      agenda = rest; curtime = time; action()
-    case List() =>
-  }
-}
-
-def run() {
-  afterDelay(0) { println("*** simulation started ***") }
-  while (!agenda.isEmpty) next()
-}
-\end{lstlisting}
-
-\paragraph{Running the Simulator}
-To run the simulator, we still need a way to inspect changes of
-signals on wires. To this purpose, we write a function \code{probe}.
-\begin{lstlisting}
-def probe(name: String, wire: Wire) {
-  wire addAction { () =>
-    println(name + " " + currentTime + " new_value = " + wire.getSignal)
-  }
-}
-\end{lstlisting}
-Now, to see the simulator in action, let's define four wires, and place
-probes on two of them: 
-\begin{lstlisting}
-scala> val input1, input2, sum, carry = new Wire
-
-scala> probe("sum", sum)
-sum 0 new_value = false
-
-scala> probe("carry", carry)
-carry 0 new_value = false
-\end{lstlisting}
-Now let's define a half-adder connecting the wires:
-\begin{lstlisting}
-scala> halfAdder(input1, input2, sum, carry)
-\end{lstlisting}
-Finally, set one after another the signals on the two input wires to
-\code{true} and run the simulation.
-\begin{lstlisting}
-scala> input1 setSignal true; run
-*** simulation started ***
-sum 8 new_value = true
-
-scala> input2 setSignal true; run
-carry 11 new_value = true
-sum 15 new_value = false
-\end{lstlisting}
-
-\section{Summary}
-
-We have seen in this chapter the constructs that let us model state in
-Scala -- these are variables, assignments, and imperative control
-structures.  State and Assignment complicate our mental model of
-computation.  In particular, referential transparency is lost.  On the
-other hand, assignment gives us new ways to formulate programs
-elegantly. As always, it depends on the situation whether purely
-functional programming or programming with assignments works best.
-
-\chapter{Computing with Streams}
-
-The previous chapters have introduced variables, assignment and
-stateful objects.  We have seen how real-world objects that change
-with time can be modeled by changing the state of variables in a
-computation.  Time changes in the real world thus are modeled by time
-changes in program execution. Of course, such time changes are usually
-stretched out or compressed, but their relative order is the same.
-This seems quite natural, but there is a also price to pay: Our simple
-and powerful substitution model for functional computation is no
-longer applicable once we introduce variables and assignment.
-
-Is there another way? Can we model state change in the real world
-using only immutable functions? Taking mathematics as a guide, the
-answer is clearly yes: A time-changing quantity is simply modeled by
-a function \code{f(t)} with a time parameter \code{t}. The same can be
-done in computation. Instead of overwriting a variable with successive
-values, we represent all these values as successive elements in a
-list. So, a mutable variable \code{var x: T} gets replaced by an
-immutable value \code{val x: List[T]}. In a sense, we trade space for
-time -- the different values of the variable now all exist concurrently
-as different elements of the list.  One advantage of the list-based
-view is that we can ``time-travel'', i.e. view several successive
-values of the variable at the same time. Another advantage is that we
-can make use of the powerful library of list processing functions,
-which often simplifies computation. For instance, consider the
-imperative way to compute the sum of all prime numbers in an interval:
-\begin{lstlisting}
-def sumPrimes(start: Int, end: Int): Int = {
-  var i = start
-  var acc = 0
-  while (i < end) {
-    if (isPrime(i)) acc += i
-    i += 1
-  }
-  acc
-}
-\end{lstlisting}
-Note that the variable \code{i} ``steps through'' all values of the interval
-\code{[start .. end-1]}.
-
-A more functional way is to represent the list of values of variable \code{i} directly as \code{range(start, end)}. Then the function can be rewritten as follows.
-\begin{lstlisting}
-def sumPrimes(start: Int, end: Int) =
-  sum(range(start, end) filter isPrime)
-\end{lstlisting}
-
-No contest which program is shorter and clearer!  However, the
-functional program is also considerably less efficient since it
-constructs a list of all numbers in the interval, and then another one
-for the prime numbers. Even worse from an efficiency point of view is
-the following example:
-
-To find the second prime number between \code{1000} and \code{10000}:
-\begin{lstlisting}
-  range(1000, 10000) filter isPrime at 1
-\end{lstlisting}
-Here, the list of all numbers between \code{1000} and \code{10000} is
-constructed.  But most of that list is never inspected!
-
-However, we can obtain efficient execution for examples like these by
-a trick:
-\begin{quote}
-%\red
- Avoid computing the tail of a sequence unless that tail is actually
-     necessary for the computation.
-\end{quote}
-We define a new class for such sequences, which is called \code{Stream}.
-
-Streams are created using the constant \code{empty} and the constructor \code{cons},
-which are both defined in module \code{scala.Stream}. For instance, the following
-expression constructs a stream with elements \code{1} and \code{2}:
-\begin{lstlisting}
-Stream.cons(1, Stream.cons(2, Stream.empty))
-\end{lstlisting}
-As another example, here is the analogue of \code{List.range},
-but returning a stream instead of a list:
-\begin{lstlisting}
-def range(start: Int, end: Int): Stream[Int] =
-  if (start >= end) Stream.empty
-  else Stream.cons(start, range(start + 1, end))
-\end{lstlisting}
-(This function is also defined as given above in module
-\code{Stream}).  Even though \code{Stream.range} and \code{List.range}
-look similar, their execution behavior is completely different: 
-
-\code{Stream.range} immediately returns with a \code{Stream} object
-whose first element is \code{start}.  All other elements are computed
-only when they are \emph{demanded} by calling the \code{tail} method
-(which might be never at all).  
-
-Streams are accessed just as lists. Similarly to lists, the basic access
-methods are \code{isEmpty}, \code{head} and \code{tail}. For instance,
-we can print all elements of a stream as follows.
-\begin{lstlisting}
-def print(xs: Stream[A]) {
-  if (!xs.isEmpty) { Console.println(xs.head); print(xs.tail) }
-}
-\end{lstlisting}
-Streams also support almost all other methods defined on lists (see
-below for where their methods sets differ). For instance, we can find
-the second prime number between \code{1000} and \code{10000} by applying methods
-\code{filter} and \code{apply} on an interval stream:
-\begin{lstlisting}
-  Stream.range(1000, 10000) filter isPrime at 1
-\end{lstlisting}
-The difference to the previous list-based implementation is that now
-we do not needlessly construct and test for primality any numbers
-beyond 1013.
-
-\paragraph{Consing and appending streams} Two methods in class \code{List}
-which are not supported by class \code{Stream} are \code{::} and
-\code{:::}.  The reason is that these methods are dispatched on their
-right-hand side argument, which means that this argument needs to be
-evaluated before the method is called. For instance, in the case of
-\code{x :: xs} on lists, the tail \code{xs} needs to be evaluated
-before \code{::} can be called and the new list can be constructed.
-This does not work for streams, where we require that the tail of a
-stream should not be evaluated until it is demanded by a \code{tail} operation.
-The argument why list-append \code{:::} cannot be adapted to streams is analogous.
-
-Instead of \code{x :: xs}, one uses \code{Stream.cons(x, xs)} for
-constructing a stream with first element \code{x} and (unevaluated)
-rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
-\code{xs append ys}.  
-
-\chapter{Iterators}
-
-Iterators are the imperative version of streams. Like streams,
-iterators describe potentially infinite lists. However, there is no
-data-structure which contains the elements of an iterator. Instead, 
-iterators allow one to step through the sequence, using two abstract methods \code{next} and \code{hasNext}.
-\begin{lstlisting}
-trait Iterator[+A] {
-  def hasNext: Boolean
-  def next: A
-\end{lstlisting}
-Method \code{next} returns successive elements.  Method \code{hasNext}
-indicates whether there are still more elements to be returned by
-\code{next}. Iterators also support some other methods, which are
-explained later.
-
-As an example, here is an application which prints the squares of all
-numbers from 1 to 100.
-\begin{lstlisting}
-val it: Iterator[Int] = Iterator.range(1, 100)
-while (it.hasNext) {
-  val x = it.next
-  println(x * x)
-}
-\end{lstlisting}
-
-\section{Iterator Methods}
-
-Iterators support a rich set of methods besides \code{next} and
-\code{hasNext}, which is described in the following. Many of these
-methods mimic a corresponding functionality in lists.
-
-\paragraph{Append}
-Method \code{append} constructs an iterator which resumes with the
-given iterator ~\code{it}~ after the current iterator has finished.
-\begin{lstlisting}
-  def append[B >: A](that: Iterator[B]): Iterator[B] = new Iterator[B] {
-    def hasNext = Iterator.this.hasNext || that.hasNext
-    def next = if (Iterator.this.hasNext) Iterator.this.next else that.next
-  }    
-\end{lstlisting}
-The terms \code{Iterator.this.next} and \code{Iterator.this.hasNext}
-in the definition of \code{append} call the corresponding methods as
-they are defined in the enclosing \code{Iterator} class.  If the
-\code{Iterator} prefix to \code{this} would have been missing,
-\code{hasNext} and \code{next} would have called recursively the
-methods being defined in the result of \code{append}, which is not
-what we want.
-
-\paragraph{Map, FlatMap, Foreach} Method \code{map} 
-constructs an iterator which returns all elements of the original
-iterator transformed by a given function \code{f}.
-\begin{lstlisting}
-  def map[B](f: A => B): Iterator[B] = new Iterator[B] {
-    def hasNext = Iterator.this.hasNext
-    def next = f(Iterator.this.next)
-  }
-\end{lstlisting}
-Method \code{flatMap} is like method \code{map}, except that the
-transformation function \code{f} now returns an iterator.
-The result of \code{flatMap} is the iterator resulting from appending
-together all iterators returned from successive calls of \code{f}.
-\begin{lstlisting}
-  def flatMap[B](f: A => Iterator[B]): Iterator[B] = new Iterator[B] {
-    private var cur: Iterator[B] = Iterator.empty
-    def hasNext: Boolean =
-      if (cur.hasNext) true
-      else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); hasNext }
-      else false
-    def next: B =
-      if (cur.hasNext) cur.next
-      else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); next }
-      else error("next on empty iterator")
-  }
-\end{lstlisting}
-Closely related to \code{map} is the \code{foreach} method, which
-applies a given function to all elements of an iterator, but does not
-construct a list of results
-\begin{lstlisting}
-  def foreach(f: A => Unit): Unit =
-    while (hasNext) { f(next) }
-\end{lstlisting}
-
-\paragraph{Filter} Method \code{filter} constructs an iterator which
-returns all elements of the original iterator that satisfy a criterion
-\code{p}.
-\begin{lstlisting}
-  def filter(p: A => Boolean) = new BufferedIterator[A] {
-    private val source =
-      Iterator.this.buffered
-    private def skip =
-      { while (source.hasNext && !p(source.head)) { source.next } }
-    def hasNext: Boolean =
-      { skip; source.hasNext }
-    def next: A =
-      { skip; source.next }
-    def head: A =
-      { skip; source.head }
-  }
-\end{lstlisting}
-In fact, \code{filter} returns instances of a subclass of iterators
-which are ``buffered''.  A \code{BufferedIterator} object is an
-iterator which has in addition a method \code{head}. This method
-returns the element which would otherwise have been returned by
-\code{head}, but does not advance beyond that element. Hence, the
-element returned by \code{head} is returned again by the next call to
-\code{head} or \code{next}. Here is the definition of the
-\code{BufferedIterator} trait.
-\begin{lstlisting}
-trait BufferedIterator[+A] extends Iterator[A] {
-  def head: A
-}
-\end{lstlisting}
-Since \code{map}, \code{flatMap}, \code{filter}, and \code{foreach}
-exist for iterators, it follows that for-comprehensions and for-loops
-can also be used on iterators. For instance, the application which prints the squares of numbers between 1 and 100 could have equivalently been expressed as follows.
-\begin{lstlisting}
-for (i <- Iterator.range(1, 100))
-  println(i * i)
-\end{lstlisting}
-
-\paragraph{Zip} Method \code{zip} takes another iterator and
-returns an iterator consisting of pairs of corresponding elements
-returned by the two iterators.
-\begin{lstlisting}
-  def zip[B](that: Iterator[B]) = new Iterator[(A, B)] {
-    def hasNext = Iterator.this.hasNext && that.hasNext
-    def next = (Iterator.this.next, that.next)
-  }
-}
-\end{lstlisting}
-
-\section{Constructing Iterators}
-
-Concrete iterators need to provide implementations for the two
-abstract methods \code{next} and \code{hasNext} in class
-\code{Iterator}. The simplest iterator is \code{Iterator.empty} which
-always returns an empty sequence:
-\begin{lstlisting}
-object Iterator {
-  object empty extends Iterator[Nothing] {
-    def hasNext = false
-    def next = error("next on empty iterator")
-  }
-\end{lstlisting}
-A more interesting iterator enumerates all elements of an array. This
-iterator is constructed by the \code{fromArray} method, which is also defined in the object \code{Iterator}
-\begin{lstlisting}
-  def fromArray[A](xs: Array[A]) = new Iterator[A] {
-    private var i = 0
-    def hasNext: Boolean =
-      i < xs.length
-    def next: A =
-      if (i < xs.length) { val x = xs(i); i += 1; x }
-      else error("next on empty iterator")
-  }
-\end{lstlisting}
-Another iterator enumerates an integer interval.  The
-\code{Iterator.range} function returns an iterator which traverses a
-given interval of integer values. It is defined as follows.
-\begin{lstlisting}
-object Iterator {
-  def range(start: Int, end: Int) = new Iterator[Int] {
-    private var current = start
-    def hasNext = current < end
-    def next = {
-      val r = current
-      if (current < end) current += 1
-      else error("end of iterator")
-      r
-    }
-  }
-}
-\end{lstlisting}
-All iterators seen so far terminate eventually. It is also possible to
-define iterators that go on forever. For instance, the following
-iterator returns successive integers from some start
-value\footnote{Due to the finite representation of type \prog{int},
-numbers will wrap around at $2^{31}$.}.
-\begin{lstlisting}
-def from(start: Int) = new Iterator[Int] {
-  private var last = start - 1
-  def hasNext = true
-  def next = { last += 1; last }
-}
-\end{lstlisting}
-
-\section{Using Iterators}
-
-Here are two more examples how iterators are used. First, to print all
-elements of an array \code{xs: Array[Int]}, one can write:
-\begin{lstlisting}
-  Iterator.fromArray(xs) foreach (x => println(x))
-\end{lstlisting}
-Or, using a for-comprehension:
-\begin{lstlisting}
-  for (x <- Iterator.fromArray(xs))
-    println(x)
-\end{lstlisting}
-As a second example, consider the problem of finding the indices of
-all the elements in an array of \code{double}s greater than some
-\code{limit}. The indices should be returned as an iterator.
-This is achieved by the following expression.
-\begin{lstlisting}
-import Iterator._
-fromArray(xs)
-.zip(from(0))
-.filter(case (x, i) => x > limit)
-.map(case (x, i) => i)
-\end{lstlisting}
-Or, using a for-comprehension:
-\begin{lstlisting}
-import Iterator._
-for ((x, i) <- fromArray(xs) zip from(0); x > limit)
-yield i
-\end{lstlisting}
-
-\chapter{Lazy Values}
-
-Lazy values provide a way to delay initialization of a value until the
-first time it is accessed. This may be useful when dealing with
-values that might not be needed during execution, and whose
-computational cost is signifficant. As a first example, let's consider
-a database of employees, containing for each employee its manager and
-its team.
-\begin{lstlisting}
-case class Employee(id: Int, 
-                    name: String, 
-                    managerId: Int) {
-  val manager: Employee = Db.get(managerId)
-  val team: List[Employee] = Db.team(id)
-}
-\end{lstlisting}
-
-The \lstinline@Employee@ class given above will eagerly initialize
-all its fields, loading the whole employee table in memory. This is
-certainly not optimal, and it can be easily  improved my making the
-fields lazy. This way we delay the database access until it is really
-needed, if it is ever needed.
-\begin{lstlisting}
-case class Employee(id: Int, 
-                    name: String, 
-                    managerId: Int) {
-  lazy val manager: Employee = Db.get(managerId)
-  lazy val team: List[Employee] = Db.team(id)
-}
-\end{lstlisting}
-
-To see what is really happening, we can use this mockup
-database which shows when records are fetched:
-\begin{lstlisting}
-object Db {
-  val table = Map(1 -> (1, "Haruki Murakami", -1),
-                  2 -> (2, "Milan Kundera", 1),
-                  3 -> (3, "Jeffrey Eugenides", 1),
-                  4 -> (4, "Mario Vargas Llosa", 1),
-                  5 -> (5, "Julian Barnes", 2))
-
-  def team(id: Int) = {
-    for (rec <- table.values.toList; if rec._3 == id)
-      yield recToEmployee(rec)
-  }
-
-  def get(id: Int) = recToEmployee(table(id))
-
-  private def recToEmployee(rec: (Int, String, Int)) = {
-    println("[db] fetching " + rec._1)
-    Employee(rec._1, rec._2, rec._3)
-  }
-}
-\end{lstlisting}
-The output when running a program that retrieves one employee 
-confirms that the database is only accessed when referring  the lazy
-values.
-
-Another use of lazy values is to resolve the
-initialization order of applications composed of several
-modules. Before lazy values were introduced, the same effect was
-achieved by using \lstinline@object@ definitions. As a second example,
-we consider a compiler composed of several modules. We look first at a
-simple symbol table that defines a class for symbols and two
-predefined functions.
-\begin{lstlisting}
-class Symbols(val compiler: Compiler) {
-  import compiler.types._
-
-  val Add = new Symbol("+", FunType(List(IntType, IntType), IntType))
-  val Sub = new Symbol("-", FunType(List(IntType, IntType), IntType))
-
-  class Symbol(name: String, tpe: Type) {
-    override def toString = name + ": " + tpe
-  }
-}
-\end{lstlisting}
-The \lstinline@symbols@ module is parameterized with a \lstinline@Compiler@
-instance, which provides access to other services, such as the types
-module. In our example there are only two predefined functions,
-addition and subtraction, and their definitions depend on the \lstinline@types@
-module.
-\begin{lstlisting}
-class Types(val compiler: Compiler) {
-  import compiler.symtab._
-
-  abstract class Type
-  case class FunType(args: List[Type], res: Type) extends Type
-  case class NamedType(sym: Symbol) extends Type
-  case object IntType extends Type
-}
-\end{lstlisting}
-In order to hook the two components together a compiler object is
-created and passed as an argument to the two components. 
-\begin{lstlisting}
-class Compiler {
-  val symtab = new Symbols(this)
-  val types  = new Types(this)
-}
-\end{lstlisting}
-Unfortunately, the straight-forward approach fails at runtime because
-the \lstinline@symtab@ module needs the \lstinline@types@
-module. In general, the dependency between modules can be complicated
-and getting the right initialization order is difficult, or even
-impossible when there are cycles. The easy fix is to make such fields
-\lstinline@lazy@ and let the compiler figure out the right order.
-\begin{lstlisting}
-class Compiler {
-  lazy val symtab = new Symbols(this)
-  lazy val types  = new Types(this)
-}
-\end{lstlisting}
-Now the two modules are initialized on first access, and the compiler
-may run as expected. 
-
-\subsection*{Syntax}
-The \lstinline@lazy@ modifier is allowed only on concrete value
-definitions. All typing rules for value definitions apply for
-\lstinline@lazy@ values as well, with one restriction removed:
-recursive local values are allowed.
-
-\chapter{Implicit Parameters and Conversions}\label{sec:implicits}
-
-Implicit parameters and conversions are powerful tools for
-custimizing existing libraries and for creating high-level
-abstractions. As an example, let's start with an abstract class of
-semi-groups that support an unspecified \lstinline@add@ operation.
-\begin{lstlisting}
-abstract class SemiGroup[A] {
-  def add(x: A, y: A): A
-}
-\end{lstlisting}
-Here's a subclass \lstinline@Monoid@ of \lstinline@SemiGroup@ which adds a
-\lstinline@unit@ element.
-\begin{lstlisting}
-abstract class Monoid[A] extends SemiGroup[A] {
-  def unit: A
-}
-\end{lstlisting}
-Here are two implementations of monoids:
-\begin{lstlisting}
-object stringMonoid extends Monoid[String] {
-  def add(x: String, y: String): String = x.concat(y)
-  def unit: String = ""
-}
-
-object intMonoid extends Monoid[Int] {
-  def add(x: Int, y: Int): Int = x + y
-  def unit: Int = 0
-}
-\end{lstlisting}
-A \lstinline@sum@ method, which works over arbitrary
-monoids, can be written in plain Scala as follows.
-\begin{lstlisting}
-def sum[A](xs: List[A])(m: Monoid[A]): A =
-  if (xs.isEmpty) m.unit
-  else m.add(xs.head, sum(m)(xs.tail)
-\end{lstlisting}
-This \lstinline@sum@ method can be called as follows:
-\begin{lstlisting}
-sum(List("a", "bc", "def"))(stringMonoid)
-sum(List(1, 2, 3))(intMonoid)
-\end{lstlisting}
-All this works, but it is not very nice. The problem is that the
-monoid implementations have to be passed into all code that uses them.
-We would sometimes wish that the system could figure out the correct
-arguments automatically, similar to what is done when type arguments
-are inferred. This is what implicit parameters provide.
-
-\subsection*{Implicit Parameters: The Basics}
-
-In Scala 2 there is a new \lstinline@implicit@ keyword that can be
-used at the beginning of a parameter list. Syntax:
-\begin{lstlisting}
-ParamClauses ::= {`(' [Param {`,' Param}] ')'} 
-                 [`(' implicit Param {`,' Param} `)']
-\end{lstlisting}
-If the keyword is present, it makes all parameters in the list
-implicit.  
-For instance, the following version of \lstinline@sum@ has
-\lstinline@m@ as an implicit parameter.
-\begin{lstlisting}
-def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
-  if (xs.isEmpty) m.unit
-  else m.add(xs.head, sum(xs.tail))
-\end{lstlisting}
-As can be seen from the example, it is possible to combine normal and
-implicit parameters. However, there may only be one implicit parameter
-list for a method or constructor, and it must come last.
-
-\lstinline@implicit@ can also be used as a modifier for definitions
-and declarations. Examples:
-
-\begin{lstlisting}
-implicit object stringMonoid extends Monoid[String] {
-  def add(x: String, y: String): String = x.concat(y)
-  def unit: String = ""
-}
-implicit object intMonoid extends Monoid[Int] {
-  def add(x: Int, y: Int): Int = x + y
-  def unit: Int = 0
-}
-\end{lstlisting}
-
-The principal idea behind implicit parameters is that arguments for
-them can be left out from a method call. If the arguments
-corresponding to an implicit parameter section are missing, they are
-inferred by the Scala compiler.
-
-The actual arguments that are eligible to be passed to an implicit
-parameter are all identifiers X that can be accessed at the point
-of the method call without a prefix and that denote an implicit
-definition or parameter.
-
-If there are several eligible arguments which match the implicit
-parameter's type, the Scala compiler will chose a most specific one,
-using the standard rules of static overloading resolution.
-For instance, assume the call
-\begin{lstlisting}
-  sum(List(1, 2, 3))
-\end{lstlisting}
-in a context where \lstinline@stringMonoid@ and \lstinline@intMonoid@
-are visible.  We know that the formal type parameter \lstinline@a@ of
-\lstinline@sum@ needs to be instantiated to \lstinline@int@. The only
-eligible value which matches the implicit formal parameter type
-\lstinline@Monoid[Int]@ is \lstinline@intMonoid@ so this object will %
-be passed as implicit parameter.
-
-This discussion also shows that implicit parameters are inferred after
-any type arguments are inferred. 
-
-\subsection*{Implicit Conversions}
-
-Say you have an expression $E$ of type $T$ which is expected to type
-$S$. $T$ does not conform to $S$ and is not convertible to $S$ by
-some other predefined conversion. Then the Scala compiler will try to
-apply as last resort an implicit conversion $I(E)$. Here, $I$ is an
-identifier denoting an implicit definition or parameter that is
-accessible without a prefix at the point of the conversion, that can
-be applied to arguments of type $T$ and whose result type conforms to the
-expected type $S$.
-
-Implicit conversions can also be applied in member
-selections. Given a selection $E.x$ where $x$ is not a member of the
-type $E$, the Scala compiler will try to insert an implicit conversion
-$I(E).x$, so that $x$ is a member of $I(E)$.
-
-Here is an example of an implicit conversion function that converts
-integers into instances of class \lstinline@scala.Ordered@:
-\begin{lstlisting}
-implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
-  def compare(y: Int): Int =
-    if (x < y) -1
-    else if (x > y) 1
-    else 0
-}
-\end{lstlisting}
-
-\subsection*{View Bounds}
-
-View bounds are convenient syntactic sugar for implicit
-parameters. Consider for instance a generic sort method:
-\begin{lstlisting}
-def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
-  if (xs.isEmpty || xs.tail.isEmpty) xs
-  else {
-    val {ys, zs} = xs.splitAt(xs.length / 2)
-    merge(ys, zs)
-  }
-\end{lstlisting}
-The view bounded type parameter \lstinline@[a <$\mbox{\%}$ Ordered[a]]@
-expresses that \lstinline@sort@ is applicable to lists of type
-\lstinline@a@ such that there exists an implicit conversion from
-\lstinline@a@ to \lstinline@Ordered[a]@. The definition is treated as
-a shorthand for the following method signature with an implicit
-parameter:
-\begin{lstlisting}
-def sort[A](xs: List[A])(implicit $c$: A => Ordered[A]): List[A] = ...
-\end{lstlisting}
-(Here, the parameter name $c$ is chosen arbitrarily in a way
-that does not collide with other names in the program.)
-
-As a more detailed example, consider the \lstinline@merge@ method that
-comes with the \lstinline@sort@ method above:
-\begin{lstlisting}
-def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
-  if (xs.isEmpty) ys
-  else if (ys.isEmpty) xs
-  else if (xs.head < ys.head) xs.head :: merge(xs.tail, ys)
-  else if ys.head :: merge(xs, ys.tail)
-\end{lstlisting}
-After expanding view bounds and inserting implicit conversions, this
-method implementation becomes:
-\begin{lstlisting}
-def merge[A](xs: List[A], ys: List[A])
-            (implicit $c$: A => Ordered[A]): List[A] =
-  if (xs.isEmpty) ys
-  else if (ys.isEmpty) xs
-  else if (c(xs.head) < ys.head) xs.head :: merge(xs.tail, ys)
-  else if ys.head :: merge(xs, ys.tail)(c)
-\end{lstlisting}
-The last two lines of this method definition illustrate two different
-uses of the implicit parameter $c$. It is applied in a conversion in
-the condition of the second to last line, and it is passed as implicit
-argument in the recursive call to \lstinline@merge@ on the last line.
-
-\comment{
-\chapter{Combinator Parsing}\label{sec:combinator-parsing}
-
-In this chapter we describe how to write combinator parsers in
-Scala. Such parsers are constructed from predefined higher-order
-functions, so called {\em parser combinators}, that closely model the
-constructions of an EBNF grammar \cite{wirth:ebnf}.
-
-As running example, we consider parsers for possibly nested
-lists of identifiers and numbers, which
-are described by the following context-free grammar.
-\bda{p{3cm}cp{10cm}}
-letter &::=& /* all letters */ \\
-digit  &::=& /* all digits */ \\[0.5em]
-ident  &::=& letter \{letter $|$ digit \}\\
-number &::=& digit \{digit\}\\[0.5em]
-list   &::=& `(' [listElems] `)' \\
-listElems &::=& expr [`,' listElems] \\
-expr   &::=& ident | number | list
-
-\eda
-
-\section{Simple Combinator Parsing}
-
-In this section we will only be concerned with the task of recognizing
-input strings, not with processing them. So we can describe parsers
-by the sets of input strings they accept.  There are two
-fundamental operators over parsers:
-\code{&} expresses the sequential composition of a parser with
-another, while \code{|} expresses an alternative. These operations
-will both be defined as methods of a \code{Parser} class.  We will
-also define constructors for the following primitive parsers:
-
-\begin{tabular}{ll}
-\code{empty}    & The parser that accepts the empty string
-\\
-\code{failure(msg: String)}  & The parser that accepts no string (\verb@msg@ 
-                               stands for an error message)
-
-\\
-\code{chr(c: char)}
-                & The parser that accepts the single-character string ``$c$''.
-\\
-\code{chrSuchThat(p: Char => Boolean)}
-                & The parser that accepts single-character strings
-                  ``$c$'' \\
-                & for which $p(c)$ is true.
-\end{tabular}
-
-There are also the two higher-order parser combinators \code{opt},
-expressing optionality and \code{rep}, expressing repetition.
-For any parser $p$, \code{opt(}$p$\code{)} yields a parser that
-accepts the strings accepted by $p$ or else the empty string, while
-\code{rep(}$p$\code{)} accepts arbitrary sequences of the strings accepted by
-$p$. In EBNF, \code{opt(}$p$\code{)} corresponds to $[p]$ and
-\code{rep(}$p$\code{)} corresponds to $\{p\}$.
-
-The central idea of parser combinators is that parsers can be produced
-by a straightforward rewrite of the grammar, replacing \code{::=} with
-\code{=}, sequencing with
-\code{&}, repetition \code{\{...\}} with
-\code{rep(...)} and optional occurrence \code{[...]} with \code{opt(...)}.
-Applying this process to the grammar of lists
-yields the following trait.
-\begin{lstlisting}
-trait ListParsers extends Parsers {
-  def chrSuchThat(p: Char => Boolean): Parser
-  def chr(c: Char): Parser = chrSuchThat(d ==)
-
-  def letter    : Parser = chr(Character.isLetter)
-  def digit     : Parser = chr(Character.isDigit)
-
-  def ident     : Parser = letter &&& rep(letter ||| digit)
-  def number    : Parser = digit &&& rep(digit)
-  def list      : Parser = chr('(') &&& opt(listElems) &&& chr(')')
-  def listElems : Parser = expr &&& (chr(',') &&& listElems ||| empty)
-  def expr      : Parser = ident ||| number ||| list
-}
-\end{lstlisting}
-This class isolates the grammar from other aspects of parsing. It
-abstracts over the type of input 
-and over the method used to parse a single character
-(represented by the abstract method \code{chr(p: char =>
-boolean))}. The missing bits of information need to be supplied by code
-applying the parser class.
-
-It remains to explain how to implement a library with the combinators
-described above. We will pack combinators and their underlying
-implementation in a base class \code{Parsers}, which is inherited by
-\code{ListParsers}.  The first question to decide is which underlying
-representation type to use for a parser. We treat parsers here
-essentially as functions that take a datum of the input type
-\code{InType} and that yield a parse result of type
-\code{Option[InType]}.  The \code{Option} type is predefined as
-follows.
-\begin{lstlisting}
-abstract class Option[+a]
-case object None extends Option[Nothing]
-case class Some[a](x: a) extends Option[a]
-\end{lstlisting}
-A parser applied to some input either succeeds or fails. If it fails,
-it returns the constant \code{None}. If it succeeds, it returns a
-value of the form \code{Some(in1)} where \code{in1} represents the
-input that remains to be parsed.
-\begin{lstlisting}
-trait Parsers {
-  type InType
-  abstract class Parser {
-    type Result = Option[InType]
-    def apply(in: InType): Result
-\end{lstlisting}
-A parser also implements the combinators
-for sequence and alternative:
-\begin{lstlisting}
-  /*** p &&& q applies first p, and if that succeeds, then q
-   */
-  def &&& (q: => Parser) = new Parser {
-    def apply(in: InType): Result = Parser.this.apply(in) match {
-      case None => None
-      case Some(in1)  => q(in1)
-    }
-  }
-
-  /*** p ||| q applies first p, and, if that fails, then q.
-   */
-  def ||| (q: => Parser) = new Parser {
-    def apply(in: InType): Result = Parser.this.apply(in) match {
-      case None => q(in)
-      case s => s
-    }
-  }
-\end{lstlisting}
-The implementations of the primitive parsers \code{empty} and \code{fail}
-are trivial:
-\begin{lstlisting}
-  val empty = new Parser { def apply(in: InType): Result = Some(in) }
-  val fail  = new Parser { def apply(in: InType): Result = None }
-\end{lstlisting}
-The higher-order parser combinators \code{opt} and \code{rep} can be
-defined in terms of the combinators for sequence and alternative:
-\begin{lstlisting}
-  def opt(p: Parser): Parser = p ||| empty;    // p? = (p | <empty>)
-  def rep(p: Parser): Parser = opt(rep1(p));   // p* = [p+]
-  def rep1(p: Parser): Parser = p &&& rep(p);  // p+ = p p*
-} // end Parser
-\end{lstlisting}
-To run combinator parsers, we still need to decide on a way to handle
-parser input. Several possibilities exist: The input could be
-represented as a list, as an array, or as a random access file.  Note
-that the presented combinator parsers use backtracking to change from
-one alternative to another.  Therefore, it must be possible to reset
-input to a point that was previously parsed. If one restricted the
-focus to LL(1) grammars, a non-backtracking implementation of the
-parser combinators in class \code{Parsers} would also be possible. In
-that case sequential input methods based on (say) iterators or
-sequential files would also be possible.
-
-In our example, we represent the input by a pair of a string, which
-contains the input phrase as a whole, and an index, which represents
-the portion of the input which has not yet been parsed. Since the
-input string does not change, just the index needs to be passed around
-as a result of individual parse steps.  This leads to the following
-class of parsers that read strings:
-\begin{lstlisting}
-class ParseString(s: String) extends Parsers {
-  type InType = Int
-  def chrSuchThat(p: Char => Boolean) = new Parser {
-    def apply(in: Int): Parser#Result =
-      if (in < s.length() && p(s charAt in)) Some(in + 1)
-      else None
-  }
-  val input = 0
-}
-\end{lstlisting}
-This class implements a method \code{chr(p: Char => Boolean)} and a
-value \code{input}. The \code{chr} method builds a parser that either
-reads a single character satisfying the given predicate \code{p} or
-fails.  All other parsers over strings are ultimately implemented in
-terms of that method. The \code{input} value represents the input as a
-whole. In out case, it is simply value \code{0}, the start index of
-the string to be read.
-
-Note \code{apply}'s result type, \code{Parser#Result}. This syntax
-selects the type element \code{Result} of the type \code{Parser}. It
-thus corresponds roughly to selecting a static inner class from some
-outer class in Java. Note that we could {\em not} have written
-\code{Parser.Result}, as the latter would express selection of the
-\code{Result} element from a {\em value} named \code{Parser}.
-
-We have now extended the root class \code{Parsers} in two different
-directions: Class \code{ListParsers} defines a grammar of phrases to
-be parsed, whereas class \code{ParseString} defines a method by which
-such phrases are input. To write a concrete parsing application, we
-need to define both grammar and input method. We do this by combining
-two extensions of \code{Parsers} using a {\em mixin composition}.
-Here is the start of a sample application:
-\begin{lstlisting}
-object Test {
-  def main(args: Array[String]) {
-    val ps = new ParseString(args(0)) with ListParsers
-  }
-\end{lstlisting}
-The last line above creates a new family of parsers by composing class
-\code{ListParsers} with class \code{ParseString}. The two classes
-share the common superclass \code{Parsers}. The abstract method
-\code{chr} in \code{ListParsers} is implemented by class \code{ParseString}.
-
-To run the parser, we apply the start symbol of the grammar
-\code{expr} the argument code{input} and observe the result:
-\begin{lstlisting}
-    ps.expr(ps.input) match {
-      case Some(n) =>
-        println("parsed: " + args(0).substring(0, n))
-      case None =>
-        println("nothing parsed")
-    }
-  }
-}// end Test
-\end{lstlisting}
-Note the syntax ~\code{ps.expr(input)}, which treats the \code{expr}
-parser as if it was a function. In Scala, objects with \code{apply}
-methods can be applied directly to arguments as if they were functions.
-
-Here is an example run of the program above:
-\begin{lstlisting}
-> java examples.Test "(x,1,(y,z))"
-parsed: (x,1,(y,z))
-> java examples.Test "(x,,1,(y,z))"
-nothing parsed
-\end{lstlisting}
-
-\section{\label{sec:parsers-results}Parsers that Produce Results}
-
-The combinator library of the previous section does not support the
-generation of output from parsing. But usually one does not just want
-to check whether a given string belongs to the defined language, one
-also wants to convert the input string into some internal
-representation such as an abstract syntax tree.
-
-In this section, we modify our parser library to build parsers that
-produce results. We will make use of the for-comprehensions introduced
-in Chapter~\ref{sec:for-notation}.  The basic combinator of sequential
-composition, formerly ~\code{p &&& q}, now becomes
-\begin{lstlisting}
-for (x <- p; y <- q) yield e .
-\end{lstlisting}
-Here, the names \code{x} and \code{y} are bound to the results of
-executing the parsers \code{p} and \code{q}. \code{e} is an expression
-that uses these results to build the tree returned by the composed
-parser.
-
-Before describing the implementation of the new parser combinators, we
-explain how the new building blocks are used. Say we want to modify
-our list parser so that it returns an abstract syntax tree of the
-parsed expression. Syntax trees are given by the following class hierarchy:
-\begin{lstlisting}
-abstract class Tree
-case class Id (s: String)         extends Tree
-case class Num(n: Int)            extends Tree
-case class Lst(elems: List[Tree]) extends Tree
-\end{lstlisting}
-That is, a syntax tree is an identifier, an integer number, or a
-\code{Lst} node with a list of trees as descendants.
-
-As a first step towards parsers that produce results we define three
-little parsers that return a single read character as result.
-\begin{lstlisting}
-trait CharParsers extends Parsers {
-  def any: Parser[Char]
-  def chr(ch: Char): Parser[Char] =
-    for (c <- any if c == ch) yield c
-  def chrSuchThat(p: Char => Boolean): Parser[Char] =
-    for (c <- any if p(c)) yield c
-}
-\end{lstlisting}
-The \code{any} parser succeeds with the first character of remaining
-input as long as input is nonempty. It is abstract in class
-\code{ListParsers} since we want to abstract in this class from the
-concrete input method used.  The two \code{chr} parsers return as before
-the first input character if it equals a given character or matches a
-given predicate. They are now implemented in terms of \code{any}.
-
-The next level is represented by parsers reading identifiers, numbers
-and lists. Here is a parser for identifiers.
-\begin{lstlisting}
-trait ListParsers extends CharParsers {
-  def ident: Parser[Tree] = 
-    for {
-      c: Char <- chrSuchThat(Character.isLetter)
-      cs: List[Char] <- rep(chrSuchThat(Character.isLetterOrDigit))
-    } yield Id((c :: cs).mkString("", "", ""))
-\end{lstlisting}
-Remark: Because \code{chrSuchThat(...)} returns a single character, its
-repetition \code{rep(chrSuchThat(...))} returns a list of characters. The
-\code{yield} part of the for-comprehension converts all intermediate
-results into an \code{Id} node with a string as element.  To convert
-the read characters into a string, it conses them into a single list,
-and invokes the \code{mkString} method on the result.
-
-Here is a parser for numbers:
-\begin{lstlisting}
-  def number: Parser[Tree] =
-    for {
-      d: Char <- chrSuchThat(Character.isDigit)
-      ds: List[Char] <- rep(chrSuchThat(Character.isDigit))
-    } yield Num(((d - '0') /: ds) ((x, digit) => x * 10 + digit - '0'))
-\end{lstlisting}
-Intermediate results are in this case the leading digit of
-the read number, followed by a list of remaining digits.  The
-\code{yield} part of the for-comprehension reduces these to a number
-by a fold-left operation.
-
-Here is a parser for lists:
-\begin{lstlisting}
-  def list: Parser[Tree] = 
-    for {
-      _ <- chr('(')
-      es <- listElems ||| succeed(List())
-      _ <- chr(')')
-    } yield Lst(es)
-
-  def listElems: Parser[List[Tree]] = 
-    for {
-      x <- expr
-      xs <- chr(',') &&& listElems ||| succeed(List())
-    } yield x :: xs
-\end{lstlisting}
-The \code{list} parser returns a \code{Lst} node with a list of trees
-as elements.  That list is either the result of \code{listElems}, or,
-if that fails, the empty list (expressed here as: the result of a
-parser which always succeeds with the empty list as result).
-
-The highest level of our grammar is represented by function
-\code{expr}:
-\begin{lstlisting}
-  def expr: Parser[Tree] = 
-    ident ||| number ||| list
-}// end ListParsers.
-\end{lstlisting}
-We now present the parser combinators that support the new
-scheme. Parsers that succeed now return a parse result besides the
-un-consumed input.
-\begin{lstlisting}
-trait Parsers {
-  type InType
-  abstract class Parser[A] {
-    type Result = Option[(A, InType)]
-    def apply(in: InType): Result
-\end{lstlisting}
-Parsers are parameterized with the type of their result. The class
-\code{Parser[a]} now defines new methods \code{map}, \code{flatMap}
-and \code{filter}. The \code{for} expressions are mapped by the
-compiler to calls of these functions using the scheme described in
-Chapter~\ref{sec:for-notation}. For parsers, these methods are
-implemented as follows.
-\begin{lstlisting}
-    def filter(pred: A => Boolean) = new Parser[A] {
-      def apply(in: InType): Result = Parser.this.apply(in) match {
-        case None => None
-        case Some(x, in1) => if (pred(x)) Some(x, in1) else None
-      }
-    }
-    def map[B](f: A => B) = new Parser[B] {
-      def apply(in: InType): Result = Parser.this.apply(in) match {
-        case None => None
-        case Some(x, in1) => Some(f(x), in1)
-      }
-    }
-    def flatMap[b](f: A => Parser[B]) = new Parser[B] {
-      def apply(in: InType): Result = Parser.this.apply(in) match {
-        case None => None
-        case Some(x, in1) => f(x).apply(in1)
-      }
-    }
-\end{lstlisting}
-The \code{filter} method takes as parameter a predicate $p$ which it
-applies to the results of the current parser. If the predicate is
-false, the parser fails by returning \code{None}; otherwise it returns
-the result of the current parser.  The \code{map} method takes as
-parameter a function $f$ which it applies to the results of the
-current parser. The \code{flatMap} takes as parameter a function
-\code{f} which returns a parser.  It applies \code{f} to the result of
-the current parser and then continues with the resulting parser.  The
-\code{|||} method is essentially defined as before.  The
-\code{&&&} method can now be defined in terms of \code{for}.
-\begin{lstlisting}
-    def ||| (p: => Parser[A]) = new Parser[A] {
-      def apply(in: InType): Result = Parser.this.apply(in) match {
-        case None => p(in)
-        case s => s
-      }
-    }
-
-    def &&& [B](p: => Parser[B]): Parser[B] =
-      for (_ <- this; x <- p) yield x
-  }// end Parser
-\end{lstlisting}
-
-The primitive parser \code{succeed} replaces \code{empty}. It consumes
-no input and returns its parameter as result.
-\begin{lstlisting}
-  def succeed[A](x: A) = new Parser[A] {
-    def apply(in: InType) = Some(x, in)
-  }
-\end{lstlisting}
-
-The parser combinators \code{rep} and \code{opt} now also return
-results. \code{rep} returns a list which contains as elements the
-results of each iteration of its sub-parser. \code{opt} returns a list
-which is either empty or returns as single element the result of the
-optional parser.
-\begin{lstlisting}
-  def rep[A](p: Parser[A]): Parser[List[A]] =
-    rep1(p) ||| succeed(List())
-
-  def rep1[A](p: Parser[A]): Parser[List[A]] =
-    for (x <- p; xs <- rep(p)) yield x :: xs
-
-  def opt[A](p: Parser[A]): Parser[List[A]] =
-    (for (x <- p) yield List(x)) ||| succeed(List())
-} // end Parsers
-\end{lstlisting}
-The root class \code{Parsers} abstracts over which kind of
-input is parsed.  As before, we determine the input method by a separate class.
-Here is \code{ParseString}, this time adapted to parsers that return results.
-It defines now the method \code{any}, which returns the first input character.
-\begin{lstlisting}
-class ParseString(s: String) extends Parsers {
-  type InType = Int
-  val input = 0
-  def any = new Parser[Char] {
-    def apply(in: Int): Parser[Char]#Result =
-      if (in < s.length()) Some(s charAt in, in + 1) else None
-  }
-}
-\end{lstlisting}
-The rest of the application is as before. Here is a test program which
-constructs a list parser over strings and prints out the result of
-applying it to the command line argument.
-\begin{lstlisting}
-object Test {
-  def main(args: Array[String]) {
-    val ps = new ParseString(args(0)) with ListParsers
-    ps.expr(ps.input) match {
-      case Some(list, _) => println("parsed: " + list)
-      case None => println("nothing parsed")
-    }
-  }
-}
-\end{lstlisting}
-
-\begin{exercise}\label{exercise:end-marker} The parsers we have defined so
-far can succeed even if there is some input beyond the parsed text. To
-prevent this, one needs a parser which recognizes the end of input.
-Redesign the parser library so that such a parser can be introduced.
-Which classes need to be modified?
-\end{exercise}
-}
-
-\chapter{\label{sec:hm}Hindley/Milner Type Inference}
-
-This chapter demonstrates Scala's data types and pattern matching by
-developing a type inference system in the Hindley/Milner style
-\cite{milner:polymorphism}. The source language for the type inferencer is
-lambda calculus with a let construct called Mini-ML. Abstract syntax
-trees for the Mini-ML are represented by the following data type of
-\code{Terms}.
-\begin{lstlisting}
-abstract class Term {}
-case class Var(x: String) extends Term {
-  override def toString = x
-}
-case class Lam(x: String, e: Term) extends Term {
-  override def toString = "(\\" + x + "." + e + ")"
-}
-case class App(f: Term, e: Term) extends Term {
-  override def toString = "(" + f + " " + e + ")"
-}
-case class Let(x: String, e: Term, f: Term) extends Term {
-  override def toString = "let " + x + " = " + e + " in " + f
-}
-\end{lstlisting}
-There are four tree constructors: \code{Var} for variables, \code{Lam}
-for function abstractions, \code{App} for function applications, and
-\code{Let} for let expressions. Each case class overrides the
-\code{toString} method of class \code{Any}, so that terms can be
-printed in legible form.
-
-We next define the types that are
-computed by the inference system.
-\begin{lstlisting}
-sealed abstract class Type {}
-case class Tyvar(a: String) extends Type {
-  override def toString = a
-}
-case class Arrow(t1: Type, t2: Type) extends Type {
-  override def toString = "(" + t1 + "->" + t2 + ")"
-}
-case class Tycon(k: String, ts: List[Type]) extends Type {
-  override def toString = 
-    k + (if (ts.isEmpty) "" else ts.mkString("[", ",", "]"))
-}
-\end{lstlisting}
-There are three type constructors: \code{Tyvar} for type variables,
-\code{Arrow} for function types and \code{Tycon} for type constructors
-such as \code{Boolean} or \code{List}. Type constructors have as
-component a list of their type parameters. This list is empty for type
-constants such as \code{Boolean}. Again, the type constructors
-implement the \code{toString} method in order to display types legibly.
-
-Note that \code{Type} is a \code{sealed} class. This means that no
-subclasses or data constructors that extend \code{Type} can be formed
-outside the sequence of definitions in which \code{Type} is defined.
-This makes \code{Type} a {\em closed} algebraic data type with exactly
-three alternatives. By contrast, type \code{Term} is an {\em open}
-algebraic type for which further alternatives can be defined.
-
-The main parts of the type inferencer are contained in object
-\code{typeInfer}. We start with a utility function which creates
-fresh type variables:
-\begin{lstlisting}
-object typeInfer {
-  private var n: Int = 0
-  def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
-\end{lstlisting}
-We next define a class for substitutions. A substitution is an
-idempotent function from type variables to types. It maps a finite
-number of type variables to some types, and leaves all other type
-variables unchanged. The meaning of a substitution is extended
-point-wise to a mapping from types to types. We also extend
-the meaning of substitution to environments, which are defined
-later.
-\begin{lstlisting}
-  abstract class Subst extends Function1[Type,Type] {
-
-    def lookup(x: Tyvar): Type
-
-    def apply(t: Type): Type = t match {
-      case tv @ Tyvar(a) => val u = lookup(tv); if (t == u) t else apply(u)
-      case Arrow(t1, t2) => Arrow(apply(t1), apply(t2))
-      case Tycon(k, ts) => Tycon(k, ts map apply)
-    }
-
-    def apply(env: Env): Env = env.map({ case (x, TypeScheme(tyvars, tpe)) =>
-      // assumes tyvars don't occur in this substitution
-      (x, TypeScheme(tyvars, apply(tpe)))
-    })
-
-    def extend(x: Tyvar, t: Type) = new Subst {
-      def lookup(y: Tyvar): Type = if (x == y) t else Subst.this.lookup(y)
-    }
-  }
-  val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
-\end{lstlisting}
-We represent substitutions as functions, of type \code{Type =>
-Type}. This is achieved by making class \code{Subst} inherit from the
-unary function type \code{Function1[Type, Type]}\footnote{
-The class inherits the function type as a mixin rather than as a direct 
-superclass. This is because in the current Scala implementation, the
-\code{Function1} type is a Java interface, which cannot be used as a direct
-superclass of some other class.}.
-To be an instance
-of this type, a substitution \code{s} has to implement an \code{apply}
-method that takes a \code{Type} as argument and yields another
-\code{Type} as result. A function application \code{s(t)} is then
-interpreted as \code{s.apply(t)}.
-
-The \code{lookup} method is abstract in class \code{Subst}.  There are
-two concrete forms of substitutions which differ in how they
-implement this method.  One form is defined by the \code{emptySubst} value,
-the other is defined by the \code{extend} method in class
-\code{Subst}.
-
-The next data type describes type schemes, which consist of a type and
-a list of names of type variables which appear universally quantified
-in the type scheme. 
-For instance, the type scheme $\forall a\forall b.a \!\arrow\! b$ would be represented in the type checker as:
-\begin{lstlisting}
-TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
-\end{lstlisting}
-The class definition of type schemes does not carry an extends
-clause; this means that type schemes extend directly class
-\code{AnyRef}.  Even though there is only one possible way to
-construct a type scheme, a case class representation was chosen
-since it offers convenient ways to decompose an instance of this type into its
-parts.
-\begin{lstlisting}
-  case class TypeScheme(tyvars: List[Tyvar], tpe: Type) {
-    def newInstance: Type = {
-      (emptySubst /: tyvars) ((s, tv) => s.extend(tv, newTyvar())) (tpe)
-    }
-  }
-\end{lstlisting}
-Type scheme objects come with a method \code{newInstance}, which
-returns the type contained in the scheme after all universally type
-variables have been renamed to fresh variables. The implementation of
-this method folds (with \code{/:}) the type scheme's type variables
-with an operation which extends a given substitution \code{s} by
-renaming a given type variable \code{tv} to a fresh type
-variable. The resulting substitution renames all type variables of the
-scheme to fresh ones. This substitution is then applied to the type
-part of the type scheme.
-
-The last type we need in the type inferencer is
-\code{Env}, a type for environments, which associate variable names
-with type schemes. They are represented by a type alias \code{Env} in
-module \code{typeInfer}:
-\begin{lstlisting}
-  type Env = List[(String, TypeScheme)]
-\end{lstlisting}
-There are two operations on environments. The \code{lookup} function
-returns the type scheme associated with a given name, or \code{null}
-if the name is not recorded in the environment.
-\begin{lstlisting}
-  def lookup(env: Env, x: String): TypeScheme = env match {
-    case List() => null
-    case (y, t) :: env1 => if (x == y) t else lookup(env1, x)
-  }
-\end{lstlisting}
-The \code{gen} function turns a given type into a type scheme,
-quantifying over all type variables that are free in the type, but
-not in the environment.
-\begin{lstlisting}
-  def gen(env: Env, t: Type): TypeScheme = 
-    TypeScheme(tyvars(t) diff tyvars(env), t)
-\end{lstlisting}
-The set of free type variables of a type is simply the set of all type
-variables which occur in the type. It is represented here as a list of
-type variables, which is constructed as follows.
-\begin{lstlisting}
-  def tyvars(t: Type): List[Tyvar] = t match {
-    case tv @ Tyvar(a) => 
-      List(tv)
-    case Arrow(t1, t2) => 
-      tyvars(t1) union tyvars(t2)
-    case Tycon(k, ts) => 
-      (List[Tyvar]() /: ts) ((tvs, t) => tvs union tyvars(t))
-  }
-\end{lstlisting}
-Note that the syntax \code{tv @ ...} in the first pattern introduces a variable
-which is bound to the pattern that follows. Note also that the explicit type parameter \code{[Tyvar]} in the expression of the third
-clause is needed to make local type inference work.
-
-The set of free type variables of a type scheme is the set of free
-type variables of its type component, excluding any quantified type variables:
-\begin{lstlisting}
-  def tyvars(ts: TypeScheme): List[Tyvar] = 
-    tyvars(ts.tpe) diff ts.tyvars
-\end{lstlisting}
-Finally, the set of free type variables of an environment is the union
-of the free type variables of all type schemes recorded in it.
-\begin{lstlisting}
-  def tyvars(env: Env): List[Tyvar] =
-    (List[Tyvar]() /: env) ((tvs, nt) => tvs union tyvars(nt._2))
-\end{lstlisting}
-A central operation of Hindley/Milner type checking is unification,
-which computes a substitution to make two given types equal (such a
-substitution is called a {\em unifier}).  Function \code{mgu} computes
-the most general unifier of two given types $t$ and $u$ under a
-pre-existing substitution $s$.  That is, it returns the most general
-substitution $s'$ which extends $s$, and which makes $s'(t)$ and
-$s'(u)$ equal types. 
-\begin{lstlisting}
-  def mgu(t: Type, u: Type, s: Subst): Subst = (s(t), s(u)) match {
-    case (Tyvar(a), Tyvar(b)) if (a == b) =>
-      s
-    case (st @ Tyvar(a), su) if !(tyvars(su) contains st) =>
-      s.extend(st, su)
-    case (_, Tyvar(a)) =>
-      mgu(u, t, s)
-    case (Arrow(t1, t2), Arrow(u1, u2)) =>
-      mgu(t1, u1, mgu(t2, u2, s))
-    case (Tycon(k1, ts), Tycon(k2, us)) if (k1 == k2) =>
-      (s /: (ts zip us)) ((s, tu) => mgu(tu._1, tu._2, s))
-    case _ => 
-      throw new TypeError("cannot unify " + s(t) + " with " + s(u))
-  }
-\end{lstlisting}
-The \code{mgu} function throws a \code{TypeError} exception if no
-unifier substitution exists. This can happen because the two types
-have different type constructors at corresponding places, or because a
-type variable is unified with a type that contains the type variable
-itself. Such exceptions are modeled here as instances of case classes
-that inherit from the predefined \code{Exception} class.
-\begin{lstlisting}
-  case class TypeError(s: String) extends Exception(s) {}
-\end{lstlisting}
-The main task of the type checker is implemented by function
-\code{tp}. This function takes as parameters an environment $env$, a
-term $e$, a proto-type $t$, and a
-pre-existing substitution $s$.  The function yields a substitution
-$s'$ that extends $s$ and that
-turns $s'(env) \ts e: s'(t)$ into a derivable type judgment according
-to the derivation rules of the Hindley/Milner type system \cite{milner:polymorphism}.  A
-\code{TypeError} exception is thrown if no such substitution exists.
-\begin{lstlisting}
-  def tp(env: Env, e: Term, t: Type, s: Subst): Subst = {
-    current = e
-    e match {
-      case Var(x) =>
-        val u = lookup(env, x)
-        if (u == null) throw new TypeError("undefined: " + x)
-        else mgu(u.newInstance, t, s)
-
-      case Lam(x, e1) =>
-        val a, b = newTyvar()
-        val s1 = mgu(t, Arrow(a, b), s)
-        val env1 = {x, TypeScheme(List(), a)} :: env
-        tp(env1, e1, b, s1)
-
-      case App(e1, e2) =>
-        val a = newTyvar()
-        val s1 = tp(env, e1, Arrow(a, t), s)
-        tp(env, e2, a, s1)
-
-      case Let(x, e1, e2) =>
-        val a = newTyvar()
-        val s1 = tp(env, e1, a, s)
-        tp({x, gen(s1(env), s1(a))} :: env, e2, t, s1)
-    }
-  } 
-  var current: Term = null
-\end{lstlisting}
-To aid error diagnostics, the \code{tp} function stores the currently
-analyzed sub-term in variable \code{current}. Thus, if type checking
-is aborted with a \code{TypeError} exception, this variable will
-contain the subterm that caused the problem.
-
-The last function of the type inference module, \code{typeOf}, is a
-simplified facade for \code{tp}. It computes the type of a given term
-$e$ in a given environment $env$. It does so by creating a fresh type
-variable $a$, computing a typing substitution that makes $env \ts e: a$
-into a derivable type judgment, and returning
-the result of applying the substitution to $a$.
-\begin{lstlisting}
-  def typeOf(env: Env, e: Term): Type = {
-    val a = newTyvar()
-    tp(env, e, a, emptySubst)(a)
-  }
-}// end typeInfer
-\end{lstlisting}
-To apply the type inferencer, it is convenient to have a predefined
-environment that contains bindings for commonly used constants. The
-module \code{predefined} defines an environment \code{env} that
-contains bindings for the types of booleans, numbers and lists
-together with some primitive operations over them. It also
-defines a fixed point operator \code{fix}, which can be used to
-represent recursion.
+%% Given this definition, let's test whether
+%% \begin{lstlisting}
+%% val x = new BankAccount; val y = new BankAccount
+%% \end{lstlisting}
+%% defines values \code{x} and \code{y} which are the same.
+%% Here are the definitions again, followed by a test sequence:
+
+%% \begin{lstlisting}
+%% > val x = new BankAccount
+%% > val y = new BankAccount
+%% > x deposit 30
+%% 30
+%% > y withdraw 20
+%% java.lang.RuntimeException: insufficient funds
+%% \end{lstlisting}
+
+%% Now, rename all occurrences of \code{y} in that sequence to
+%% \code{x}. We get:
+%% \begin{lstlisting}
+%% > val x = new BankAccount
+%% > val y = new BankAccount
+%% > x deposit 30
+%% 30
+%% > x withdraw 20
+%% 10
+%% \end{lstlisting}
+%% Since the final results are different, we have established that
+%% \code{x} and \code{y} are not the same.
+%% On the other hand, if we define
+%% \begin{lstlisting}
+%% val x = new BankAccount; val y = x
+%% \end{lstlisting}
+%% then no sequence of operations can distinguish between \code{x} and
+%% \code{y}, so \code{x} and \code{y} are the same in this case.
+
+%% \paragraph{Assignment and the Substitution Model}
+%% These examples show that our previous substitution model of
+%% computation cannot be used anymore.  After all, under this
+%% model we could always replace a value name by its
+%% defining expression.
+%% For instance in
+%% \begin{lstlisting}
+%% val x = new BankAccount; val y = x
+%% \end{lstlisting}
+%% the \code{x} in the definition of \code{y} could
+%% be replaced by \code{new BankAccount}.
+%% But we have seen that this change leads to a different program.
+%% So the substitution model must be invalid, once we add assignments. 
+
+%% \section{Imperative Control Structures}
+
+%% Scala has the \code{while} and \code{do-while} loop constructs known
+%% from the C and Java languages. There is also a single branch \code{if}
+%% which leaves out the else-part as well as a \code{return} statement which
+%% aborts a function prematurely. This makes it possible to program in a
+%% conventional imperative style. For instance, the following function,
+%% which computes the \code{n}'th power of a given parameter \code{x}, is
+%% implemented using \code{while} and single-branch \code{if}.
+%% \begin{lstlisting}
+%% def power(x: Double, n: Int): Double = {
+%%   var r = 1.0
+%%   var i = n
+%%   var j = 0
+%%   while (j < 32) {
+%%     r = r * r
+%%     if (i < 0)
+%%       r *= x
+%%     i = i << 1
+%%     j += 1
+%%   }
+%%   r
+%% }
+%% \end{lstlisting}
+%% These imperative control constructs are in the language for
+%% convenience. They could have been left out, as the same constructs can
+%% be implemented using just functions. As an example, let's develop a
+%% functional implementation of the while loop. \code{whileLoop} should
+%% be a function that takes two parameters: a condition, of type
+%% \code{Boolean}, and a command, of type \code{Unit}. Both condition and
+%% command need to be passed by-name, so that they are evaluated
+%% repeatedly for each loop iteration.  This leads to the following
+%% definition of \code{whileLoop}.
+%% \begin{lstlisting}
+%% def whileLoop(condition: => Boolean)(command: => Unit) {
+%%   if (condition) {
+%%     command; whileLoop(condition)(command)
+%%   } else ()
+%% }
+%% \end{lstlisting}
+%% Note that \code{whileLoop} is tail recursive, so it operates in
+%% constant stack space.
+
+%% \begin{exercise} Write a function \code{repeatLoop}, which should be 
+%% applied as follows:
+%% \begin{lstlisting}
+%% repeatLoop { command } ( condition )
+%% \end{lstlisting}
+%% Is there also a way to obtain a loop syntax like the following?
+%% \begin{lstlisting}
+%% repeatLoop { command } until ( condition )
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% Some other control constructs known from C and Java are missing in
+%% Scala: There are no \code{break} and \code{continue} jumps for loops.
+%% There are also no for-loops in the Java sense -- these have been
+%% replaced by the more general for-loop construct discussed in
+%% Section~\ref{sec:for-loops}.
+
+%% \section{Extended Example: Discrete Event Simulation}
+
+%% We now discuss an example that demonstrates how assignments and
+%% higher-order functions can be combined in interesting ways.  
+%% We will build a simulator for digital circuits.
+
+%% The example is taken from Abelson and Sussman's book
+%% \cite{abelson-sussman:structure}. We augment their basic (Scheme-)
+%% code by an object-oriented structure which allows code-reuse through
+%% inheritance. The example also shows how discrete event simulation programs
+%% in general are structured and built.
+
+%% We start with a little language to describe digital circuits.
+%% A digital circuit is built from {\em wires} and {\em function boxes}.
+%% Wires carry signals which are transformed by function boxes.
+%% We will represent signals by the booleans \code{true} and
+%% \code{false}.
+
+%% Basic function boxes (or: {\em gates}) are:
+%% \begin{itemize}
+%% \item An \emph{inverter}, which negates its signal
+%% \item An \emph{and-gate}, which sets its output to the conjunction of its input.
+%% \item An \emph{or-gate}, which sets its output to the disjunction of its
+%% input.
+%% \end{itemize}
+%% Other function boxes can be built by combining basic ones.
+
+%% Gates have {\em delays}, so an output of a gate will change only some
+%% time after its inputs change.
+
+%% \paragraph{A Language for Digital Circuits}
+
+%% We describe the elements of a digital circuit by the following set of
+%% Scala classes and functions.
+
+%% First, there is a class \code{Wire} for wires.
+%% We can construct wires as follows.
+%% \begin{lstlisting}
+%% val a = new Wire
+%% val b = new Wire
+%% val c = new Wire
+%% \end{lstlisting}
+%% Second, there are procedures
+%% \begin{lstlisting}
+%% def inverter(input: Wire, output: Wire)
+%% def andGate(a1: Wire, a2: Wire, output: Wire)
+%% def orGate(o1: Wire, o2: Wire, output: Wire)
+%% \end{lstlisting}
+%% which ``make'' the basic gates we need (as side-effects).
+%% More complicated function boxes can now be built from these.
+%% For instance, to construct a half-adder, we can define:
+%% \begin{lstlisting}
+%%   def halfAdder(a: Wire, b: Wire, s: Wire, c: Wire) {
+%%     val d = new Wire
+%%     val e = new Wire
+%%     orGate(a, b, d)
+%%     andGate(a, b, c)
+%%     inverter(c, e)
+%%     andGate(d, e, s)
+%%   }
+%% \end{lstlisting}
+%% This abstraction can itself be used, for instance in defining a full
+%% adder:
+%% \begin{lstlisting}
+%%   def fullAdder(a: Wire, b: Wire, cin: Wire, sum: Wire, cout: Wire) {
+%%     val s = new Wire
+%%     val c1 = new Wire
+%%     val c2 = new Wire
+%%     halfAdder(a, cin, s, c1)
+%%     halfAdder(b, s, sum, c2)
+%%     orGate(c1, c2, cout)
+%%   }
+%% \end{lstlisting}
+%% Class \code{Wire} and functions \code{inverter}, \code{andGate}, and
+%% \code{orGate} represent thus a little language in which users can
+%% define digital circuits.  We now give implementations of this class
+%% and these functions, which allow one to simulate circuits.
+%% These implementations are based on a simple and general API for
+%% discrete event simulation.
+
+%% \paragraph{The Simulation API}
+
+%% Discrete event simulation performs user-defined \emph{actions} at
+%% specified \emph{times}.  
+%% An {\em action} is represented as a function which takes no parameters and
+%% returns a \code{Unit} result:
+%% \begin{lstlisting}
+%% type Action = () => Unit
+%% \end{lstlisting}
+%% The \emph{time} is simulated; it is not the actual ``wall-clock'' time.
+
+%% A concrete simulation will be done inside an object which inherits
+%% from the abstract \code{Simulation} class. This class has the following
+%% signature:
+
+%% \begin{lstlisting}
+%% abstract class Simulation {
+%%   def currentTime: Int
+%%   def afterDelay(delay: Int, action: => Action)
+%%   def run()
+%% }
+%% \end{lstlisting}
+%% Here,
+%% \code{currentTime} returns the current simulated time as an integer
+%% number,
+%% \code{afterDelay} schedules an action to be performed at a specified
+%% delay after \code{currentTime}, and
+%% \code{run} runs the simulation until there are no further actions to be 
+%% performed.
+
+%% \paragraph{The Wire Class}
+%% A wire needs to support three basic actions.
+%% \begin{itemize}
+%% \item[]
+%% \code{getSignal: Boolean}~~ returns the current signal on the wire.
+%% \item[]
+%% \code{setSignal(sig: Boolean)}~~ sets the wire's signal to \code{sig}.
+%% \item[]
+%% \code{addAction(p: Action)}~~ attaches the specified procedure
+%% \code{p} to the {\em actions} of the wire. All attached action
+%% procedures will be executed every time the signal of a wire changes.
+%% \end{itemize}
+%% Here is an implementation of the \code{Wire} class:
+%% \begin{lstlisting}
+%% class Wire {
+%%   private var sigVal = false
+%%   private var actions: List[Action] = List()
+%%   def getSignal = sigVal
+%%   def setSignal(s: Boolean) =
+%%     if (s != sigVal) {
+%%       sigVal = s
+%%       actions.foreach(action => action())
+%%     }
+%%   def addAction(a: Action) {
+%%     actions = a :: actions; a()
+%%   }
+%% }
+%% \end{lstlisting}
+%% Two private variables make up the state of a wire.  The variable
+%% \code{sigVal} represents the current signal, and the variable
+%% \code{actions} represents the action procedures currently attached to
+%% the wire.
+
+%% \paragraph{The Inverter Class}
+%% We implement an inverter by installing an action on its input wire,
+%% namely the action which puts the negated input signal onto the output
+%% signal.  The action needs to take effect at \code{InverterDelay}
+%% simulated time units after the input changes. This suggests the 
+%% following implementation:
+%% \begin{lstlisting}
+%% def inverter(input: Wire, output: Wire) {
+%%   def invertAction() {
+%%     val inputSig = input.getSignal
+%%     afterDelay(InverterDelay) { output setSignal !inputSig }
+%%   }
+%%   input addAction invertAction
+%% }
+%% \end{lstlisting}
+
+%% \paragraph{The And-Gate Class}
+%% And-gates are implemented analogously to inverters.  The action of an
+%% \code{andGate} is to output the conjunction of its input signals.
+%% This should happen at \code{AndGateDelay} simulated time units after
+%% any one of its two inputs changes. Hence, the following implementation:
+%% \begin{lstlisting}
+%% def andGate(a1: Wire, a2: Wire, output: Wire) {
+%%   def andAction() {
+%%     val a1Sig = a1.getSignal
+%%     val a2Sig = a2.getSignal
+%%     afterDelay(AndGateDelay) { output setSignal (a1Sig & a2Sig) }
+%%   }
+%%   a1 addAction andAction
+%%   a2 addAction andAction
+%% }
+%% \end{lstlisting}
+
+%% \begin{exercise} Write the implementation of \code{orGate}.
+%% \end{exercise}
+
+%% \begin{exercise} Another way is to define an or-gate by a combination of
+%% inverters and and gates. Define a function \code{orGate} in terms of
+%% \code{andGate} and \code{inverter}. What is the delay time of this function?
+%% \end{exercise}
+
+%% \paragraph{The Simulation Class}
+
+%% Now, we just need to implement class \code{Simulation}, and we are
+%% done.  The idea is that we maintain inside a \code{Simulation} object
+%% an \emph{agenda} of actions to perform.  The agenda is represented as
+%% a list of pairs of actions and the times they need to be run.  The
+%% agenda list is sorted, so that earlier actions come before later ones.
+%% \begin{lstlisting} 
+%% abstract class Simulation {
+%%   case class WorkItem(time: Int, action: Action)
+%%   private type Agenda = List[WorkItem]
+%%   private var agenda: Agenda = List()
+%% \end{lstlisting}
+%% There is also a private variable \code{curtime} to keep track of the
+%% current simulated time.
+%% \begin{lstlisting}
+%%   private var curtime = 0
+%% \end{lstlisting}
+%% An application of the method \code{afterDelay(delay, block)} 
+%% inserts the element \lstinline@WorkItem(currentTime + delay, () => block)@
+%% into the \code{agenda} list at the appropriate place.
+%% \begin{lstlisting}
+%% private def insert(ag: Agenda, item: WorkItem): Agenda =
+%%   if (ag.isEmpty || item.time < ag.head.time) item :: ag
+%%   else ag.head :: insert(ag.tail, item)
+
+%% def afterDelay(delay: Int)(block: => Unit) {
+%%   val item = WorkItem(currentTime + delay, () => block)
+%%   agenda = insert(agenda, item)
+%% }
+%% \end{lstlisting}
+%% An application of the \code{run} method removes successive elements
+%% from the \code{agenda} and performs their actions.
+%% It continues until the agenda is empty:
+%% \begin{lstlisting}
+%% private def next() {
+%%   agenda match {
+%%     case WorkItem(time, action) :: rest =>
+%%       agenda = rest; curtime = time; action()
+%%     case List() =>
+%%   }
+%% }
+
+%% def run() {
+%%   afterDelay(0) { println("*** simulation started ***") }
+%%   while (!agenda.isEmpty) next()
+%% }
+%% \end{lstlisting}
+
+%% \paragraph{Running the Simulator}
+%% To run the simulator, we still need a way to inspect changes of
+%% signals on wires. To this purpose, we write a function \code{probe}.
+%% \begin{lstlisting}
+%% def probe(name: String, wire: Wire) {
+%%   wire addAction { () =>
+%%     println(name + " " + currentTime + " new_value = " + wire.getSignal)
+%%   }
+%% }
+%% \end{lstlisting}
+%% Now, to see the simulator in action, let's define four wires, and place
+%% probes on two of them: 
+%% \begin{lstlisting}
+%% scala> val input1, input2, sum, carry = new Wire
+
+%% scala> probe("sum", sum)
+%% sum 0 new_value = false
+
+%% scala> probe("carry", carry)
+%% carry 0 new_value = false
+%% \end{lstlisting}
+%% Now let's define a half-adder connecting the wires:
+%% \begin{lstlisting}
+%% scala> halfAdder(input1, input2, sum, carry)
+%% \end{lstlisting}
+%% Finally, set one after another the signals on the two input wires to
+%% \code{true} and run the simulation.
+%% \begin{lstlisting}
+%% scala> input1 setSignal true; run
+%% *** simulation started ***
+%% sum 8 new_value = true
+
+%% scala> input2 setSignal true; run
+%% carry 11 new_value = true
+%% sum 15 new_value = false
+%% \end{lstlisting}
+
+%% \section{Summary}
+
+%% We have seen in this chapter the constructs that let us model state in
+%% Scala -- these are variables, assignments, and imperative control
+%% structures.  State and Assignment complicate our mental model of
+%% computation.  In particular, referential transparency is lost.  On the
+%% other hand, assignment gives us new ways to formulate programs
+%% elegantly. As always, it depends on the situation whether purely
+%% functional programming or programming with assignments works best.
+
+%% \chapter{Computing with Streams}
+
+%% The previous chapters have introduced variables, assignment and
+%% stateful objects.  We have seen how real-world objects that change
+%% with time can be modeled by changing the state of variables in a
+%% computation.  Time changes in the real world thus are modeled by time
+%% changes in program execution. Of course, such time changes are usually
+%% stretched out or compressed, but their relative order is the same.
+%% This seems quite natural, but there is a also price to pay: Our simple
+%% and powerful substitution model for functional computation is no
+%% longer applicable once we introduce variables and assignment.
+
+%% Is there another way? Can we model state change in the real world
+%% using only immutable functions? Taking mathematics as a guide, the
+%% answer is clearly yes: A time-changing quantity is simply modeled by
+%% a function \code{f(t)} with a time parameter \code{t}. The same can be
+%% done in computation. Instead of overwriting a variable with successive
+%% values, we represent all these values as successive elements in a
+%% list. So, a mutable variable \code{var x: T} gets replaced by an
+%% immutable value \code{val x: List[T]}. In a sense, we trade space for
+%% time -- the different values of the variable now all exist concurrently
+%% as different elements of the list.  One advantage of the list-based
+%% view is that we can ``time-travel'', i.e. view several successive
+%% values of the variable at the same time. Another advantage is that we
+%% can make use of the powerful library of list processing functions,
+%% which often simplifies computation. For instance, consider the
+%% imperative way to compute the sum of all prime numbers in an interval:
+%% \begin{lstlisting}
+%% def sumPrimes(start: Int, end: Int): Int = {
+%%   var i = start
+%%   var acc = 0
+%%   while (i < end) {
+%%     if (isPrime(i)) acc += i
+%%     i += 1
+%%   }
+%%   acc
+%% }
+%% \end{lstlisting}
+%% Note that the variable \code{i} ``steps through'' all values of the interval
+%% \code{[start .. end-1]}.
+
+%% A more functional way is to represent the list of values of variable \code{i} directly as \code{range(start, end)}. Then the function can be rewritten as follows.
+%% \begin{lstlisting}
+%% def sumPrimes(start: Int, end: Int) =
+%%   sum(range(start, end) filter isPrime)
+%% \end{lstlisting}
+
+%% No contest which program is shorter and clearer!  However, the
+%% functional program is also considerably less efficient since it
+%% constructs a list of all numbers in the interval, and then another one
+%% for the prime numbers. Even worse from an efficiency point of view is
+%% the following example:
+
+%% To find the second prime number between \code{1000} and \code{10000}:
+%% \begin{lstlisting}
+%%   range(1000, 10000) filter isPrime at 1
+%% \end{lstlisting}
+%% Here, the list of all numbers between \code{1000} and \code{10000} is
+%% constructed.  But most of that list is never inspected!
+
+%% However, we can obtain efficient execution for examples like these by
+%% a trick:
+%% \begin{quote}
+%% %\red
+%%  Avoid computing the tail of a sequence unless that tail is actually
+%%      necessary for the computation.
+%% \end{quote}
+%% We define a new class for such sequences, which is called \code{Stream}.
+
+%% Streams are created using the constant \code{empty} and the constructor \code{cons},
+%% which are both defined in module \code{scala.Stream}. For instance, the following
+%% expression constructs a stream with elements \code{1} and \code{2}:
+%% \begin{lstlisting}
+%% Stream.cons(1, Stream.cons(2, Stream.empty))
+%% \end{lstlisting}
+%% As another example, here is the analogue of \code{List.range},
+%% but returning a stream instead of a list:
+%% \begin{lstlisting}
+%% def range(start: Int, end: Int): Stream[Int] =
+%%   if (start >= end) Stream.empty
+%%   else Stream.cons(start, range(start + 1, end))
+%% \end{lstlisting}
+%% (This function is also defined as given above in module
+%% \code{Stream}).  Even though \code{Stream.range} and \code{List.range}
+%% look similar, their execution behavior is completely different: 
+
+%% \code{Stream.range} immediately returns with a \code{Stream} object
+%% whose first element is \code{start}.  All other elements are computed
+%% only when they are \emph{demanded} by calling the \code{tail} method
+%% (which might be never at all).  
+
+%% Streams are accessed just as lists. Similarly to lists, the basic access
+%% methods are \code{isEmpty}, \code{head} and \code{tail}. For instance,
+%% we can print all elements of a stream as follows.
+%% \begin{lstlisting}
+%% def print(xs: Stream[A]) {
+%%   if (!xs.isEmpty) { Console.println(xs.head); print(xs.tail) }
+%% }
+%% \end{lstlisting}
+%% Streams also support almost all other methods defined on lists (see
+%% below for where their methods sets differ). For instance, we can find
+%% the second prime number between \code{1000} and \code{10000} by applying methods
+%% \code{filter} and \code{apply} on an interval stream:
+%% \begin{lstlisting}
+%%   Stream.range(1000, 10000) filter isPrime at 1
+%% \end{lstlisting}
+%% The difference to the previous list-based implementation is that now
+%% we do not needlessly construct and test for primality any numbers
+%% beyond 1013.
+
+%% \paragraph{Consing and appending streams} Two methods in class \code{List}
+%% which are not supported by class \code{Stream} are \code{::} and
+%% \code{:::}.  The reason is that these methods are dispatched on their
+%% right-hand side argument, which means that this argument needs to be
+%% evaluated before the method is called. For instance, in the case of
+%% \code{x :: xs} on lists, the tail \code{xs} needs to be evaluated
+%% before \code{::} can be called and the new list can be constructed.
+%% This does not work for streams, where we require that the tail of a
+%% stream should not be evaluated until it is demanded by a \code{tail} operation.
+%% The argument why list-append \code{:::} cannot be adapted to streams is analogous.
+
+%% Instead of \code{x :: xs}, one uses \code{Stream.cons(x, xs)} for
+%% constructing a stream with first element \code{x} and (unevaluated)
+%% rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
+%% \code{xs append ys}.  
+
+%% \chapter{Iterators}
+
+%% Iterators are the imperative version of streams. Like streams,
+%% iterators describe potentially infinite lists. However, there is no
+%% data-structure which contains the elements of an iterator. Instead, 
+%% iterators allow one to step through the sequence, using two abstract methods \code{next} and \code{hasNext}.
+%% \begin{lstlisting}
+%% trait Iterator[+A] {
+%%   def hasNext: Boolean
+%%   def next: A
+%% \end{lstlisting}
+%% Method \code{next} returns successive elements.  Method \code{hasNext}
+%% indicates whether there are still more elements to be returned by
+%% \code{next}. Iterators also support some other methods, which are
+%% explained later.
+
+%% As an example, here is an application which prints the squares of all
+%% numbers from 1 to 100.
+%% \begin{lstlisting}
+%% val it: Iterator[Int] = Iterator.range(1, 100)
+%% while (it.hasNext) {
+%%   val x = it.next
+%%   println(x * x)
+%% }
+%% \end{lstlisting}
+
+%% \section{Iterator Methods}
+
+%% Iterators support a rich set of methods besides \code{next} and
+%% \code{hasNext}, which is described in the following. Many of these
+%% methods mimic a corresponding functionality in lists.
+
+%% \paragraph{Append}
+%% Method \code{append} constructs an iterator which resumes with the
+%% given iterator ~\code{it}~ after the current iterator has finished.
+%% \begin{lstlisting}
+%%   def append[B >: A](that: Iterator[B]): Iterator[B] = new Iterator[B] {
+%%     def hasNext = Iterator.this.hasNext || that.hasNext
+%%     def next = if (Iterator.this.hasNext) Iterator.this.next else that.next
+%%   }    
+%% \end{lstlisting}
+%% The terms \code{Iterator.this.next} and \code{Iterator.this.hasNext}
+%% in the definition of \code{append} call the corresponding methods as
+%% they are defined in the enclosing \code{Iterator} class.  If the
+%% \code{Iterator} prefix to \code{this} would have been missing,
+%% \code{hasNext} and \code{next} would have called recursively the
+%% methods being defined in the result of \code{append}, which is not
+%% what we want.
+
+%% \paragraph{Map, FlatMap, Foreach} Method \code{map} 
+%% constructs an iterator which returns all elements of the original
+%% iterator transformed by a given function \code{f}.
+%% \begin{lstlisting}
+%%   def map[B](f: A => B): Iterator[B] = new Iterator[B] {
+%%     def hasNext = Iterator.this.hasNext
+%%     def next = f(Iterator.this.next)
+%%   }
+%% \end{lstlisting}
+%% Method \code{flatMap} is like method \code{map}, except that the
+%% transformation function \code{f} now returns an iterator.
+%% The result of \code{flatMap} is the iterator resulting from appending
+%% together all iterators returned from successive calls of \code{f}.
+%% \begin{lstlisting}
+%%   def flatMap[B](f: A => Iterator[B]): Iterator[B] = new Iterator[B] {
+%%     private var cur: Iterator[B] = Iterator.empty
+%%     def hasNext: Boolean =
+%%       if (cur.hasNext) true
+%%       else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); hasNext }
+%%       else false
+%%     def next: B =
+%%       if (cur.hasNext) cur.next
+%%       else if (Iterator.this.hasNext) { cur = f(Iterator.this.next); next }
+%%       else error("next on empty iterator")
+%%   }
+%% \end{lstlisting}
+%% Closely related to \code{map} is the \code{foreach} method, which
+%% applies a given function to all elements of an iterator, but does not
+%% construct a list of results
+%% \begin{lstlisting}
+%%   def foreach(f: A => Unit): Unit =
+%%     while (hasNext) { f(next) }
+%% \end{lstlisting}
+
+%% \paragraph{Filter} Method \code{filter} constructs an iterator which
+%% returns all elements of the original iterator that satisfy a criterion
+%% \code{p}.
+%% \begin{lstlisting}
+%%   def filter(p: A => Boolean) = new BufferedIterator[A] {
+%%     private val source =
+%%       Iterator.this.buffered
+%%     private def skip =
+%%       { while (source.hasNext && !p(source.head)) { source.next } }
+%%     def hasNext: Boolean =
+%%       { skip; source.hasNext }
+%%     def next: A =
+%%       { skip; source.next }
+%%     def head: A =
+%%       { skip; source.head }
+%%   }
+%% \end{lstlisting}
+%% In fact, \code{filter} returns instances of a subclass of iterators
+%% which are ``buffered''.  A \code{BufferedIterator} object is an
+%% iterator which has in addition a method \code{head}. This method
+%% returns the element which would otherwise have been returned by
+%% \code{head}, but does not advance beyond that element. Hence, the
+%% element returned by \code{head} is returned again by the next call to
+%% \code{head} or \code{next}. Here is the definition of the
+%% \code{BufferedIterator} trait.
+%% \begin{lstlisting}
+%% trait BufferedIterator[+A] extends Iterator[A] {
+%%   def head: A
+%% }
+%% \end{lstlisting}
+%% Since \code{map}, \code{flatMap}, \code{filter}, and \code{foreach}
+%% exist for iterators, it follows that for-comprehensions and for-loops
+%% can also be used on iterators. For instance, the application which prints the squares of numbers between 1 and 100 could have equivalently been expressed as follows.
+%% \begin{lstlisting}
+%% for (i <- Iterator.range(1, 100))
+%%   println(i * i)
+%% \end{lstlisting}
+
+%% \paragraph{Zip} Method \code{zip} takes another iterator and
+%% returns an iterator consisting of pairs of corresponding elements
+%% returned by the two iterators.
+%% \begin{lstlisting}
+%%   def zip[B](that: Iterator[B]) = new Iterator[(A, B)] {
+%%     def hasNext = Iterator.this.hasNext && that.hasNext
+%%     def next = (Iterator.this.next, that.next)
+%%   }
+%% }
+%% \end{lstlisting}
+
+%% \section{Constructing Iterators}
+
+%% Concrete iterators need to provide implementations for the two
+%% abstract methods \code{next} and \code{hasNext} in class
+%% \code{Iterator}. The simplest iterator is \code{Iterator.empty} which
+%% always returns an empty sequence:
+%% \begin{lstlisting}
+%% object Iterator {
+%%   object empty extends Iterator[Nothing] {
+%%     def hasNext = false
+%%     def next = error("next on empty iterator")
+%%   }
+%% \end{lstlisting}
+%% A more interesting iterator enumerates all elements of an array. This
+%% iterator is constructed by the \code{fromArray} method, which is also defined in the object \code{Iterator}
+%% \begin{lstlisting}
+%%   def fromArray[A](xs: Array[A]) = new Iterator[A] {
+%%     private var i = 0
+%%     def hasNext: Boolean =
+%%       i < xs.length
+%%     def next: A =
+%%       if (i < xs.length) { val x = xs(i); i += 1; x }
+%%       else error("next on empty iterator")
+%%   }
+%% \end{lstlisting}
+%% Another iterator enumerates an integer interval.  The
+%% \code{Iterator.range} function returns an iterator which traverses a
+%% given interval of integer values. It is defined as follows.
+%% \begin{lstlisting}
+%% object Iterator {
+%%   def range(start: Int, end: Int) = new Iterator[Int] {
+%%     private var current = start
+%%     def hasNext = current < end
+%%     def next = {
+%%       val r = current
+%%       if (current < end) current += 1
+%%       else error("end of iterator")
+%%       r
+%%     }
+%%   }
+%% }
+%% \end{lstlisting}
+%% All iterators seen so far terminate eventually. It is also possible to
+%% define iterators that go on forever. For instance, the following
+%% iterator returns successive integers from some start
+%% value\footnote{Due to the finite representation of type \prog{int},
+%% numbers will wrap around at $2^{31}$.}.
+%% \begin{lstlisting}
+%% def from(start: Int) = new Iterator[Int] {
+%%   private var last = start - 1
+%%   def hasNext = true
+%%   def next = { last += 1; last }
+%% }
+%% \end{lstlisting}
+
+%% \section{Using Iterators}
+
+%% Here are two more examples how iterators are used. First, to print all
+%% elements of an array \code{xs: Array[Int]}, one can write:
+%% \begin{lstlisting}
+%%   Iterator.fromArray(xs) foreach (x => println(x))
+%% \end{lstlisting}
+%% Or, using a for-comprehension:
+%% \begin{lstlisting}
+%%   for (x <- Iterator.fromArray(xs))
+%%     println(x)
+%% \end{lstlisting}
+%% As a second example, consider the problem of finding the indices of
+%% all the elements in an array of \code{double}s greater than some
+%% \code{limit}. The indices should be returned as an iterator.
+%% This is achieved by the following expression.
+%% \begin{lstlisting}
+%% import Iterator._
+%% fromArray(xs)
+%% .zip(from(0))
+%% .filter(case (x, i) => x > limit)
+%% .map(case (x, i) => i)
+%% \end{lstlisting}
+%% Or, using a for-comprehension:
+%% \begin{lstlisting}
+%% import Iterator._
+%% for ((x, i) <- fromArray(xs) zip from(0); x > limit)
+%% yield i
+%% \end{lstlisting}
+
+%% \chapter{Lazy Values}
+
+%% Lazy values provide a way to delay initialization of a value until the
+%% first time it is accessed. This may be useful when dealing with
+%% values that might not be needed during execution, and whose
+%% computational cost is signifficant. As a first example, let's consider
+%% a database of employees, containing for each employee its manager and
+%% its team.
+%% \begin{lstlisting}
+%% case class Employee(id: Int, 
+%%                     name: String, 
+%%                     managerId: Int) {
+%%   val manager: Employee = Db.get(managerId)
+%%   val team: List[Employee] = Db.team(id)
+%% }
+%% \end{lstlisting}
+
+%% The \lstinline@Employee@ class given above will eagerly initialize
+%% all its fields, loading the whole employee table in memory. This is
+%% certainly not optimal, and it can be easily  improved my making the
+%% fields lazy. This way we delay the database access until it is really
+%% needed, if it is ever needed.
+%% \begin{lstlisting}
+%% case class Employee(id: Int, 
+%%                     name: String, 
+%%                     managerId: Int) {
+%%   lazy val manager: Employee = Db.get(managerId)
+%%   lazy val team: List[Employee] = Db.team(id)
+%% }
+%% \end{lstlisting}
+
+%% To see what is really happening, we can use this mockup
+%% database which shows when records are fetched:
+%% \begin{lstlisting}
+%% object Db {
+%%   val table = Map(1 -> (1, "Haruki Murakami", -1),
+%%                   2 -> (2, "Milan Kundera", 1),
+%%                   3 -> (3, "Jeffrey Eugenides", 1),
+%%                   4 -> (4, "Mario Vargas Llosa", 1),
+%%                   5 -> (5, "Julian Barnes", 2))
+
+%%   def team(id: Int) = {
+%%     for (rec <- table.values.toList; if rec._3 == id)
+%%       yield recToEmployee(rec)
+%%   }
+
+%%   def get(id: Int) = recToEmployee(table(id))
+
+%%   private def recToEmployee(rec: (Int, String, Int)) = {
+%%     println("[db] fetching " + rec._1)
+%%     Employee(rec._1, rec._2, rec._3)
+%%   }
+%% }
+%% \end{lstlisting}
+%% The output when running a program that retrieves one employee 
+%% confirms that the database is only accessed when referring  the lazy
+%% values.
+
+%% Another use of lazy values is to resolve the
+%% initialization order of applications composed of several
+%% modules. Before lazy values were introduced, the same effect was
+%% achieved by using \lstinline@object@ definitions. As a second example,
+%% we consider a compiler composed of several modules. We look first at a
+%% simple symbol table that defines a class for symbols and two
+%% predefined functions.
+%% \begin{lstlisting}
+%% class Symbols(val compiler: Compiler) {
+%%   import compiler.types._
+
+%%   val Add = new Symbol("+", FunType(List(IntType, IntType), IntType))
+%%   val Sub = new Symbol("-", FunType(List(IntType, IntType), IntType))
+
+%%   class Symbol(name: String, tpe: Type) {
+%%     override def toString = name + ": " + tpe
+%%   }
+%% }
+%% \end{lstlisting}
+%% The \lstinline@symbols@ module is parameterized with a \lstinline@Compiler@
+%% instance, which provides access to other services, such as the types
+%% module. In our example there are only two predefined functions,
+%% addition and subtraction, and their definitions depend on the \lstinline@types@
+%% module.
+%% \begin{lstlisting}
+%% class Types(val compiler: Compiler) {
+%%   import compiler.symtab._
+
+%%   abstract class Type
+%%   case class FunType(args: List[Type], res: Type) extends Type
+%%   case class NamedType(sym: Symbol) extends Type
+%%   case object IntType extends Type
+%% }
+%% \end{lstlisting}
+%% In order to hook the two components together a compiler object is
+%% created and passed as an argument to the two components. 
+%% \begin{lstlisting}
+%% class Compiler {
+%%   val symtab = new Symbols(this)
+%%   val types  = new Types(this)
+%% }
+%% \end{lstlisting}
+%% Unfortunately, the straight-forward approach fails at runtime because
+%% the \lstinline@symtab@ module needs the \lstinline@types@
+%% module. In general, the dependency between modules can be complicated
+%% and getting the right initialization order is difficult, or even
+%% impossible when there are cycles. The easy fix is to make such fields
+%% \lstinline@lazy@ and let the compiler figure out the right order.
+%% \begin{lstlisting}
+%% class Compiler {
+%%   lazy val symtab = new Symbols(this)
+%%   lazy val types  = new Types(this)
+%% }
+%% \end{lstlisting}
+%% Now the two modules are initialized on first access, and the compiler
+%% may run as expected. 
+
+%% \subsection*{Syntax}
+%% The \lstinline@lazy@ modifier is allowed only on concrete value
+%% definitions. All typing rules for value definitions apply for
+%% \lstinline@lazy@ values as well, with one restriction removed:
+%% recursive local values are allowed.
+
+%% \chapter{Implicit Parameters and Conversions}\label{sec:implicits}
+
+%% Implicit parameters and conversions are powerful tools for
+%% custimizing existing libraries and for creating high-level
+%% abstractions. As an example, let's start with an abstract class of
+%% semi-groups that support an unspecified \lstinline@add@ operation.
+%% \begin{lstlisting}
+%% abstract class SemiGroup[A] {
+%%   def add(x: A, y: A): A
+%% }
+%% \end{lstlisting}
+%% Here's a subclass \lstinline@Monoid@ of \lstinline@SemiGroup@ which adds a
+%% \lstinline@unit@ element.
+%% \begin{lstlisting}
+%% abstract class Monoid[A] extends SemiGroup[A] {
+%%   def unit: A
+%% }
+%% \end{lstlisting}
+%% Here are two implementations of monoids:
+%% \begin{lstlisting}
+%% object stringMonoid extends Monoid[String] {
+%%   def add(x: String, y: String): String = x.concat(y)
+%%   def unit: String = ""
+%% }
+
+%% object intMonoid extends Monoid[Int] {
+%%   def add(x: Int, y: Int): Int = x + y
+%%   def unit: Int = 0
+%% }
+%% \end{lstlisting}
+%% A \lstinline@sum@ method, which works over arbitrary
+%% monoids, can be written in plain Scala as follows.
+%% \begin{lstlisting}
+%% def sum[A](xs: List[A])(m: Monoid[A]): A =
+%%   if (xs.isEmpty) m.unit
+%%   else m.add(xs.head, sum(m)(xs.tail)
+%% \end{lstlisting}
+%% This \lstinline@sum@ method can be called as follows:
+%% \begin{lstlisting}
+%% sum(List("a", "bc", "def"))(stringMonoid)
+%% sum(List(1, 2, 3))(intMonoid)
+%% \end{lstlisting}
+%% All this works, but it is not very nice. The problem is that the
+%% monoid implementations have to be passed into all code that uses them.
+%% We would sometimes wish that the system could figure out the correct
+%% arguments automatically, similar to what is done when type arguments
+%% are inferred. This is what implicit parameters provide.
+
+%% \subsection*{Implicit Parameters: The Basics}
+
+%% In Scala 2 there is a new \lstinline@implicit@ keyword that can be
+%% used at the beginning of a parameter list. Syntax:
+%% \begin{lstlisting}
+%% ParamClauses ::= {`(' [Param {`,' Param}] ')'} 
+%%                  [`(' implicit Param {`,' Param} `)']
+%% \end{lstlisting}
+%% If the keyword is present, it makes all parameters in the list
+%% implicit.  
+%% For instance, the following version of \lstinline@sum@ has
+%% \lstinline@m@ as an implicit parameter.
+%% \begin{lstlisting}
+%% def sum[A](xs: List[A])(implicit m: Monoid[A]): A =
+%%   if (xs.isEmpty) m.unit
+%%   else m.add(xs.head, sum(xs.tail))
+%% \end{lstlisting}
+%% As can be seen from the example, it is possible to combine normal and
+%% implicit parameters. However, there may only be one implicit parameter
+%% list for a method or constructor, and it must come last.
+
+%% \lstinline@implicit@ can also be used as a modifier for definitions
+%% and declarations. Examples:
+
+%% \begin{lstlisting}
+%% implicit object stringMonoid extends Monoid[String] {
+%%   def add(x: String, y: String): String = x.concat(y)
+%%   def unit: String = ""
+%% }
+%% implicit object intMonoid extends Monoid[Int] {
+%%   def add(x: Int, y: Int): Int = x + y
+%%   def unit: Int = 0
+%% }
+%% \end{lstlisting}
+
+%% The principal idea behind implicit parameters is that arguments for
+%% them can be left out from a method call. If the arguments
+%% corresponding to an implicit parameter section are missing, they are
+%% inferred by the Scala compiler.
+
+%% The actual arguments that are eligible to be passed to an implicit
+%% parameter are all identifiers X that can be accessed at the point
+%% of the method call without a prefix and that denote an implicit
+%% definition or parameter.
+
+%% If there are several eligible arguments which match the implicit
+%% parameter's type, the Scala compiler will chose a most specific one,
+%% using the standard rules of static overloading resolution.
+%% For instance, assume the call
+%% \begin{lstlisting}
+%%   sum(List(1, 2, 3))
+%% \end{lstlisting}
+%% in a context where \lstinline@stringMonoid@ and \lstinline@intMonoid@
+%% are visible.  We know that the formal type parameter \lstinline@a@ of
+%% \lstinline@sum@ needs to be instantiated to \lstinline@int@. The only
+%% eligible value which matches the implicit formal parameter type
+%% \lstinline@Monoid[Int]@ is \lstinline@intMonoid@ so this object will %
+%% be passed as implicit parameter.
+
+%% This discussion also shows that implicit parameters are inferred after
+%% any type arguments are inferred. 
+
+%% \subsection*{Implicit Conversions}
+
+%% Say you have an expression $E$ of type $T$ which is expected to type
+%% $S$. $T$ does not conform to $S$ and is not convertible to $S$ by
+%% some other predefined conversion. Then the Scala compiler will try to
+%% apply as last resort an implicit conversion $I(E)$. Here, $I$ is an
+%% identifier denoting an implicit definition or parameter that is
+%% accessible without a prefix at the point of the conversion, that can
+%% be applied to arguments of type $T$ and whose result type conforms to the
+%% expected type $S$.
+
+%% Implicit conversions can also be applied in member
+%% selections. Given a selection $E.x$ where $x$ is not a member of the
+%% type $E$, the Scala compiler will try to insert an implicit conversion
+%% $I(E).x$, so that $x$ is a member of $I(E)$.
+
+%% Here is an example of an implicit conversion function that converts
+%% integers into instances of class \lstinline@scala.Ordered@:
+%% \begin{lstlisting}
+%% implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
+%%   def compare(y: Int): Int =
+%%     if (x < y) -1
+%%     else if (x > y) 1
+%%     else 0
+%% }
+%% \end{lstlisting}
+
+%% \subsection*{View Bounds}
+
+%% View bounds are convenient syntactic sugar for implicit
+%% parameters. Consider for instance a generic sort method:
+%% \begin{lstlisting}
+%% def sort[A <$\mbox{\%}$ Ordered[A]](xs: List[A]): List[A] =
+%%   if (xs.isEmpty || xs.tail.isEmpty) xs
+%%   else {
+%%     val {ys, zs} = xs.splitAt(xs.length / 2)
+%%     merge(ys, zs)
+%%   }
+%% \end{lstlisting}
+%% The view bounded type parameter \lstinline@[a <$\mbox{\%}$ Ordered[a]]@
+%% expresses that \lstinline@sort@ is applicable to lists of type
+%% \lstinline@a@ such that there exists an implicit conversion from
+%% \lstinline@a@ to \lstinline@Ordered[a]@. The definition is treated as
+%% a shorthand for the following method signature with an implicit
+%% parameter:
+%% \begin{lstlisting}
+%% def sort[A](xs: List[A])(implicit $c$: A => Ordered[A]): List[A] = ...
+%% \end{lstlisting}
+%% (Here, the parameter name $c$ is chosen arbitrarily in a way
+%% that does not collide with other names in the program.)
+
+%% As a more detailed example, consider the \lstinline@merge@ method that
+%% comes with the \lstinline@sort@ method above:
+%% \begin{lstlisting}
+%% def merge[A <$\mbox{\%}$ Ordered[A]](xs: List[A], ys: List[A]): List[A] =
+%%   if (xs.isEmpty) ys
+%%   else if (ys.isEmpty) xs
+%%   else if (xs.head < ys.head) xs.head :: merge(xs.tail, ys)
+%%   else if ys.head :: merge(xs, ys.tail)
+%% \end{lstlisting}
+%% After expanding view bounds and inserting implicit conversions, this
+%% method implementation becomes:
+%% \begin{lstlisting}
+%% def merge[A](xs: List[A], ys: List[A])
+%%             (implicit $c$: A => Ordered[A]): List[A] =
+%%   if (xs.isEmpty) ys
+%%   else if (ys.isEmpty) xs
+%%   else if (c(xs.head) < ys.head) xs.head :: merge(xs.tail, ys)
+%%   else if ys.head :: merge(xs, ys.tail)(c)
+%% \end{lstlisting}
+%% The last two lines of this method definition illustrate two different
+%% uses of the implicit parameter $c$. It is applied in a conversion in
+%% the condition of the second to last line, and it is passed as implicit
+%% argument in the recursive call to \lstinline@merge@ on the last line.
+
+%% \comment{
+%% \chapter{Combinator Parsing}\label{sec:combinator-parsing}
+
+%% In this chapter we describe how to write combinator parsers in
+%% Scala. Such parsers are constructed from predefined higher-order
+%% functions, so called {\em parser combinators}, that closely model the
+%% constructions of an EBNF grammar \cite{wirth:ebnf}.
+
+%% As running example, we consider parsers for possibly nested
+%% lists of identifiers and numbers, which
+%% are described by the following context-free grammar.
+%% \bda{p{3cm}cp{10cm}}
+%% letter &::=& /* all letters */ \\
+%% digit  &::=& /* all digits */ \\[0.5em]
+%% ident  &::=& letter \{letter $|$ digit \}\\
+%% number &::=& digit \{digit\}\\[0.5em]
+%% list   &::=& `(' [listElems] `)' \\
+%% listElems &::=& expr [`,' listElems] \\
+%% expr   &::=& ident | number | list
+
+%% \eda
+
+%% \section{Simple Combinator Parsing}
+
+%% In this section we will only be concerned with the task of recognizing
+%% input strings, not with processing them. So we can describe parsers
+%% by the sets of input strings they accept.  There are two
+%% fundamental operators over parsers:
+%% \code{&} expresses the sequential composition of a parser with
+%% another, while \code{|} expresses an alternative. These operations
+%% will both be defined as methods of a \code{Parser} class.  We will
+%% also define constructors for the following primitive parsers:
+
+%% \begin{tabular}{ll}
+%% \code{empty}    & The parser that accepts the empty string
+%% \\
+%% \code{failure(msg: String)}  & The parser that accepts no string (\verb@msg@ 
+%%                                stands for an error message)
+
+%% \\
+%% \code{chr(c: char)}
+%%                 & The parser that accepts the single-character string ``$c$''.
+%% \\
+%% \code{chrSuchThat(p: Char => Boolean)}
+%%                 & The parser that accepts single-character strings
+%%                   ``$c$'' \\
+%%                 & for which $p(c)$ is true.
+%% \end{tabular}
+
+%% There are also the two higher-order parser combinators \code{opt},
+%% expressing optionality and \code{rep}, expressing repetition.
+%% For any parser $p$, \code{opt(}$p$\code{)} yields a parser that
+%% accepts the strings accepted by $p$ or else the empty string, while
+%% \code{rep(}$p$\code{)} accepts arbitrary sequences of the strings accepted by
+%% $p$. In EBNF, \code{opt(}$p$\code{)} corresponds to $[p]$ and
+%% \code{rep(}$p$\code{)} corresponds to $\{p\}$.
+
+%% The central idea of parser combinators is that parsers can be produced
+%% by a straightforward rewrite of the grammar, replacing \code{::=} with
+%% \code{=}, sequencing with
+%% \code{&}, repetition \code{\{...\}} with
+%% \code{rep(...)} and optional occurrence \code{[...]} with \code{opt(...)}.
+%% Applying this process to the grammar of lists
+%% yields the following trait.
+%% \begin{lstlisting}
+%% trait ListParsers extends Parsers {
+%%   def chrSuchThat(p: Char => Boolean): Parser
+%%   def chr(c: Char): Parser = chrSuchThat(d ==)
+
+%%   def letter    : Parser = chr(Character.isLetter)
+%%   def digit     : Parser = chr(Character.isDigit)
+
+%%   def ident     : Parser = letter &&& rep(letter ||| digit)
+%%   def number    : Parser = digit &&& rep(digit)
+%%   def list      : Parser = chr('(') &&& opt(listElems) &&& chr(')')
+%%   def listElems : Parser = expr &&& (chr(',') &&& listElems ||| empty)
+%%   def expr      : Parser = ident ||| number ||| list
+%% }
+%% \end{lstlisting}
+%% This class isolates the grammar from other aspects of parsing. It
+%% abstracts over the type of input 
+%% and over the method used to parse a single character
+%% (represented by the abstract method \code{chr(p: char =>
+%% boolean))}. The missing bits of information need to be supplied by code
+%% applying the parser class.
+
+%% It remains to explain how to implement a library with the combinators
+%% described above. We will pack combinators and their underlying
+%% implementation in a base class \code{Parsers}, which is inherited by
+%% \code{ListParsers}.  The first question to decide is which underlying
+%% representation type to use for a parser. We treat parsers here
+%% essentially as functions that take a datum of the input type
+%% \code{InType} and that yield a parse result of type
+%% \code{Option[InType]}.  The \code{Option} type is predefined as
+%% follows.
+%% \begin{lstlisting}
+%% abstract class Option[+a]
+%% case object None extends Option[Nothing]
+%% case class Some[a](x: a) extends Option[a]
+%% \end{lstlisting}
+%% A parser applied to some input either succeeds or fails. If it fails,
+%% it returns the constant \code{None}. If it succeeds, it returns a
+%% value of the form \code{Some(in1)} where \code{in1} represents the
+%% input that remains to be parsed.
+%% \begin{lstlisting}
+%% trait Parsers {
+%%   type InType
+%%   abstract class Parser {
+%%     type Result = Option[InType]
+%%     def apply(in: InType): Result
+%% \end{lstlisting}
+%% A parser also implements the combinators
+%% for sequence and alternative:
+%% \begin{lstlisting}
+%%   /*** p &&& q applies first p, and if that succeeds, then q
+%%    */
+%%   def &&& (q: => Parser) = new Parser {
+%%     def apply(in: InType): Result = Parser.this.apply(in) match {
+%%       case None => None
+%%       case Some(in1)  => q(in1)
+%%     }
+%%   }
+
+%%   /*** p ||| q applies first p, and, if that fails, then q.
+%%    */
+%%   def ||| (q: => Parser) = new Parser {
+%%     def apply(in: InType): Result = Parser.this.apply(in) match {
+%%       case None => q(in)
+%%       case s => s
+%%     }
+%%   }
+%% \end{lstlisting}
+%% The implementations of the primitive parsers \code{empty} and \code{fail}
+%% are trivial:
+%% \begin{lstlisting}
+%%   val empty = new Parser { def apply(in: InType): Result = Some(in) }
+%%   val fail  = new Parser { def apply(in: InType): Result = None }
+%% \end{lstlisting}
+%% The higher-order parser combinators \code{opt} and \code{rep} can be
+%% defined in terms of the combinators for sequence and alternative:
+%% \begin{lstlisting}
+%%   def opt(p: Parser): Parser = p ||| empty;    // p? = (p | <empty>)
+%%   def rep(p: Parser): Parser = opt(rep1(p));   // p* = [p+]
+%%   def rep1(p: Parser): Parser = p &&& rep(p);  // p+ = p p*
+%% } // end Parser
+%% \end{lstlisting}
+%% To run combinator parsers, we still need to decide on a way to handle
+%% parser input. Several possibilities exist: The input could be
+%% represented as a list, as an array, or as a random access file.  Note
+%% that the presented combinator parsers use backtracking to change from
+%% one alternative to another.  Therefore, it must be possible to reset
+%% input to a point that was previously parsed. If one restricted the
+%% focus to LL(1) grammars, a non-backtracking implementation of the
+%% parser combinators in class \code{Parsers} would also be possible. In
+%% that case sequential input methods based on (say) iterators or
+%% sequential files would also be possible.
+
+%% In our example, we represent the input by a pair of a string, which
+%% contains the input phrase as a whole, and an index, which represents
+%% the portion of the input which has not yet been parsed. Since the
+%% input string does not change, just the index needs to be passed around
+%% as a result of individual parse steps.  This leads to the following
+%% class of parsers that read strings:
+%% \begin{lstlisting}
+%% class ParseString(s: String) extends Parsers {
+%%   type InType = Int
+%%   def chrSuchThat(p: Char => Boolean) = new Parser {
+%%     def apply(in: Int): Parser#Result =
+%%       if (in < s.length() && p(s charAt in)) Some(in + 1)
+%%       else None
+%%   }
+%%   val input = 0
+%% }
+%% \end{lstlisting}
+%% This class implements a method \code{chr(p: Char => Boolean)} and a
+%% value \code{input}. The \code{chr} method builds a parser that either
+%% reads a single character satisfying the given predicate \code{p} or
+%% fails.  All other parsers over strings are ultimately implemented in
+%% terms of that method. The \code{input} value represents the input as a
+%% whole. In out case, it is simply value \code{0}, the start index of
+%% the string to be read.
+
+%% Note \code{apply}'s result type, \code{Parser#Result}. This syntax
+%% selects the type element \code{Result} of the type \code{Parser}. It
+%% thus corresponds roughly to selecting a static inner class from some
+%% outer class in Java. Note that we could {\em not} have written
+%% \code{Parser.Result}, as the latter would express selection of the
+%% \code{Result} element from a {\em value} named \code{Parser}.
+
+%% We have now extended the root class \code{Parsers} in two different
+%% directions: Class \code{ListParsers} defines a grammar of phrases to
+%% be parsed, whereas class \code{ParseString} defines a method by which
+%% such phrases are input. To write a concrete parsing application, we
+%% need to define both grammar and input method. We do this by combining
+%% two extensions of \code{Parsers} using a {\em mixin composition}.
+%% Here is the start of a sample application:
+%% \begin{lstlisting}
+%% object Test {
+%%   def main(args: Array[String]) {
+%%     val ps = new ParseString(args(0)) with ListParsers
+%%   }
+%% \end{lstlisting}
+%% The last line above creates a new family of parsers by composing class
+%% \code{ListParsers} with class \code{ParseString}. The two classes
+%% share the common superclass \code{Parsers}. The abstract method
+%% \code{chr} in \code{ListParsers} is implemented by class \code{ParseString}.
+
+%% To run the parser, we apply the start symbol of the grammar
+%% \code{expr} the argument code{input} and observe the result:
+%% \begin{lstlisting}
+%%     ps.expr(ps.input) match {
+%%       case Some(n) =>
+%%         println("parsed: " + args(0).substring(0, n))
+%%       case None =>
+%%         println("nothing parsed")
+%%     }
+%%   }
+%% }// end Test
+%% \end{lstlisting}
+%% Note the syntax ~\code{ps.expr(input)}, which treats the \code{expr}
+%% parser as if it was a function. In Scala, objects with \code{apply}
+%% methods can be applied directly to arguments as if they were functions.
+
+%% Here is an example run of the program above:
+%% \begin{lstlisting}
+%% > java examples.Test "(x,1,(y,z))"
+%% parsed: (x,1,(y,z))
+%% > java examples.Test "(x,,1,(y,z))"
+%% nothing parsed
+%% \end{lstlisting}
+
+%% \section{\label{sec:parsers-results}Parsers that Produce Results}
+
+%% The combinator library of the previous section does not support the
+%% generation of output from parsing. But usually one does not just want
+%% to check whether a given string belongs to the defined language, one
+%% also wants to convert the input string into some internal
+%% representation such as an abstract syntax tree.
+
+%% In this section, we modify our parser library to build parsers that
+%% produce results. We will make use of the for-comprehensions introduced
+%% in Chapter~\ref{sec:for-notation}.  The basic combinator of sequential
+%% composition, formerly ~\code{p &&& q}, now becomes
+%% \begin{lstlisting}
+%% for (x <- p; y <- q) yield e .
+%% \end{lstlisting}
+%% Here, the names \code{x} and \code{y} are bound to the results of
+%% executing the parsers \code{p} and \code{q}. \code{e} is an expression
+%% that uses these results to build the tree returned by the composed
+%% parser.
+
+%% Before describing the implementation of the new parser combinators, we
+%% explain how the new building blocks are used. Say we want to modify
+%% our list parser so that it returns an abstract syntax tree of the
+%% parsed expression. Syntax trees are given by the following class hierarchy:
+%% \begin{lstlisting}
+%% abstract class Tree
+%% case class Id (s: String)         extends Tree
+%% case class Num(n: Int)            extends Tree
+%% case class Lst(elems: List[Tree]) extends Tree
+%% \end{lstlisting}
+%% That is, a syntax tree is an identifier, an integer number, or a
+%% \code{Lst} node with a list of trees as descendants.
+
+%% As a first step towards parsers that produce results we define three
+%% little parsers that return a single read character as result.
+%% \begin{lstlisting}
+%% trait CharParsers extends Parsers {
+%%   def any: Parser[Char]
+%%   def chr(ch: Char): Parser[Char] =
+%%     for (c <- any if c == ch) yield c
+%%   def chrSuchThat(p: Char => Boolean): Parser[Char] =
+%%     for (c <- any if p(c)) yield c
+%% }
+%% \end{lstlisting}
+%% The \code{any} parser succeeds with the first character of remaining
+%% input as long as input is nonempty. It is abstract in class
+%% \code{ListParsers} since we want to abstract in this class from the
+%% concrete input method used.  The two \code{chr} parsers return as before
+%% the first input character if it equals a given character or matches a
+%% given predicate. They are now implemented in terms of \code{any}.
+
+%% The next level is represented by parsers reading identifiers, numbers
+%% and lists. Here is a parser for identifiers.
+%% \begin{lstlisting}
+%% trait ListParsers extends CharParsers {
+%%   def ident: Parser[Tree] = 
+%%     for {
+%%       c: Char <- chrSuchThat(Character.isLetter)
+%%       cs: List[Char] <- rep(chrSuchThat(Character.isLetterOrDigit))
+%%     } yield Id((c :: cs).mkString("", "", ""))
+%% \end{lstlisting}
+%% Remark: Because \code{chrSuchThat(...)} returns a single character, its
+%% repetition \code{rep(chrSuchThat(...))} returns a list of characters. The
+%% \code{yield} part of the for-comprehension converts all intermediate
+%% results into an \code{Id} node with a string as element.  To convert
+%% the read characters into a string, it conses them into a single list,
+%% and invokes the \code{mkString} method on the result.
+
+%% Here is a parser for numbers:
+%% \begin{lstlisting}
+%%   def number: Parser[Tree] =
+%%     for {
+%%       d: Char <- chrSuchThat(Character.isDigit)
+%%       ds: List[Char] <- rep(chrSuchThat(Character.isDigit))
+%%     } yield Num(((d - '0') /: ds) ((x, digit) => x * 10 + digit - '0'))
+%% \end{lstlisting}
+%% Intermediate results are in this case the leading digit of
+%% the read number, followed by a list of remaining digits.  The
+%% \code{yield} part of the for-comprehension reduces these to a number
+%% by a fold-left operation.
+
+%% Here is a parser for lists:
+%% \begin{lstlisting}
+%%   def list: Parser[Tree] = 
+%%     for {
+%%       _ <- chr('(')
+%%       es <- listElems ||| succeed(List())
+%%       _ <- chr(')')
+%%     } yield Lst(es)
+
+%%   def listElems: Parser[List[Tree]] = 
+%%     for {
+%%       x <- expr
+%%       xs <- chr(',') &&& listElems ||| succeed(List())
+%%     } yield x :: xs
+%% \end{lstlisting}
+%% The \code{list} parser returns a \code{Lst} node with a list of trees
+%% as elements.  That list is either the result of \code{listElems}, or,
+%% if that fails, the empty list (expressed here as: the result of a
+%% parser which always succeeds with the empty list as result).
+
+%% The highest level of our grammar is represented by function
+%% \code{expr}:
+%% \begin{lstlisting}
+%%   def expr: Parser[Tree] = 
+%%     ident ||| number ||| list
+%% }// end ListParsers.
+%% \end{lstlisting}
+%% We now present the parser combinators that support the new
+%% scheme. Parsers that succeed now return a parse result besides the
+%% un-consumed input.
+%% \begin{lstlisting}
+%% trait Parsers {
+%%   type InType
+%%   abstract class Parser[A] {
+%%     type Result = Option[(A, InType)]
+%%     def apply(in: InType): Result
+%% \end{lstlisting}
+%% Parsers are parameterized with the type of their result. The class
+%% \code{Parser[a]} now defines new methods \code{map}, \code{flatMap}
+%% and \code{filter}. The \code{for} expressions are mapped by the
+%% compiler to calls of these functions using the scheme described in
+%% Chapter~\ref{sec:for-notation}. For parsers, these methods are
+%% implemented as follows.
+%% \begin{lstlisting}
+%%     def filter(pred: A => Boolean) = new Parser[A] {
+%%       def apply(in: InType): Result = Parser.this.apply(in) match {
+%%         case None => None
+%%         case Some(x, in1) => if (pred(x)) Some(x, in1) else None
+%%       }
+%%     }
+%%     def map[B](f: A => B) = new Parser[B] {
+%%       def apply(in: InType): Result = Parser.this.apply(in) match {
+%%         case None => None
+%%         case Some(x, in1) => Some(f(x), in1)
+%%       }
+%%     }
+%%     def flatMap[b](f: A => Parser[B]) = new Parser[B] {
+%%       def apply(in: InType): Result = Parser.this.apply(in) match {
+%%         case None => None
+%%         case Some(x, in1) => f(x).apply(in1)
+%%       }
+%%     }
+%% \end{lstlisting}
+%% The \code{filter} method takes as parameter a predicate $p$ which it
+%% applies to the results of the current parser. If the predicate is
+%% false, the parser fails by returning \code{None}; otherwise it returns
+%% the result of the current parser.  The \code{map} method takes as
+%% parameter a function $f$ which it applies to the results of the
+%% current parser. The \code{flatMap} takes as parameter a function
+%% \code{f} which returns a parser.  It applies \code{f} to the result of
+%% the current parser and then continues with the resulting parser.  The
+%% \code{|||} method is essentially defined as before.  The
+%% \code{&&&} method can now be defined in terms of \code{for}.
+%% \begin{lstlisting}
+%%     def ||| (p: => Parser[A]) = new Parser[A] {
+%%       def apply(in: InType): Result = Parser.this.apply(in) match {
+%%         case None => p(in)
+%%         case s => s
+%%       }
+%%     }
+
+%%     def &&& [B](p: => Parser[B]): Parser[B] =
+%%       for (_ <- this; x <- p) yield x
+%%   }// end Parser
+%% \end{lstlisting}
+
+%% The primitive parser \code{succeed} replaces \code{empty}. It consumes
+%% no input and returns its parameter as result.
+%% \begin{lstlisting}
+%%   def succeed[A](x: A) = new Parser[A] {
+%%     def apply(in: InType) = Some(x, in)
+%%   }
+%% \end{lstlisting}
+
+%% The parser combinators \code{rep} and \code{opt} now also return
+%% results. \code{rep} returns a list which contains as elements the
+%% results of each iteration of its sub-parser. \code{opt} returns a list
+%% which is either empty or returns as single element the result of the
+%% optional parser.
+%% \begin{lstlisting}
+%%   def rep[A](p: Parser[A]): Parser[List[A]] =
+%%     rep1(p) ||| succeed(List())
+
+%%   def rep1[A](p: Parser[A]): Parser[List[A]] =
+%%     for (x <- p; xs <- rep(p)) yield x :: xs
+
+%%   def opt[A](p: Parser[A]): Parser[List[A]] =
+%%     (for (x <- p) yield List(x)) ||| succeed(List())
+%% } // end Parsers
+%% \end{lstlisting}
+%% The root class \code{Parsers} abstracts over which kind of
+%% input is parsed.  As before, we determine the input method by a separate class.
+%% Here is \code{ParseString}, this time adapted to parsers that return results.
+%% It defines now the method \code{any}, which returns the first input character.
+%% \begin{lstlisting}
+%% class ParseString(s: String) extends Parsers {
+%%   type InType = Int
+%%   val input = 0
+%%   def any = new Parser[Char] {
+%%     def apply(in: Int): Parser[Char]#Result =
+%%       if (in < s.length()) Some(s charAt in, in + 1) else None
+%%   }
+%% }
+%% \end{lstlisting}
+%% The rest of the application is as before. Here is a test program which
+%% constructs a list parser over strings and prints out the result of
+%% applying it to the command line argument.
+%% \begin{lstlisting}
+%% object Test {
+%%   def main(args: Array[String]) {
+%%     val ps = new ParseString(args(0)) with ListParsers
+%%     ps.expr(ps.input) match {
+%%       case Some(list, _) => println("parsed: " + list)
+%%       case None => println("nothing parsed")
+%%     }
+%%   }
+%% }
+%% \end{lstlisting}
+
+%% \begin{exercise}\label{exercise:end-marker} The parsers we have defined so
+%% far can succeed even if there is some input beyond the parsed text. To
+%% prevent this, one needs a parser which recognizes the end of input.
+%% Redesign the parser library so that such a parser can be introduced.
+%% Which classes need to be modified?
+%% \end{exercise}
+%% }
+
+%% \chapter{\label{sec:hm}Hindley/Milner Type Inference}
+
+%% This chapter demonstrates Scala's data types and pattern matching by
+%% developing a type inference system in the Hindley/Milner style
+%% \cite{milner:polymorphism}. The source language for the type inferencer is
+%% lambda calculus with a let construct called Mini-ML. Abstract syntax
+%% trees for the Mini-ML are represented by the following data type of
+%% \code{Terms}.
+%% \begin{lstlisting}
+%% abstract class Term {}
+%% case class Var(x: String) extends Term {
+%%   override def toString = x
+%% }
+%% case class Lam(x: String, e: Term) extends Term {
+%%   override def toString = "(\\" + x + "." + e + ")"
+%% }
+%% case class App(f: Term, e: Term) extends Term {
+%%   override def toString = "(" + f + " " + e + ")"
+%% }
+%% case class Let(x: String, e: Term, f: Term) extends Term {
+%%   override def toString = "let " + x + " = " + e + " in " + f
+%% }
+%% \end{lstlisting}
+%% There are four tree constructors: \code{Var} for variables, \code{Lam}
+%% for function abstractions, \code{App} for function applications, and
+%% \code{Let} for let expressions. Each case class overrides the
+%% \code{toString} method of class \code{Any}, so that terms can be
+%% printed in legible form.
+
+%% We next define the types that are
+%% computed by the inference system.
+%% \begin{lstlisting}
+%% sealed abstract class Type {}
+%% case class Tyvar(a: String) extends Type {
+%%   override def toString = a
+%% }
+%% case class Arrow(t1: Type, t2: Type) extends Type {
+%%   override def toString = "(" + t1 + "->" + t2 + ")"
+%% }
+%% case class Tycon(k: String, ts: List[Type]) extends Type {
+%%   override def toString = 
+%%     k + (if (ts.isEmpty) "" else ts.mkString("[", ",", "]"))
+%% }
+%% \end{lstlisting}
+%% There are three type constructors: \code{Tyvar} for type variables,
+%% \code{Arrow} for function types and \code{Tycon} for type constructors
+%% such as \code{Boolean} or \code{List}. Type constructors have as
+%% component a list of their type parameters. This list is empty for type
+%% constants such as \code{Boolean}. Again, the type constructors
+%% implement the \code{toString} method in order to display types legibly.
+
+%% Note that \code{Type} is a \code{sealed} class. This means that no
+%% subclasses or data constructors that extend \code{Type} can be formed
+%% outside the sequence of definitions in which \code{Type} is defined.
+%% This makes \code{Type} a {\em closed} algebraic data type with exactly
+%% three alternatives. By contrast, type \code{Term} is an {\em open}
+%% algebraic type for which further alternatives can be defined.
+
+%% The main parts of the type inferencer are contained in object
+%% \code{typeInfer}. We start with a utility function which creates
+%% fresh type variables:
+%% \begin{lstlisting}
+%% object typeInfer {
+%%   private var n: Int = 0
+%%   def newTyvar(): Type = { n += 1; Tyvar("a" + n) }
+%% \end{lstlisting}
+%% We next define a class for substitutions. A substitution is an
+%% idempotent function from type variables to types. It maps a finite
+%% number of type variables to some types, and leaves all other type
+%% variables unchanged. The meaning of a substitution is extended
+%% point-wise to a mapping from types to types. We also extend
+%% the meaning of substitution to environments, which are defined
+%% later.
+%% \begin{lstlisting}
+%%   abstract class Subst extends Function1[Type,Type] {
+
+%%     def lookup(x: Tyvar): Type
+
+%%     def apply(t: Type): Type = t match {
+%%       case tv @ Tyvar(a) => val u = lookup(tv); if (t == u) t else apply(u)
+%%       case Arrow(t1, t2) => Arrow(apply(t1), apply(t2))
+%%       case Tycon(k, ts) => Tycon(k, ts map apply)
+%%     }
+
+%%     def apply(env: Env): Env = env.map({ case (x, TypeScheme(tyvars, tpe)) =>
+%%       // assumes tyvars don't occur in this substitution
+%%       (x, TypeScheme(tyvars, apply(tpe)))
+%%     })
+
+%%     def extend(x: Tyvar, t: Type) = new Subst {
+%%       def lookup(y: Tyvar): Type = if (x == y) t else Subst.this.lookup(y)
+%%     }
+%%   }
+%%   val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
+%% \end{lstlisting}
+%% We represent substitutions as functions, of type \code{Type =>
+%% Type}. This is achieved by making class \code{Subst} inherit from the
+%% unary function type \code{Function1[Type, Type]}\footnote{
+%% The class inherits the function type as a mixin rather than as a direct 
+%% superclass. This is because in the current Scala implementation, the
+%% \code{Function1} type is a Java interface, which cannot be used as a direct
+%% superclass of some other class.}.
+%% To be an instance
+%% of this type, a substitution \code{s} has to implement an \code{apply}
+%% method that takes a \code{Type} as argument and yields another
+%% \code{Type} as result. A function application \code{s(t)} is then
+%% interpreted as \code{s.apply(t)}.
+
+%% The \code{lookup} method is abstract in class \code{Subst}.  There are
+%% two concrete forms of substitutions which differ in how they
+%% implement this method.  One form is defined by the \code{emptySubst} value,
+%% the other is defined by the \code{extend} method in class
+%% \code{Subst}.
+
+%% The next data type describes type schemes, which consist of a type and
+%% a list of names of type variables which appear universally quantified
+%% in the type scheme. 
+%% For instance, the type scheme $\forall a\forall b.a \!\arrow\! b$ would be represented in the type checker as:
+%% \begin{lstlisting}
+%% TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
+%% \end{lstlisting}
+%% The class definition of type schemes does not carry an extends
+%% clause; this means that type schemes extend directly class
+%% \code{AnyRef}.  Even though there is only one possible way to
+%% construct a type scheme, a case class representation was chosen
+%% since it offers convenient ways to decompose an instance of this type into its
+%% parts.
+%% \begin{lstlisting}
+%%   case class TypeScheme(tyvars: List[Tyvar], tpe: Type) {
+%%     def newInstance: Type = {
+%%       (emptySubst /: tyvars) ((s, tv) => s.extend(tv, newTyvar())) (tpe)
+%%     }
+%%   }
+%% \end{lstlisting}
+%% Type scheme objects come with a method \code{newInstance}, which
+%% returns the type contained in the scheme after all universally type
+%% variables have been renamed to fresh variables. The implementation of
+%% this method folds (with \code{/:}) the type scheme's type variables
+%% with an operation which extends a given substitution \code{s} by
+%% renaming a given type variable \code{tv} to a fresh type
+%% variable. The resulting substitution renames all type variables of the
+%% scheme to fresh ones. This substitution is then applied to the type
+%% part of the type scheme.
+
+%% The last type we need in the type inferencer is
+%% \code{Env}, a type for environments, which associate variable names
+%% with type schemes. They are represented by a type alias \code{Env} in
+%% module \code{typeInfer}:
+%% \begin{lstlisting}
+%%   type Env = List[(String, TypeScheme)]
+%% \end{lstlisting}
+%% There are two operations on environments. The \code{lookup} function
+%% returns the type scheme associated with a given name, or \code{null}
+%% if the name is not recorded in the environment.
+%% \begin{lstlisting}
+%%   def lookup(env: Env, x: String): TypeScheme = env match {
+%%     case List() => null
+%%     case (y, t) :: env1 => if (x == y) t else lookup(env1, x)
+%%   }
+%% \end{lstlisting}
+%% The \code{gen} function turns a given type into a type scheme,
+%% quantifying over all type variables that are free in the type, but
+%% not in the environment.
+%% \begin{lstlisting}
+%%   def gen(env: Env, t: Type): TypeScheme = 
+%%     TypeScheme(tyvars(t) diff tyvars(env), t)
+%% \end{lstlisting}
+%% The set of free type variables of a type is simply the set of all type
+%% variables which occur in the type. It is represented here as a list of
+%% type variables, which is constructed as follows.
+%% \begin{lstlisting}
+%%   def tyvars(t: Type): List[Tyvar] = t match {
+%%     case tv @ Tyvar(a) => 
+%%       List(tv)
+%%     case Arrow(t1, t2) => 
+%%       tyvars(t1) union tyvars(t2)
+%%     case Tycon(k, ts) => 
+%%       (List[Tyvar]() /: ts) ((tvs, t) => tvs union tyvars(t))
+%%   }
+%% \end{lstlisting}
+%% Note that the syntax \code{tv @ ...} in the first pattern introduces a variable
+%% which is bound to the pattern that follows. Note also that the explicit type parameter \code{[Tyvar]} in the expression of the third
+%% clause is needed to make local type inference work.
+
+%% The set of free type variables of a type scheme is the set of free
+%% type variables of its type component, excluding any quantified type variables:
+%% \begin{lstlisting}
+%%   def tyvars(ts: TypeScheme): List[Tyvar] = 
+%%     tyvars(ts.tpe) diff ts.tyvars
+%% \end{lstlisting}
+%% Finally, the set of free type variables of an environment is the union
+%% of the free type variables of all type schemes recorded in it.
+%% \begin{lstlisting}
+%%   def tyvars(env: Env): List[Tyvar] =
+%%     (List[Tyvar]() /: env) ((tvs, nt) => tvs union tyvars(nt._2))
+%% \end{lstlisting}
+%% A central operation of Hindley/Milner type checking is unification,
+%% which computes a substitution to make two given types equal (such a
+%% substitution is called a {\em unifier}).  Function \code{mgu} computes
+%% the most general unifier of two given types $t$ and $u$ under a
+%% pre-existing substitution $s$.  That is, it returns the most general
+%% substitution $s'$ which extends $s$, and which makes $s'(t)$ and
+%% $s'(u)$ equal types. 
+%% \begin{lstlisting}
+%%   def mgu(t: Type, u: Type, s: Subst): Subst = (s(t), s(u)) match {
+%%     case (Tyvar(a), Tyvar(b)) if (a == b) =>
+%%       s
+%%     case (st @ Tyvar(a), su) if !(tyvars(su) contains st) =>
+%%       s.extend(st, su)
+%%     case (_, Tyvar(a)) =>
+%%       mgu(u, t, s)
+%%     case (Arrow(t1, t2), Arrow(u1, u2)) =>
+%%       mgu(t1, u1, mgu(t2, u2, s))
+%%     case (Tycon(k1, ts), Tycon(k2, us)) if (k1 == k2) =>
+%%       (s /: (ts zip us)) ((s, tu) => mgu(tu._1, tu._2, s))
+%%     case _ => 
+%%       throw new TypeError("cannot unify " + s(t) + " with " + s(u))
+%%   }
+%% \end{lstlisting}
+%% The \code{mgu} function throws a \code{TypeError} exception if no
+%% unifier substitution exists. This can happen because the two types
+%% have different type constructors at corresponding places, or because a
+%% type variable is unified with a type that contains the type variable
+%% itself. Such exceptions are modeled here as instances of case classes
+%% that inherit from the predefined \code{Exception} class.
+%% \begin{lstlisting}
+%%   case class TypeError(s: String) extends Exception(s) {}
+%% \end{lstlisting}
+%% The main task of the type checker is implemented by function
+%% \code{tp}. This function takes as parameters an environment $env$, a
+%% term $e$, a proto-type $t$, and a
+%% pre-existing substitution $s$.  The function yields a substitution
+%% $s'$ that extends $s$ and that
+%% turns $s'(env) \ts e: s'(t)$ into a derivable type judgment according
+%% to the derivation rules of the Hindley/Milner type system \cite{milner:polymorphism}.  A
+%% \code{TypeError} exception is thrown if no such substitution exists.
+%% \begin{lstlisting}
+%%   def tp(env: Env, e: Term, t: Type, s: Subst): Subst = {
+%%     current = e
+%%     e match {
+%%       case Var(x) =>
+%%         val u = lookup(env, x)
+%%         if (u == null) throw new TypeError("undefined: " + x)
+%%         else mgu(u.newInstance, t, s)
+
+%%       case Lam(x, e1) =>
+%%         val a, b = newTyvar()
+%%         val s1 = mgu(t, Arrow(a, b), s)
+%%         val env1 = {x, TypeScheme(List(), a)} :: env
+%%         tp(env1, e1, b, s1)
+
+%%       case App(e1, e2) =>
+%%         val a = newTyvar()
+%%         val s1 = tp(env, e1, Arrow(a, t), s)
+%%         tp(env, e2, a, s1)
+
+%%       case Let(x, e1, e2) =>
+%%         val a = newTyvar()
+%%         val s1 = tp(env, e1, a, s)
+%%         tp({x, gen(s1(env), s1(a))} :: env, e2, t, s1)
+%%     }
+%%   } 
+%%   var current: Term = null
+%% \end{lstlisting}
+%% To aid error diagnostics, the \code{tp} function stores the currently
+%% analyzed sub-term in variable \code{current}. Thus, if type checking
+%% is aborted with a \code{TypeError} exception, this variable will
+%% contain the subterm that caused the problem.
+
+%% The last function of the type inference module, \code{typeOf}, is a
+%% simplified facade for \code{tp}. It computes the type of a given term
+%% $e$ in a given environment $env$. It does so by creating a fresh type
+%% variable $a$, computing a typing substitution that makes $env \ts e: a$
+%% into a derivable type judgment, and returning
+%% the result of applying the substitution to $a$.
+%% \begin{lstlisting}
+%%   def typeOf(env: Env, e: Term): Type = {
+%%     val a = newTyvar()
+%%     tp(env, e, a, emptySubst)(a)
+%%   }
+%% }// end typeInfer
+%% \end{lstlisting}
+%% To apply the type inferencer, it is convenient to have a predefined
+%% environment that contains bindings for commonly used constants. The
+%% module \code{predefined} defines an environment \code{env} that
+%% contains bindings for the types of booleans, numbers and lists
+%% together with some primitive operations over them. It also
+%% defines a fixed point operator \code{fix}, which can be used to
+%% represent recursion.
 \begin{lstlisting}
 object predefined {
   val booleanType = Tycon("Boolean", List())
@@ -6325,10 +6395,10 @@ object predefined {
   )
 }
 \end{lstlisting}
-Here's an example how the type inferencer can be used.
-Let's define a function \code{showType} which returns the type of
-a given term computed in the predefined environment
-\code{Predefined.env}:
+%% Here's an example how the type inferencer can be used.
+%% Let's define a function \code{showType} which returns the type of
+%% a given term computed in the predefined environment
+%% \code{Predefined.env}:
 \begin{lstlisting}
 object testInfer {
   def showType(e: Term): String =
@@ -6348,12 +6418,12 @@ would give the response
 \begin{lstlisting}
 > (a6->List[a6])
 \end{lstlisting}
-\comment{
-To make the type inferencer more useful, we complete it with a
-parser. 
-Function \code{main} of module \code{testInfer}
-parses and typechecks a Mini-ML expression which is given as the first
-command line argument.
+%% \comment{
+%% To make the type inferencer more useful, we complete it with a
+%% parser. 
+%% Function \code{main} of module \code{testInfer}
+%% parses and typechecks a Mini-ML expression which is given as the first
+%% command line argument.
 \begin{lstlisting}
   def main(args: Array[String]) {
     val ps = new ParseString(args(0)) with MiniMLParsers
@@ -6366,12 +6436,12 @@ command line argument.
   }
 %}// testInfer
 \end{lstlisting}
-To do the parsing, method \code{main} uses the combinator parser
-scheme of Chapter~\ref{sec:combinator-parsing}. It creates a parser
-family \code{ps} as a mixin composition of parsers
-that understand MiniML (but do not know where input comes from) and
-parsers that read input from a given string.  The \code{MiniMLParsers}
-object implements parsers for the following grammar.
+%% To do the parsing, method \code{main} uses the combinator parser
+%% scheme of Chapter~\ref{sec:combinator-parsing}. It creates a parser
+%% family \code{ps} as a mixin composition of parsers
+%% that understand MiniML (but do not know where input comes from) and
+%% parsers that read input from a given string.  The \code{MiniMLParsers}
+%% object implements parsers for the following grammar.
 \begin{lstlisting}
 term  ::= "\" ident "." term
        |  term1 {term1}
@@ -6380,13 +6450,13 @@ term1 ::= ident
        |  "(" term ")"
 all   ::= term ";"
 \end{lstlisting}
-Input as a whole is described by the production \code{all}; it
-consists of a term followed by a semicolon. We allow ``whitespace''
-consisting of one or more space, tabulator or newline characters
-between any two lexemes (this is not reflected in the grammar
-above). Identifiers are defined as in
-Chapter~\ref{sec:combinator-parsing} except that an identifier cannot
-be one of the two reserved words "let" and "in".
+%% Input as a whole is described by the production \code{all}; it
+%% consists of a term followed by a semicolon. We allow ``whitespace''
+%% consisting of one or more space, tabulator or newline characters
+%% between any two lexemes (this is not reflected in the grammar
+%% above). Identifiers are defined as in
+%% Chapter~\ref{sec:combinator-parsing} except that an identifier cannot
+%% be one of the two reserved words "let" and "in".
 \begin{lstlisting}
 trait MiniMLParsers extends CharParsers {
 
@@ -6484,20 +6554,20 @@ let id = (\x.x) in (((if (id true)) (id nil)) zero):
  reason: cannot unify Int with List[a14]
 \end{lstlisting}
 
-\begin{exercise}\label{exercise:hm-parse} Using the parser library constructed in
-Exercise~\ref{exercise:end-marker}, modify the MiniML parser library
-so that no marker ``;'' is necessary for indicating the end of input.
-\end{exercise}
-}
+%% \begin{exercise}\label{exercise:hm-parse} Using the parser library constructed in
+%% Exercise~\ref{exercise:end-marker}, modify the MiniML parser library
+%% so that no marker ``;'' is necessary for indicating the end of input.
+%% \end{exercise}
+%% }
 
-\begin{exercise}\label{execcise:hm-extend} Extend the Mini-ML \comment{parser and} type
-inferencer with a \code{letrec} construct which allows the definition of
-recursive functions. Syntax:
-\begin{lstlisting}
-letrec ident "=" term in term .
-\end{lstlisting}
-The typing of \code{letrec} is as for \code{let}, 
-except that the defined identifier is visible in the defining expression. Using \code{letrec}, the \code{length} function for lists can now be defined as follows.
+%% \begin{exercise}\label{execcise:hm-extend} Extend the Mini-ML \comment{parser and} type
+%% inferencer with a \code{letrec} construct which allows the definition of
+%% recursive functions. Syntax:
+%% \begin{lstlisting}
+%% letrec ident "=" term in term .
+%% \end{lstlisting}
+%% The typing of \code{letrec} is as for \code{let}, 
+%% except that the defined identifier is visible in the defining expression. Using \code{letrec}, the \code{length} function for lists can now be defined as follows.
 \begin{lstlisting}
 letrec length = \xs.
   if (isEmpty xs)
@@ -6507,17 +6577,17 @@ in ...
 \end{lstlisting}
 \end{exercise}
 
-\chapter{Abstractions for Concurrency}\label{sec:ex-concurrency}
+%% \chapter{Abstractions for Concurrency}\label{sec:ex-concurrency}
 
-This section reviews common concurrent programming patterns and shows
-how they can be implemented in Scala.
+%% This section reviews common concurrent programming patterns and shows
+%% how they can be implemented in Scala.
 
-\section{Signals and Monitors}
+%% \section{Signals and Monitors}
 
-\example
-The {\em monitor} provides the basic means for mutual exclusion
-of processes in Scala. Every instance of class \code{AnyRef} can be
-used as a monitor by calling one or more of the methods below.
+%% \example
+%% The {\em monitor} provides the basic means for mutual exclusion
+%% of processes in Scala. Every instance of class \code{AnyRef} can be
+%% used as a monitor by calling one or more of the methods below.
 \begin{lstlisting}
   def synchronized[A] (e: => A): A
   def wait()
@@ -6525,31 +6595,31 @@ used as a monitor by calling one or more of the methods below.
   def notify()
   def notifyAll()
 \end{lstlisting}
-The \code{synchronized} method executes its argument computation
-\code{e} in mutual exclusive mode -- at any one time, only one thread
-can execute a \code{synchronized} argument of a given monitor.
+%% The \code{synchronized} method executes its argument computation
+%% \code{e} in mutual exclusive mode -- at any one time, only one thread
+%% can execute a \code{synchronized} argument of a given monitor.
 
-Threads can suspend inside a monitor by waiting on a signal.  Threads
-that call the \code{wait} method wait until a \code{notify} method of
-the same object is called subsequently by some other thread. Calls to
-\code{notify} with no threads waiting for the signal are ignored.
+%% Threads can suspend inside a monitor by waiting on a signal.  Threads
+%% that call the \code{wait} method wait until a \code{notify} method of
+%% the same object is called subsequently by some other thread. Calls to
+%% \code{notify} with no threads waiting for the signal are ignored.
 
-There is also a timed form of \code{wait}, which blocks only as long
-as no signal was received or the specified amount of time (given in
-milliseconds) has elapsed. Furthermore, there is a \code{notifyAll}
-method which unblocks all threads which wait for the signal.  These
-methods, as well as class \code{Monitor} are primitive in Scala; they
-are implemented in terms of the underlying runtime system.
+%% There is also a timed form of \code{wait}, which blocks only as long
+%% as no signal was received or the specified amount of time (given in
+%% milliseconds) has elapsed. Furthermore, there is a \code{notifyAll}
+%% method which unblocks all threads which wait for the signal.  These
+%% methods, as well as class \code{Monitor} are primitive in Scala; they
+%% are implemented in terms of the underlying runtime system.
 
-Typically, a thread waits for some condition to be established. If the
-condition does not hold at the time of the wait call, the thread
-blocks until some other thread has established the condition. It is
-the responsibility of this other thread to wake up waiting processes
-by issuing a \code{notify} or \code{notifyAll}. Note however, that
-there is no guarantee that a waiting process gets to run immediately
-after the call to notify is issued. It could be that other processes
-get to run first which invalidate the condition again. Therefore, the
-correct form of waiting for a condition $C$ uses a while loop:
+%% Typically, a thread waits for some condition to be established. If the
+%% condition does not hold at the time of the wait call, the thread
+%% blocks until some other thread has established the condition. It is
+%% the responsibility of this other thread to wake up waiting processes
+%% by issuing a \code{notify} or \code{notifyAll}. Note however, that
+%% there is no guarantee that a waiting process gets to run immediately
+%% after the call to notify is issued. It could be that other processes
+%% get to run first which invalidate the condition again. Therefore, the
+%% correct form of waiting for a condition $C$ uses a while loop:
 \begin{lstlisting}
 while (!$C$) wait()
 \end{lstlisting}
@@ -6585,9 +6655,9 @@ spawn { while (true) { val s = produceString ; buf.put(s) } }
 spawn { while (true) { val s = buf.get ; consumeString(s) } }
 }
 \end{lstlisting}
-The \code{spawn} method spawns a new thread which executes the
-expression given in the parameter. It is defined in object \code{concurrent.ops}
-as follows.
+%% The \code{spawn} method spawns a new thread which executes the
+%% expression given in the parameter. It is defined in object \code{concurrent.ops}
+%% as follows.
 \begin{lstlisting}
 def spawn(p: => Unit) {
   val t = new Thread() { override def run() = p }
@@ -6595,15 +6665,15 @@ def spawn(p: => Unit) {
 }
 \end{lstlisting}
 
-\comment{
-\section{Logic Variable}
+%% \comment{
+%% \section{Logic Variable}
 
-A logic variable (or lvar for short) offers operations \code{:=}
-and \code{value} to define the variable and to retrieve its value.
-Variables can be \code{define}d only once. A call to \code{value}
-blocks until the variable has been defined.
+%% A logic variable (or lvar for short) offers operations \code{:=}
+%% and \code{value} to define the variable and to retrieve its value.
+%% Variables can be \code{define}d only once. A call to \code{value}
+%% blocks until the variable has been defined.
 
-Logic variables can be implemented as follows.
+%% Logic variables can be implemented as follows.
 
 \begin{lstlisting}
 class LVar[A] {
@@ -6621,14 +6691,14 @@ class LVar[A] {
 \end{lstlisting}
 }
 
-\section{SyncVars}
+%% \section{SyncVars}
 
-A synchronized variable (or syncvar for short) offers \code{get} and
-\code{put} operations to read and set the variable. \code{get} operations
-block until the variable has been defined. An \code{unset} operation
-resets the variable to undefined state.
+%% A synchronized variable (or syncvar for short) offers \code{get} and
+%% \code{put} operations to read and set the variable. \code{get} operations
+%% block until the variable has been defined. An \code{unset} operation
+%% resets the variable to undefined state.
 
-Here's the standard implementation of synchronized variables.
+%% Here's the standard implementation of synchronized variables.
 \begin{lstlisting}
 package scala.concurrent
 class SyncVar[A] {
@@ -6650,13 +6720,13 @@ class SyncVar[A] {
 }
 \end{lstlisting}
 
-\section{Futures}
-\label{sec:futures}
+%% \section{Futures}
+%% \label{sec:futures}
 
-A {\em future} is a value which is computed in parallel to some other
-client thread, to be used by the client thread at some future time.
-Futures are used in order to make good use of parallel processing
-resources.  A typical usage is:
+%% A {\em future} is a value which is computed in parallel to some other
+%% client thread, to be used by the client thread at some future time.
+%% Futures are used in order to make good use of parallel processing
+%% resources.  A typical usage is:
 
 \begin{lstlisting}
 import scala.concurrent.ops._
@@ -6666,8 +6736,8 @@ anotherLengthyComputation
 val y = f(x()) + g(x())
 \end{lstlisting}
 
-The \code{future} method is defined in object
-\code{scala.concurrent.ops} as follows.
+%% The \code{future} method is defined in object
+%% \code{scala.concurrent.ops} as follows.
 \begin{lstlisting}
 def future[A](p: => A): Unit => A = {
   val result = new SyncVar[A]
@@ -6676,28 +6746,28 @@ def future[A](p: => A): Unit => A = {
 }
 \end{lstlisting}
 
-The \code{future} method gets as parameter a computation \code{p} to
-be performed. The type of the computation is arbitrary; it is
-represented by \code{future}'s type parameter \code{a}.  The
-\code{future} method defines a guard \code{result}, which takes a
-parameter representing the result of the computation. It then forks
-off a new thread that computes the result and invokes the
-\code{result} guard when it is finished. In parallel to this thread,
-the function returns an anonymous function of type \code{a}.
-When called, this functions waits on the result guard to be
-invoked, and, once this happens returns the result argument.
-At the same time, the function reinvokes the \code{result} guard with
-the same argument, so that future invocations of the function can
-return the result immediately.
+%% The \code{future} method gets as parameter a computation \code{p} to
+%% be performed. The type of the computation is arbitrary; it is
+%% represented by \code{future}'s type parameter \code{a}.  The
+%% \code{future} method defines a guard \code{result}, which takes a
+%% parameter representing the result of the computation. It then forks
+%% off a new thread that computes the result and invokes the
+%% \code{result} guard when it is finished. In parallel to this thread,
+%% the function returns an anonymous function of type \code{a}.
+%% When called, this functions waits on the result guard to be
+%% invoked, and, once this happens returns the result argument.
+%% At the same time, the function reinvokes the \code{result} guard with
+%% the same argument, so that future invocations of the function can
+%% return the result immediately.
 
-\section{Parallel Computations}
+%% \section{Parallel Computations}
 
-The next example presents a function \code{par} which takes a pair of
-computations as parameters and which returns the results of the computations
-in another pair. The two computations are performed in parallel.
+%% The next example presents a function \code{par} which takes a pair of
+%% computations as parameters and which returns the results of the computations
+%% in another pair. The two computations are performed in parallel.
 
-The function is defined in object
-\code{scala.concurrent.ops} as follows.
+%% The function is defined in object
+%% \code{scala.concurrent.ops} as follows.
 \begin{lstlisting}
   def par[A, B](xp: => A, yp: => B): (A, B) = {
     val y = new SyncVar[B]
@@ -6705,9 +6775,9 @@ The function is defined in object
     (xp, y.get)
   }
 \end{lstlisting}
-Defined in the same place is a function \code{replicate} which performs a
-number of replicates of a computation in parallel. Each
-replication instance is passed an integer number which identifies it.
+%% Defined in the same place is a function \code{replicate} which performs a
+%% number of replicates of a computation in parallel. Each
+%% replication instance is passed an integer number which identifies it.
 \begin{lstlisting}
   def replicate(start: Int, end: Int)(p: Int => Unit) {
     if (start == end)
@@ -6722,8 +6792,8 @@ replication instance is passed an integer number which identifies it.
   }
 \end{lstlisting}
 
-The next function uses \code{replicate} to perform parallel
-computations on all elements of an array.
+%% The next function uses \code{replicate} to perform parallel
+%% computations on all elements of an array.
 
 \begin{lstlisting}
 def parMap[A,B](f: A => B, xs: Array[A]): Array[B] = {
@@ -6733,11 +6803,11 @@ def parMap[A,B](f: A => B, xs: Array[A]): Array[B] = {
 }
 \end{lstlisting}
 
-\section{Semaphores}
+%% \section{Semaphores}
 
-A common mechanism for process synchronization is a {\em lock} (or:
-{\em semaphore}). A lock offers two atomic actions: \prog{acquire} and
-\prog{release}. Here's the implementation of a lock in Scala:
+%% A common mechanism for process synchronization is a {\em lock} (or:
+%% {\em semaphore}). A lock offers two atomic actions: \prog{acquire} and
+%% \prog{release}. Here's the implementation of a lock in Scala:
 
 \begin{lstlisting}
 package scala.concurrent
@@ -6755,21 +6825,21 @@ class Lock {
 }
 \end{lstlisting}
 
-\section{Readers/Writers}
+%% \section{Readers/Writers}
 
-A more complex form of synchronization distinguishes between {\em
-readers} which access a common resource without modifying it and {\em
-writers} which can both access and modify it. To synchronize readers
-and writers we need to implement operations \prog{startRead}, \prog{startWrite},
-\prog{endRead}, \prog{endWrite}, such that:
-\begin{itemize}
-\item there can be multiple concurrent readers,
-\item there can only be one writer at one time,
-\item pending write requests have priority over pending read requests,
-but don't preempt ongoing read operations.
-\end{itemize}
-The following implementation of a readers/writers lock is based on the
-{\em mailbox} concept (see Section~\ref{sec:mailbox}).
+%% A more complex form of synchronization distinguishes between {\em
+%% readers} which access a common resource without modifying it and {\em
+%% writers} which can both access and modify it. To synchronize readers
+%% and writers we need to implement operations \prog{startRead}, \prog{startWrite},
+%% \prog{endRead}, \prog{endWrite}, such that:
+%% \begin{itemize}
+%% \item there can be multiple concurrent readers,
+%% \item there can only be one writer at one time,
+%% \item pending write requests have priority over pending read requests,
+%% but don't preempt ongoing read operations.
+%% \end{itemize}
+%% The following implementation of a readers/writers lock is based on the
+%% {\em mailbox} concept (see Section~\ref{sec:mailbox}).
 
 \begin{lstlisting}
 import scala.concurrent._
@@ -6797,26 +6867,26 @@ class ReadersWriters {
 }
 \end{lstlisting}
 
-\section{Asynchronous Channels}
+%% \section{Asynchronous Channels}
 
-A fundamental way of interprocess communication is the asynchronous
-channel. Its implementation makes use the following simple class for linked
-lists:
+%% A fundamental way of interprocess communication is the asynchronous
+%% channel. Its implementation makes use the following simple class for linked
+%% lists:
 \begin{lstlisting}
 class LinkedList[A] {
   var elem: A = _
   var next: LinkedList[A] = null
 }
 \end{lstlisting}
-To facilitate insertion and deletion of elements into linked lists,
-every reference into a linked list points to the node which precedes
-the node which conceptually forms the top of the list.
-Empty linked lists start with a dummy node, whose successor is \code{null}.
+%% To facilitate insertion and deletion of elements into linked lists,
+%% every reference into a linked list points to the node which precedes
+%% the node which conceptually forms the top of the list.
+%% Empty linked lists start with a dummy node, whose successor is \code{null}.
 
-The channel class uses a linked list to store data that has been sent
-but not read yet. At the opposite end, threads that
-wish to read from an empty channel, register their presence by
-incrementing the \code{nreaders} field and waiting to be notified.
+%% The channel class uses a linked list to store data that has been sent
+%% but not read yet. At the opposite end, threads that
+%% wish to read from an empty channel, register their presence by
+%% incrementing the \code{nreaders} field and waiting to be notified.
 \begin{lstlisting}
 package scala.concurrent
 
@@ -6847,12 +6917,12 @@ class Channel[A] {
 }
 \end{lstlisting}
 
-\section{Synchronous Channels}
+%% \section{Synchronous Channels}
 
-Here's an implementation of synchronous channels, where the sender of
-a message blocks until that message has been received. Synchronous
-channels only need a single variable to store messages in transit, but
-three signals are used to coordinate reader and writer processes.
+%% Here's an implementation of synchronous channels, where the sender of
+%% a message blocks until that message has been received. Synchronous
+%% channels only need a single variable to store messages in transit, but
+%% three signals are used to coordinate reader and writer processes.
 \begin{lstlisting}
 package scala.concurrent
 
@@ -6882,16 +6952,16 @@ class SyncChannel[A] {
 }
 \end{lstlisting}
 
-\section{Workers}
+%% \section{Workers}
 
-Here's an implementation of a {\em compute server} in Scala. The
-server implements a \code{future} method which evaluates a given
-expression in parallel with its caller. Unlike the implementation in
-Section~\ref{sec:futures} the server computes futures only with a
-predefined number of threads. A possible implementation of the server
-could run each thread on a separate processor, and could hence avoid
-the overhead inherent in context-switching several threads on a single
-processor.
+%% Here's an implementation of a {\em compute server} in Scala. The
+%% server implements a \code{future} method which evaluates a given
+%% expression in parallel with its caller. Unlike the implementation in
+%% Section~\ref{sec:futures} the server computes futures only with a
+%% predefined number of threads. A possible implementation of the server
+%% could run each thread on a separate processor, and could hence avoid
+%% the overhead inherent in context-switching several threads on a single
+%% processor.
 
 \begin{lstlisting}
 import scala.concurrent._, scala.concurrent.ops._
@@ -6928,39 +6998,39 @@ class ComputeServer(n: Int) {
   spawn(replicate(0, n) { processor })
 }
 \end{lstlisting}
-Expressions to be computed (i.e. arguments
-to calls of \code{future}) are written to the \code{openJobs}
-channel. A {\em job} is an object with
-\begin{itemize}
-\item
-An abstract type \code{T} which describes the result of the compute
-job.
-\item
-A parameterless \code{task} method of type \code{t} which denotes
-the expression to be computed.
-\item
-A \code{ret} method which consumes the result once it is
-computed.
-\end{itemize}
-The compute server creates $n$ \code{processor} processes as part of
-its initialization.  Every such process repeatedly consumes an open
-job, evaluates the job's \code{task} method and passes the result on
-to the job's
-\code{ret} method. The polymorphic \code{future} method creates
-a new job where the \code{ret} method is implemented by a guard
-named \code{reply} and inserts this job into the set of open jobs. 
-It then waits until the corresponding
-\code{reply} guard is called.
+%% Expressions to be computed (i.e. arguments
+%% to calls of \code{future}) are written to the \code{openJobs}
+%% channel. A {\em job} is an object with
+%% \begin{itemize}
+%% \item
+%% An abstract type \code{T} which describes the result of the compute
+%% job.
+%% \item
+%% A parameterless \code{task} method of type \code{t} which denotes
+%% the expression to be computed.
+%% \item
+%% A \code{ret} method which consumes the result once it is
+%% computed.
+%% \end{itemize}
+%% The compute server creates $n$ \code{processor} processes as part of
+%% its initialization.  Every such process repeatedly consumes an open
+%% job, evaluates the job's \code{task} method and passes the result on
+%% to the job's
+%% \code{ret} method. The polymorphic \code{future} method creates
+%% a new job where the \code{ret} method is implemented by a guard
+%% named \code{reply} and inserts this job into the set of open jobs. 
+%% It then waits until the corresponding
+%% \code{reply} guard is called.
 
-The example demonstrates the use of abstract types. The abstract type
-\code{t} keeps track of the result type of a job, which can vary
-between different jobs. Without abstract types it would be impossible
-to implement the same class to the user in a statically type-safe
-way, without relying on dynamic type tests and type casts.
+%% The example demonstrates the use of abstract types. The abstract type
+%% \code{t} keeps track of the result type of a job, which can vary
+%% between different jobs. Without abstract types it would be impossible
+%% to implement the same class to the user in a statically type-safe
+%% way, without relying on dynamic type tests and type casts.
 
 
-Here is some code which uses the compute server to evaluate 
-the expression \code{41 + 1}.
+%% Here is some code which uses the compute server to evaluate 
+%% the expression \code{41 + 1}.
 \begin{lstlisting}
 object Test with Executable {
   val server = new ComputeServer(1)
@@ -6972,11 +7042,11 @@ object Test with Executable {
 \section{Mailboxes}
 \label{sec:mailbox}
 
-Mailboxes are high-level, flexible constructs for process
-synchronization and communication. They allow sending and receiving of
-messages. A {\em message} in this context is an arbitrary object.
-There is a special message \code{TIMEOUT} which is used to signal a
-time-out.
+%% Mailboxes are high-level, flexible constructs for process
+%% synchronization and communication. They allow sending and receiving of
+%% messages. A {\em message} in this context is an arbitrary object.
+%% There is a special message \code{TIMEOUT} which is used to signal a
+%% time-out.
 \begin{lstlisting}
 case object TIMEOUT
 \end{lstlisting}
@@ -6988,23 +7058,23 @@ class MailBox {
   def receiveWithin[A](msec: Long)(f: PartialFunction[Any, A]): A
 }
 \end{lstlisting}
-The state of a mailbox consists of a multi-set of messages.
-Messages are added to the mailbox with the \code{send} method. Messages
-are removed using the \code{receive} method, which is passed a message
-processor \code{f} as argument, which is a partial function from
-messages to some arbitrary result type. Typically, this function is
-implemented as a pattern matching expression. The \code{receive}
-method blocks until there is a message in the mailbox for which its
-message processor is defined.  The matching message is then removed
-from the mailbox and the blocked thread is restarted by applying the
-message processor to the message. Both sent messages and receivers are
-ordered in time. A receiver $r$ is applied to a matching message $m$
-only if there is no other $\{$message, receiver$\}$ pair which precedes ${m,
-r}$ in the partial ordering on pairs that orders each component in
-time.
+%% The state of a mailbox consists of a multi-set of messages.
+%% Messages are added to the mailbox with the \code{send} method. Messages
+%% are removed using the \code{receive} method, which is passed a message
+%% processor \code{f} as argument, which is a partial function from
+%% messages to some arbitrary result type. Typically, this function is
+%% implemented as a pattern matching expression. The \code{receive}
+%% method blocks until there is a message in the mailbox for which its
+%% message processor is defined.  The matching message is then removed
+%% from the mailbox and the blocked thread is restarted by applying the
+%% message processor to the message. Both sent messages and receivers are
+%% ordered in time. A receiver $r$ is applied to a matching message $m$
+%% only if there is no other $\{$message, receiver$\}$ pair which precedes ${m,
+%% r}$ in the partial ordering on pairs that orders each component in
+%% time.
 
-As a simple example of how mailboxes are used, consider a
-one-place buffer:
+%% As a simple example of how mailboxes are used, consider a
+%% one-place buffer:
 \begin{lstlisting}
 class OnePlaceBuffer {
   private val m = new MailBox             // An internal mailbox
@@ -7016,7 +7086,7 @@ class OnePlaceBuffer {
     m receive { case Full(x) => m send Empty; x }
 }
 \end{lstlisting}
-Here's how the mailbox class can be implemented:
+%% Here's how the mailbox class can be implemented:
 \begin{lstlisting}
 class MailBox {
   private abstract class Receiver extends Signal {
@@ -7024,21 +7094,21 @@ class MailBox {
     var msg = null
   }
 \end{lstlisting}
-We define an internal class for receivers with a test method
-\code{isDefined}, which indicates whether the receiver is
-defined for a given message.  The receiver inherits from class
-\code{Signal} a \code{notify} method which is used to wake up a
-receiver thread. When the receiver thread is woken up, the message it
-needs to be applied to is stored in the \code{msg} variable of
-\code{Receiver}.
+%% We define an internal class for receivers with a test method
+%% \code{isDefined}, which indicates whether the receiver is
+%% defined for a given message.  The receiver inherits from class
+%% \code{Signal} a \code{notify} method which is used to wake up a
+%% receiver thread. When the receiver thread is woken up, the message it
+%% needs to be applied to is stored in the \code{msg} variable of
+%% \code{Receiver}.
 \begin{lstlisting}
   private val sent = new LinkedList[Any]
   private var lastSent = sent
   private val receivers = new LinkedList[Receiver]
   private var lastReceiver = receivers
 \end{lstlisting}
-The mailbox class maintains two linked lists,
-one for sent but unconsumed messages, the other for waiting receivers.
+%% The mailbox class maintains two linked lists,
+%% one for sent but unconsumed messages, the other for waiting receivers.
 \begin{lstlisting}
   def send(msg: Any) = synchronized {
     var r = receivers, r1 = r.next
@@ -7052,9 +7122,9 @@ one for sent but unconsumed messages, the other for waiting receivers.
     }
   }
 \end{lstlisting}
-The \code{send} method first checks whether a waiting receiver is
-applicable to the sent message. If yes, the receiver is notified.
-Otherwise, the message is appended to the linked list of sent messages.
+%% The \code{send} method first checks whether a waiting receiver is
+%% applicable to the sent message. If yes, the receiver is notified.
+%% Otherwise, the message is appended to the linked list of sent messages.
 \begin{lstlisting}
   def receive[A](f: PartialFunction[Any, A]): A = {
     val msg: Any = synchronized {
@@ -7076,14 +7146,14 @@ Otherwise, the message is appended to the linked list of sent messages.
     f(msg)
   }
 \end{lstlisting}
-The \code{receive} method first checks whether the message processor function
-\code{f} can be applied to a message that has already been sent but that
-was not yet consumed. If yes, the thread continues immediately by
-applying \code{f} to the message. Otherwise, a new receiver is created
-and linked into the \code{receivers} list, and the thread waits for a
-notification on this receiver. Once the thread is woken up again, it
-continues by applying \code{f} to the message that was stored in the
-receiver. The insert method on linked lists is defined as follows.
+%% The \code{receive} method first checks whether the message processor function
+%% \code{f} can be applied to a message that has already been sent but that
+%% was not yet consumed. If yes, the thread continues immediately by
+%% applying \code{f} to the message. Otherwise, a new receiver is created
+%% and linked into the \code{receivers} list, and the thread waits for a
+%% notification on this receiver. Once the thread is woken up again, it
+%% continues by applying \code{f} to the message that was stored in the
+%% receiver. The insert method on linked lists is defined as follows.
 \begin{lstlisting}
   def insert(l: LinkedList[A], x: A): LinkedList[A] = {
     l.next = new LinkedList[A]
@@ -7092,12 +7162,12 @@ receiver. The insert method on linked lists is defined as follows.
     l
   }
 \end{lstlisting}
-The mailbox class also offers a method \code{receiveWithin}
-which blocks for only a specified maximal amount of time.  If no
-message is received within the specified time interval (given in
-milliseconds), the message processor argument $f$ will be unblocked
-with the special \code{TIMEOUT} message.  The implementation of
-\code{receiveWithin} is quite similar to \code{receive}:
+%% The mailbox class also offers a method \code{receiveWithin}
+%% which blocks for only a specified maximal amount of time.  If no
+%% message is received within the specified time interval (given in
+%% milliseconds), the message processor argument $f$ will be unblocked
+%% with the special \code{TIMEOUT} message.  The implementation of
+%% \code{receiveWithin} is quite similar to \code{receive}:
 \begin{lstlisting}
   def receiveWithin[A](msec: Long)(f: PartialFunction[Any, A]): A = {
     val msg: Any = synchronized {
@@ -7121,33 +7191,33 @@ with the special \code{TIMEOUT} message.  The implementation of
   }
 } // end MailBox
 \end{lstlisting}
-The only differences are the timed call to \code{wait}, and the
-statement following it.
+%% The only differences are the timed call to \code{wait}, and the
+%% statement following it.
 
-\section{Actors}
-\label{sec:actors}
+%% \section{Actors}
+%% \label{sec:actors}
 
-Chapter~\ref{chap:example-auction} sketched as a program example the
-implementation of an electronic auction service. This service was
-based on high-level actor processes that work by inspecting messages
-in their mailbox using pattern matching. A refined and optimized
-implementation of actors is found in the \lstinline@scala.actors@
-package.  We now give a sketch of a simplified version of the actors library.
+%% Chapter~\ref{chap:example-auction} sketched as a program example the
+%% implementation of an electronic auction service. This service was
+%% based on high-level actor processes that work by inspecting messages
+%% in their mailbox using pattern matching. A refined and optimized
+%% implementation of actors is found in the \lstinline@scala.actors@
+%% package.  We now give a sketch of a simplified version of the actors library.
 
-The code below is different from the implementation in the \lstinline@scala.actors@
-package, so it should be seen as an example how a simple version of
-actors could be implemented.  It is not a description how actors are actually defined and
-implemented in the standard Scala library. For the latter, please
-refer to the Scala API documentation.
+%% The code below is different from the implementation in the \lstinline@scala.actors@
+%% package, so it should be seen as an example how a simple version of
+%% actors could be implemented.  It is not a description how actors are actually defined and
+%% implemented in the standard Scala library. For the latter, please
+%% refer to the Scala API documentation.
 
-A simplified actor is just a thread whose communication primitives are those
-of a mailbox.  Such an actor can be defined as a mixin composition
-extension of Java's standard
-\code{Thread} class with the \code{MailBox} class. We also override
-the \code{run} method of the \code{Thread} class, so that it executes the
-behavior of the actor that is defined by its \code{act} method.
-The \code{!} method simply calls the \code{send} method of the
-\code{MailBox} class:
+%% A simplified actor is just a thread whose communication primitives are those
+%% of a mailbox.  Such an actor can be defined as a mixin composition
+%% extension of Java's standard
+%% \code{Thread} class with the \code{MailBox} class. We also override
+%% the \code{run} method of the \code{Thread} class, so that it executes the
+%% behavior of the actor that is defined by its \code{act} method.
+%% The \code{!} method simply calls the \code{send} method of the
+%% \code{MailBox} class:
 \begin{lstlisting}
 abstract class Actor extends Thread with MailBox {
   def act(): Unit
@@ -7156,10 +7226,10 @@ abstract class Actor extends Thread with MailBox {
 }
 \end{lstlisting}
 
-\comment{
-As an extended example of an application that uses actors, we come
-back to the auction server example of Section~\ref{sec:ex-auction}.
-The following code implements:
+%% \comment{
+%% As an extended example of an application that uses actors, we come
+%% back to the auction server example of Section~\ref{sec:ex-auction}.
+%% The following code implements:
 
 \begin{figure}[thb]
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5306,11 +5306,9 @@ range(1, n)
       .map(j => (i, j)))
 \end{lstlisting}
 %---------------xpto
-Conversely, it would also be possible to express functions \code{map},
-\code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
-three functions again, this time implemented using for-comprehensions.
 De modo inverso, também seria possível expressar as funções \code{map}, \code{flatMap} e \code{filter}
-usando for-comprehensions. Aqui estão as três funções novamente 
+usando for-comprehensions. Aqui estão as três funções novamente, desta vez implementadas usando
+for-comprehensions.
 
 \begin{lstlisting}
 object Demo {
@@ -5324,13 +5322,12 @@ object Demo {
     for (x <- xs if p(x)) yield x
 }
 \end{lstlisting}
-Not surprisingly, the translation of the for-comprehension in the body of
-\code{Demo.map} will produce a call to \code{map} in class \code{List}.
-Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
-\code{flatMap} and \code{filter} in class \code{List}.
+Não surpreendentemente, a tradução do for-comprehension no corpo de \code{Demo.map} produzirá
+uma chamada para \code{map} na classe \code{List}. Similarmente, \code{Demo.flatMap} e
+\code{Demo.filter} são traduzidos para \code{flatMap} e \code{filter} na classe \code{List}.
 
 \begin{exercise}
-Define the following function in terms of \code{for}.
+Defina a seguinte função em termos de \code{for}.
 \begin{lstlisting}
 def flatten[A](xss: List[List[A]]): List[A] =
   (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
@@ -5338,7 +5335,7 @@ def flatten[A](xss: List[List[A]]): List[A] =
 \end{exercise}
 
 \begin{exercise}
-Translate
+Traduza 
 \begin{lstlisting}
 for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
 for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
@@ -5348,31 +5345,28 @@ to higher-order functions.
 
 \section{For-Loops}\label{sec:for-loops}
 
-For-comprehensions resemble for-loops in imperative languages, except
-that they produce a list of results. Sometimes, a list of results is
-not needed but we would still like the flexibility of generators and
-filters in iterations over lists. This is made possible by a variant
-of the for-comprehension syntax, which expresses for-loops:
+For-comprehensions lembram for-loops das linguagens imperativas, exceto que eles produzem uma lista 
+de resultados. Algumas vezes, uma lista de resultados não é necessária, mas ainda gostaríamos da
+flexibilidade dos geradores e filtros nas iterações sobre listas. Isso é possível por uma variante
+da sintaxe dos for-comprehensions, os quais expressam for-loops:  
 \begin{lstlisting}
 for ( $s$ ) $e$
 \end{lstlisting}
-This construct is the same as the standard for-comprehension syntax
-except that the keyword \code{yield} is missing. The for-loop is
-executed by executing the expression $e$ for each element generated
-from the sequence of generators and filters $s$.
+Esta construção é a mesma da sintaxe padrão do for-comprehension, exceto que a palavra chave \code{yield}
+está faltando. O for-loop é executado pela execução da expressão $e$ para cada elemento gerado da sequência 
+de geradores e filtros $s$.
 
-As an example, the following expression prints out all elements of a
-matrix represented as a list of lists:
+Como um exemplo, a seguinte expressão imprime todos os elementos de uma matriz representada como 
+uma lista de listas:
  \begin{lstlisting}
 for (xs <- xss) {
   for (x <- xs) print(x + "\t")
   println()
 }
 \end{lstlisting}
-The translation of for-loops to higher-order methods of class
-\code{List} is similar to the translation of for-comprehensions, but
-is simpler. Where for-comprehensions translate to \code{map} and
-\code{flatMap}, for-loops translate in each case to \code{foreach}.
+A tradução de for-loops para métodos de alta ordem da classe \code{List} é similar à tradução de
+for-comprehensions, mas mais simples. Onde for-comprehensions são traduzidos para \code{map} e 
+\code{flatMap}, for-loops traduzem em cada caso para \code{foreach}.
 
 \section{Generalizing For}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -500,6 +500,10 @@ finalmente parar, permanece ativo para um outro período determinado pela consta
 %% messages matching the pattern. The \code{receiveWithin} method selects
 %% the first message in the mailbox which matches one of these patterns
 %% and applies the corresponding action to it.
+Aqui estão algumas explicações extras sobre os construtores usados neste programa:
+\begin{itemize}
+\item
+O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um   
 %----------
 
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2928,13 +2928,18 @@ antes que objetos de uma classe abstrata ou trait sejam criados.
 %----------
 
 
-%----------xpto
+%----------
 %% \chapter{Case Classes and Pattern Matching}
-
+\chapter{Classes Case e Casamento de Padrões}
 %% Say, we want to write an interpreter for arithmetic expressions.  To
 %% keep things simple initially, we restrict ourselves to just numbers
 %% and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
 %% \code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
+Digamos, queremos escrever um interpretador para expressões aritméticas. Para 
+deixar as coisas simples inicialmente, vamos nos restringir somente a números e operações \code{+}.
+Tais expressões podem ser representadas como hierarquia de classes, 
+com uma classe abstrata base \code{Expr} como raiz, e duas subclasses \code{Number} e \code{Sum}.
+Então, uma expressão \code{1 + (3 + 7)} é representada como 
  \begin{lstlisting}
  new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
  \end{lstlisting}
@@ -2945,6 +2950,10 @@ antes que objetos de uma classe abstrata ou trait sejam criados.
 %% form it is (either \code{Sum} or \code{Number}) and also needs to
 %% access the components of the expression.  The following
 %% implementation provides all necessary methods.
+Agora, um avaliador de uma expressão como esta precisa saber de 
+qual forma ela é (ou \code{Sum} ou \code{Number}) e também precisa
+acessar os componentes da expressão. A implementação a seguir provê
+todos os métodos necessários.
 \begin{lstlisting}
 abstract class Expr {
   def isNumber: Boolean
@@ -2970,8 +2979,9 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %%With these classification and access methods, writing an evaluator function is simple:
+Com esta classificação e métodos de acesso, escrever uma função avaliador é simples:
 \begin{lstlisting}
 def eval(e: Expr): Int = {
   if (e.isNumber) e.numValue

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1,5 +1,4 @@
 
-
 \def\exercise{
    \def\theresult{Exercise~\thesection.\arabic{result}}
    \refstepcounter{result}
@@ -42,13 +41,12 @@ ou C. Nós usamos os mesmos operadores e estruturas de controle.
 Existem também algumas pequenas diferenças sintáticas, particularmente:
 \begin{itemize}
 \item
-Definitions start with a reserved word. Function definitions start
-with \code{def}, variable definitions start with \code{var} and
-definitions of values (i.e. read only variables) start with \code{val}.
+As declarações começam usando palavras reservadas. Particularmente, declarações de funções são iniciadas
+com a palavra \code{def}, declarações de variáveis são iniciadas com a palavra \code{var} e
+declaração de constantes (chamadas de valores) são iniciadas com a palavra \code{val}.
 \item
-The declared type of a symbol is given after the symbol and a colon.
-The declared type can often be omitted, because the compiler can infer
-it from the context.
+O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
+O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
 Array types are written \code{Array[T]} rather than \code{T[]}, 
 and array selections are written \code{a(i)} rather than \code{a[i]}.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -139,7 +139,7 @@ maiores ou iguais ao piv\^{o}.}
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
 Tanto a implementa\c{c}\~{a}o imperativa quanto a funcional tem mesma complexidade
-assint\'{o}tica -- $O(N;log(N))$ no caso m\'{e}dio e $O(N FIXME)$ no pior caso. Mas onde
+assint\'{o}tica -- $O(N;log(N))$ no caso m\'{e}dio e $O(N^2)$ no pior caso. Mas onde
 a implementa\c{c}\~{a}o imperativa opera localmente, modificando o vetor original,
 a implementa\c{c}\~{a}o funcional retorna um novo vetor ordenado e deixa o vetor
 original inalterado. A implementa\c{c}\~{a}o funcional, portanto, requer mais
@@ -6374,9 +6374,8 @@ dada função a todos elementos de um iterador, mas não constrói uma lista de 
     while (hasNext) { f(next) }
 \end{lstlisting}
 
-\paragraph{Filter} Method \code{filter} constructs an iterator which
-returns all elements of the original iterator that satisfy a criterion
-\code{p}.
+\paragraph{Filter} O método \code{filter} constrói um iterador que retorna
+todos os elementos do iterador original que satisfazem um dado critério \code{p}.
 \begin{lstlisting}
   def filter(p: A => Boolean) = new BufferedIterator[A] {
     private val source =
@@ -6391,22 +6390,20 @@ returns all elements of the original iterator that satisfy a criterion
       { skip; source.head }
   }
 \end{lstlisting}
-In fact, \code{filter} returns instances of a subclass of iterators
-which are ``buffered''.  A \code{BufferedIterator} object is an
-iterator which has in addition a method \code{head}. This method
-returns the element which would otherwise have been returned by
-\code{head}, but does not advance beyond that element. Hence, the
-element returned by \code{head} is returned again by the next call to
-\code{head} or \code{next}. Here is the definition of the
-\code{BufferedIterator} trait.
+Na prática, \code{filter} retorna uma instância de uma sub-classe dos iteradores que trabalha com um
+ ``buffer''.  Um objeto do tipo \code{BufferedIterator} é um iterador que tem adicionalmente um método
+ \code{head}. Este método retorna um elemento que seria retornado pelo método \code{next}, porém
+não avança além daquele elemento. Com isso, o elemento retornado por \code{head} é retornado novamente
+pela próxima chamada de \code{head} ou \code{next}. Esta é a definição do trait 
+\code{BufferedIterator}:
 \begin{lstlisting}
 trait BufferedIterator[+A] extends Iterator[A] {
   def head: A
 }
 \end{lstlisting}
-Since \code{map}, \code{flatMap}, \code{filter}, and \code{foreach}
-exist for iterators, it follows that for-comprehensions and for-loops
-can also be used on iterators. For instance, the application which prints the squares of numbers between 1 and 100 could have equivalently been expressed as follows.
+Como \code{map}, \code{flatMap}, \code{filter} e \code{foreach}
+existem para iteradores, como consequência for-comprehensions e loops de for também podem ser usados em iteradores.
+Por exemplo, a aplicação que imprime os quadrados dos números entre 1 e 100 poderia ter sido expressada da seguinte forma:
 \begin{lstlisting}
 for (i <- Iterator.range(1, 100))
   println(i * i)

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -49,13 +49,6 @@ O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto
 \item
 A  declara\c{c}\~{a}o de vetores do tipo \code{T} \'{e} feita usando a express\~{a}o \code{Array[T]} ao inv\'{e}s de \code{T[]}. 
 O i-\'{e}simo elemento de um vetor \code{a} \'{e} acessado usando \code{a(i)} ao inv\'{e}s de \code{a[i]}.
-%----------
-%\item
-%Functions can be nested inside other functions. Nested functions can
-%access parameters and local variables of enclosing functions. For
-%instance, the name of the array \code{xs} is visible in functions
-%\code{swap} and \code{sort1}, and therefore need not be passed as a
-%parameter to them.
 \item
 Fun\c{c}\~{o}es podem ser aninhadas umas dentro das outras. Fun\c{c}\~{o}es aninhadas podem
 acessar par\^{a}metros e vari\'{a}veis locais de suas fun\c{c}\~{o}es externas. Por
@@ -64,17 +57,6 @@ exemplo, o nome do vetor \code{xs} \'{e} vis\'{i}vel nas fun\c{c}\~{o}es \code{s
 %----------
 \end{itemize}
 
-%----------
-%So far, Scala looks like a fairly conventional language with some
-%syntactic peculiarities. In fact it is possible to write programs in a
-%conventional imperative or object-oriented style. This is important
-%because it is one of the things that makes it easy to combine Scala
-%components with components written in mainstream languages such as
-%Java, C\# or Visual Basic.
-%
-%However, it is also possible to write programs in a style which looks
-%completely different. Here is Quicksort again, this time written in
-%functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
 com algumas peculiaridades sint\'{a}ticas. De fato \'{e} poss\'{i}vel escrever
 programas em estilo imperativo ou orientado a objetos. Isto \'{e} 
@@ -273,10 +255,6 @@ especial da chamada de m\'{e}todo \code{+} sobre argumentos inteiros e
 para gerar c\'{o}digo inline eficiente para isso.  
 %----------
 
-%----------
-%% For efficiency and better error diagnostics the \code{while} loop is a
-%% primitive construct in Scala. But in principle, it could have just as
-%% well been a predefined function. Here is a possible implementation of it:
 Por efici\^{e}ncia e melhor detec\c{c}\~{a}o de erros o la\c{c}o \code{while} \'{e} um construtor 
 primitivo em Scala. Mas em princ\'{i}pio, poderia do mesmo modo ser uma fun\c{c}\~{a}o 
 predefinida. Aqui est\'{a} uma poss\'{i}vel implementa\c{c}\~{a}o para ele: 
@@ -287,12 +265,7 @@ def While (p: => Boolean) (s: => Unit) {
 }
 \end{lstlisting}
 
-%----------
-%% The \code{While} function takes as first parameter a test function,
-%% which takes no parameters and yields a boolean value. As second
-%% parameter it takes a command function which also takes no parameters
-%% and yields a result of type \lstinline@Unit@. \code{While} invokes the
-%% command function as long as the test function yields true.
+
 A fun\c{c}\~{a}o \code{While} recebe como primeiro par\^{a}metro uma fun\c{c}\~{a}o teste,
 que n\~{a}o recebe par\^{a}metros e produz um valor boleano. Como segundo par\^{a}metro 
 recebe uma fun\c{c}\~{a}o comando que tamb\'{e}m n\~{a}o recebe par\^{a}metros e produz como 
@@ -300,17 +273,6 @@ resultado o tipo  \lstinline@Unit@. \code{While} invoca a fun\c{c}\~{a}o comando
 enquanto a fun\c{c}\~{a}o teste produzir verdadeiro.
 %----------
 
-%----------
-%% Scala's \lstinline@Unit@ type roughly corresponds to \lstinline@void@
-%% in Java; it is used whenever a function does not return an interesting
-%% result. In fact, because Scala is an expression-oriented language,
-%% every function returns some result. If no explicit return expression
-%% is given, the value \lstinline@()@, which is pronounced ``unit'', is
-%% assumed.  This value is of type \lstinline@Unit@.
-%% Unit-returning functions are also called {\em procedures}.  
-%% Here's a more
-%% ``expression-oriented'' formulation of the \lstinline@swap@ function
-%% in the first implementation of quicksort, which makes this explicit:
 O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
 no Java; \'{e} usado sempre que uma fun\c{c}\~{a}o n\~{a}o retornar um resultado interessante.
 De fato, porque Scala \'{e} uma linguagem orientada a express\~{o}es, cada fun\c{c}\~{a}o 
@@ -486,20 +448,7 @@ repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, at\'{e} 
 leil\~{a}o seja fechado, o que \'{e} sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
 finalmente parar, permanece ativo para um outro per\'{i}odo determinado pela constante 
 \code{timeToShutdown} e replica para ofertas posteriores que o leil\~{a}o est\'{a} fechado.    
-%----------
 
-%----------
-%% Here are some further explanations of the constructs used in this
-%% program:
-%% \begin{itemize}
-%% \item
-%% The \code{receiveWithin} method of class \code{Actor} takes as
-%% parameters a time span given in milliseconds and a function that
-%% processes messages in the mailbox. The function is given by a sequence
-%% of cases that each specify a pattern and an action to perform for
-%% messages matching the pattern. The \code{receiveWithin} method selects
-%% the first message in the mailbox which matches one of these patterns
-%% and applies the corresponding action to it.
 Aqui est\~{a}o algumas explica\c{c}\~{o}es extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
@@ -739,9 +688,8 @@ chamado {\em redu\c{c}\~{a}o}.
 %----------
 
 
-\section{Parameters}
+\section{Par\^{a}metros}
 
-%% Using \code{def}, one can also define functions with parameters. For example:
 Usando \code{def}, pode-se tamb\'{e}m definir fun\c{c}\~{o}es com par\^{a}metros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
@@ -894,18 +842,7 @@ unnamed0: Int = 1
 scala> constOne(loop, 2)               // leva a la\c{c}o infinito
 ^C                                     // para a execu\c{c}\~{a}o com Ctrl-C
 \end{lstlisting}
-%----------
 
-
-%----------
-%%\section{Conditional Expressions}
-
-%% Scala's \code{if-else} lets one choose between two alternatives.  Its
-%% syntax is like Java's \code{if-else}. But where Java's \code{if-else}
-%% can be used only as an alternative of statements, Scala allows the
-%% same syntax to choose between two expressions. That's why Scala's
-%% \code{if-else} serves also as a substitute for Java's conditional
-%% expression \code{ ... ? ... : ...}.
 \section{Express\~{o}es Condicionais}
 O \code{if-else} do Scala leva a uma escolha entre duas alternativas. Sua
 sintaxe \'{e} a mesma do \code{if-else} do Java. Mas onde o \code{if-else} do 
@@ -913,20 +850,7 @@ Java pode ser usado somente como uma alternativa entre comandos, Scala
 permite a mesma sintaxe para escolher entre duas express\~{o}es. Isso porque o
 \code{if-else} do Scala serve tamb\'{e}m como um substituto para a express\~{a}o 
 condicional do Java \code{... ? ... : ...}.      
-%----------
 
-%----------
-%% \example\ 
-
-%% \begin{lstlisting}
-%% scala> def abs(x: Double) = if (x >= 0) x else -x
-%% abs: (Double)Double
-%% \end{lstlisting}
-%% Scala's boolean expressions are similar to Java's; they are formed
-%% from the constants
-%% \code{true} and
-%% \code{false}, comparison operators, boolean negation \code{!} and the
-%% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
 \example\
 \begin{lstlisting}
 scala> def abs(x: Double) = if (x >= 0) x else -x
@@ -937,42 +861,22 @@ a partir de constantes.
 \code{true} e
 \code{false}, operadores de compara\c{c}\~{a}o, nega\c{c}\~{a}o boleana \code{!} e os 
 operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}. 
-%----------
 
-%----------
-%% \section{\label{sec:sqrt}Example: Square Roots by Newton's Method}
-
-%% We now illustrate the language elements introduced so far in the
-%% construction of a more interesting program. The task is to write a
-%% function
-%% \begin{lstlisting}
-%% def sqrt(x: Double): Double = ...
-%% \end{lstlisting}
-%% which computes the square root of \code{x}.
-
-\section{\label{sec:sqrt}Example: Raiz Quadrada pelo M\'{e}todo de Newton}
+\section{\label{sec:sqrt}Exemplo: Raiz Quadrada pelo M\'{e}todo de Newton}
 Agora ilustraremos elementos da linguagem intruduzidos at\'{e} aqui na
 constru\c{c}\~{a}o de um programa mais interessante. A tarefa \'{e} escrever um fun\c{c}\~{a}o  
  \begin{lstlisting}
  def sqrt(x: Double): Double = ...
  \end{lstlisting}
 que computa a raiz quadrada de \code{x}. 
-%----------
 
-%----------
-%% A common way to compute square roots is by Newton's method of
-%% successive approximations. One starts with an initial guess \code{y}
-%% (say: \code{y = 1}). One then repeatedly improves the current guess
-%% \code{y} by taking the average of \code{y} and \code{x/y}.  As an
-%% example, the next three columns indicate the guess \code{y}, the
-%% quotient \code{x/y}, and their average for the first approximations of
-%% $\sqrt 2$.
 Um modo comum de se computar raizes quadradas \'{e} pelo m\'{e}todo das aproxima\c{c}\~{o}es
 sucessivas de Newton. Inicia-se com um palpite inicial \code{y} (digamos:
 \code{y = 1}). Ent\~{a}o melhora-se repetidamente o atual palpite \code{y} 
 tomando-se a m\'{e}dia de \code{y} e \code{x/y}. Como um exemplo, as pr\'{o}ximas
 tr\^{e}s colunas indicam o palpite \code{y}, o quociente \code{x/y}, e suas
-m\'{e}dias para as primeiras aproxima\c{c}\~{o}es para $\sqrt 2$.       
+m\'{e}dias para as primeiras aproxima\c{c}\~{o}es para 
+$\sqrt 2$.       
 
 \begin{lstlisting}
 1            2/1 = 2               1.5
@@ -1214,7 +1118,7 @@ def sqrt(x: Double) = {
 %----------
 
 
-\section{Tail Recursion}
+\section{Recurs\~{a}o de Cauda}
 
 %%Consider the following function to compute the greatest common divisor
 %%of two given numbers.
@@ -1883,27 +1787,14 @@ como segue.
 \begin{lstlisting}
 def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
 \end{lstlisting}
-%% This expresses the elements of the algorithm as clearly as possible.
+
 Isto expressa os elementos do algoritmo t\~{a}o claramente quanto poss\'{i}vel.
 \begin{exercise} 
-%%Write a function for cube roots using \code{fixedPoint} and 
-%% \code{averageDamp}.
 Escreva uma fun\c{c}\~{a}o para a raiz c\'{u}bica usando \code{fixedPoint} e \code{averageDamp}.  
 \end{exercise}
-%----------
 
-%----------
-%% \section{Summary}
+\section{Summary}
 
-%% We have seen in the previous chapter that functions are essential
-%% abstractions, because they permit us to introduce general methods of
-%% computing as explicit, named elements in our programming language.
-%% The present chapter has shown that these abstractions can be combined
-%% by higher-order functions to create further abstractions.  As
-%% programmers, we should look out for opportunities to abstract and to
-%% reuse. The highest possible level of abstraction is not always the
-%% best, but it is important to know abstraction techniques, so that one
-%% can use abstractions where appropriate.
 Vimos no cap\'{i}tulo anterior que fun\c{c}\~{o}es s\~{a}o abstra\c{c}\~{o}es essenciais porque 
 nos permitem introduzir m\'{e}todos gen\'{e}ricos de computa\c{c}\~{a}o como expl\'{i}citos,
 elementos nomeados em nossa linguagem de programa\c{c}\~{a}o. O presente cap\'{i}tulo
@@ -1912,56 +1803,36 @@ para criar mais abstra\c{c}\~{o}es. Como programadores, devemos procurar por opo
 de reuso e abstra\c{c}\~{a}o. O mais alto n\'{i}vel poss\'{i}vel de abstra\c{c}\~{a}o nem sempre \'{e} 
 o melhor, mas \'{e} importante saber t\'{e}cnicas de abstra\c{c}\~{a}o, de modo que possamos
 us\'{a}-las quando apropriado. 
-%----------
 
-%----------
-%% \section{Language Elements Seen So Far}
 \section{Elementos da Linguagem Vistos At\'{e} Aqui}
-%% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
-%% covered Scala's language elements to express expressions and types
-%% comprising of primitive data and functions.  The context-free syntax
-%% of these language elements is given below in extended Backus-Naur
-%% form, where `\code{|}' denotes alternatives, \code{[...]} denotes
-%% option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
-%% (0 or more occurrences).
+
  Os cap\'{i}tulos ~\ref{chap:simple-funs} e \ref{chap:first-class-funs} trataram
 elementos da linguagem Scala para expressar tipos e express\~{o}es relacionados a
 tipos primitivos e fun\c{c}\~{o}es. A sintaxe livre de contexto desses elementos da
 linguagem s\~{a}o dados abaixo em formato Backus-Naur estendido, onde `\code{|}'
 denotam alternativas, \code{[...]} denotam op\c{c}\~{a}o  (0 ou 1 ocorr\^{e}ncia), e  
 \lstinline@{...}@ denotam (0 ou mais ocorr\^{e}ncias). 
-%% \subsection*{Characters}
 \subsection*{Caracteres}
-%% Scala programs are sequences of (Unicode) characters. We distinguish the
-%% following character sets:
 Programas em Scala s\~{a}o sequ\^{e}ncia de caracteres (Unicode). Distinguimos os
 seguintes conjuntos de caracteres.
  \begin{itemize}
  \item
-%% whitespace, such as `\code{ }', tabulator, or newline characters,
 espa\c{c}o em branco, tal como `\code{ }', tabula\c{c}\~{a}o, ou caracter de mudan\c{c}a de linha (newline), 
  \item
-%% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
 letras `\code{a}' a `\code{z}', `\code{A}' a `\code{Z}',    
  \item
-%% digits \code{`0'} to `\code{9}',
 digitos `\code{0}' a `\code{9}',   
  \item
-%% the delimiter characters
 caracteres delimitadores
  \begin{lstlisting}
  .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
  \end{lstlisting}
  \item
-%% operator characters, such as `\code{#}' `\code{+}',
-%% `\code{:}'. Essentially, these are printable characters which are
-%% in none of the character sets above.
 caracteres operadores, tal como `\code{#}', `\code{+}' e `\code{:}'.
 Essencialmente, h\'{a} caracteres imprim\'{i}veis que n\~{a}o est\~{a}o em nenhum dos 
 conjuntos de caracteres acima.   
  \end{itemize}
 
-%% \subsection*{Lexemes:}
 \subsection*{Lexemas:}
 
 \begin{lstlisting}
@@ -7689,7 +7560,10 @@ as threads que estejam esperando por um sinal. Estes métodos, assim como a clas
 são primitivos em Scala, ou seja, eles são implementados usando os mecanismos internos do sistema de execução
 dos programas.
 
-Typically, a thread waits for some condition to be established. If the
+Typicamente, uma thread espera até que um certa condição ocorra. 
+Se esta condição não ocorrer até o tempo definido na chamada do método \code{wait}, 
+a thread fica com execução suspensa até que alguma outra thread 
+estally, a thread waits for some condition to be established. If the
 condition does not hold at the time of the wait call, the thread
 blocks until some other thread has established the condition. It is
 the responsibility of this other thread to wake up waiting processes

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -808,7 +808,7 @@ $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
 
-%----------xpto
+%----------
 %% The example shows that the interpreter reduces function arguments to
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
@@ -837,7 +837,9 @@ $\rightarrow$  25
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
 A segunda ordem de avaliação é conhecida como \emph{chamada por nome},
-e a primeira por \emph{chamada por valor}. Para expressões que 
+e a primeira por \emph{chamada por valor}. Para expressões que se utilizam
+apenas de funções e que portanto podem ser reduzidas com o modelo de 
+substituição, ambos os esquemas levam ao mesmo valor final.
 %----------
 
 %----------
@@ -847,8 +849,13 @@ e a primeira por \emph{chamada por valor}. Para expressões que
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
+Chamada por valor tem a vantagem de evitar avaliações repetidas de argumentos.
+Chamada por nome tem a vantagem de evitar avaliações de argumentos quando o 
+parâmetro não é usado pela função. Chamada por valor é geralmente mais 
+eficiente que chamada por nome, mas uma avaliação de chamada por valor
+pode entrar em laço infinito, enquanto uma avaliação de chamada por nome 
+termina. Considere: 
 %----------
-
 \begin{lstlisting}
 scala> def loop: Int = loop
 loop: Int
@@ -860,6 +867,9 @@ first: (Int,Int)Int
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
+Então \code{first(1, loop)} é reduzido com uma chamada por nome a \code{1},
+enquanto o mesmo termo, através de uma chamada por valor reduz a si mesmo 
+repetidamente, logo a avaliação não termina.  
 %----------
 \begin{lstlisting}
 $\,\,\,$   first(1, loop)
@@ -870,7 +880,8 @@ $\rightarrow$  ...
 %----------
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
-
+Scala usa chamada por valor por default, mas muda para avaliação de chamada por nome 
+se o tipo do parâmetro for precedido por \code{=>}. 
 \example\ 
  
 \begin{lstlisting}
@@ -880,8 +891,8 @@ constOne: (Int,=> Int)Int
 scala> constOne(1, loop)
 unnamed0: Int = 1
 
-scala> constOne(loop, 2)               // gives an infinite loop.
-^C                                     // stops execution with Ctrl-C
+scala> constOne(loop, 2)               // leva a laço infinito
+^C                                     // para a execução com Ctrl-C
 \end{lstlisting}
 %----------
 
@@ -895,6 +906,8 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% same syntax to choose between two expressions. That's why Scala's
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
+\section{Expressões Condicionais}
+
 %----------
 
 %----------
@@ -941,7 +954,7 @@ scala> constOne(loop, 2)               // gives an infinite loop.
 %% \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% One can implement this algorithm in Scala by a set of small functions,
 %% which each represent one of the elements of the algorithm.  
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1785,21 +1785,29 @@ def fixedPoint(f: Double => Double)(firstGuess: Double) = {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% We now apply this idea in a reformulation of the square root function.
 %% Let's start with a specification of \code{sqrt}:
+Agora aplicaremos esta idéia na reformulação da função raiz quadrada.
+Vamos começar pela especificação de \code{sqrt}:  
 \begin{lstlisting}
 sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
          =  $\mbox{the {\sl y} such that}$  y = x / y
 \end{lstlisting}
+
 %% Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
 %% This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
+Consequentemente, \code{sqrt(x)} é um ponto fixo da função \code{y => x / y}.
+Isso sugere que \code{sqrt(x)} pode ser computado por uma iteração de ponto fixo: 
 \begin{lstlisting}
 def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
 \end{lstlisting}
 %% But if we try this, we find that the computation does not
 %% converge. Let's instrument the fixed point function with a print
 %% statement which keeps track of the current \code{guess} value:
+Mas se tentarmos isso, percebemos que aquela computação não converge. 
+Vamos agregar à função de ponto fixo um comando print que mostra o 
+valor corrente de \code{guess}: 
 \begin{lstlisting}
 def fixedPoint(f: Double => Double)(firstGuess: Double) = {
   def iterate(guess: Double): Double = {
@@ -1812,6 +1820,7 @@ def fixedPoint(f: Double => Double)(firstGuess: Double) = {
 }
 \end{lstlisting}
 %% Then, \code{sqrt(2)} yields:
+Então, \code{sqrt(2)} dá: 
 \begin{lstlisting}
   2.0
   1.0
@@ -1822,7 +1831,7 @@ def fixedPoint(f: Double => Double)(firstGuess: Double) = {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% One way to control such oscillations is to prevent the guess from changing too much. 
 %% This can be achieved by {\em averaging} successive values of the original sequence:
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -763,7 +763,7 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
-%----------xpto
+%----------
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
 %% following the parameter name and a colon.  At the present time, we
@@ -788,6 +788,11 @@ e \code{int} é um tipo alias para \code{scala.Int}.
 %% the function's right hand side, and at the same time all formal
 %% parameters of the function are replaced by their corresponding actual
 %% arguments.
+Funções com parâmetros são avaliadas analogamente a operadores em expressões.
+Primeiro, os argumentos da função são avaliados (da esquerda para direita). 
+Então, a aplicação da função é substituído pelo lado direito da função, e
+ao mesmo tempo todos os parâmetros formais são substituídos pelos seus 
+argumentos atuais. 
 %----------
 
 \example\ 
@@ -803,11 +808,15 @@ $\rightarrow$  9 + 16
 $\rightarrow$  25
 \end{lstlisting}
 
-%----------
+%----------xpto
 %% The example shows that the interpreter reduces function arguments to
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
 %% have yielded the following reduction sequence:
+O exemplo mostra que o interpretador reduz argumentos de funções a valores 
+antes de reescrever a aplicação da função. Pode-se ao invés escolher aplicar
+a função a argumentos não reduzidos. Isto levará a seguinte sequência de 
+redução: 
 %----------
 
 \begin{lstlisting}
@@ -827,6 +836,8 @@ $\rightarrow$  25
 %% expressions that use only pure functions and that therefore can be
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
+A segunda ordem de avaliação é conhecida como \emph{chamada por nome},
+e a primeira por \emph{chamada por valor}. Para expressões que 
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -286,7 +286,7 @@ def While (p: => Boolean) (s: => Unit) {
 }
 \end{lstlisting}
 
-%xpto----------
+%----------
 %% The \code{While} function takes as first parameter a test function,
 %% which takes no parameters and yields a boolean value. As second
 %% parameter it takes a command function which also takes no parameters
@@ -299,7 +299,7 @@ resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
 enquanto a função teste produzir verdadeiro.
 %----------
 
-%----------
+%----------xpto
 %% Scala's \lstinline@Unit@ type roughly corresponds to \lstinline@void@
 %% in Java; it is used whenever a function does not return an interesting
 %% result. In fact, because Scala is an expression-oriented language,
@@ -310,6 +310,15 @@ enquanto a função teste produzir verdadeiro.
 %% Here's a more
 %% ``expression-oriented'' formulation of the \lstinline@swap@ function
 %% in the first implementation of quicksort, which makes this explicit:
+O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
+no Java; é usado sempre que uma função não retornar um resultado interessante.
+De fato, porque Scala é uma linguagem orientada a expressões, cada função 
+retorna algum resultado. Se nenhuma expressão de retorno é  explicitamente
+fornecida, o valor \lstinline@()@, que é pronunciado ``unit'', é assumido.
+Este valor é do tipo \lstinline@Unit@. Funções que retornam ``unit'' são 
+também chamadas {\em procedimentos}. Aqui está uma formulação mais 
+``orientada a expressão'' da função \lstinline@swap@ na primeira implementação
+do quicksort, que explicita isto:
 %----------
 
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2455,27 +2455,33 @@ um valor do tipo \code{EmptySet} ou \code{NonEmptySet} pode ser usado sempre que
  do tipo \code{IntSet} é requerido.
 %----------
 
-%----------xpto
+%----------
 %% \begin{exercise} Write methods \code{union} and \code{intersection} to form
 %% the union and intersection between two sets.
 %% \end{exercise}
-
-%% \begin{exercise} Add a method 
+\begin{exercise}
+Escreva os métodos \code{uniao} e \code{intersecao} para formar a união e interseção entre
+dois conjuntos.
+\end{exercise}
+ \begin{exercise} Adicione um método  
  \begin{lstlisting}
  def excl(x: Int)
  \end{lstlisting}
 %% to return the given set without the element \code{x}. To accomplish this,
 %% it is useful to also implement a test method
+para retornar um dado conjunto sem o elemento \code{x}. Para isso, é interessante também 
+implementar um método teste
  \begin{lstlisting}
  def isEmpty: Boolean
  \end{lstlisting}
 %% for sets.
-%% \end{exercise}
+para conjuntos.
+ \end{exercise}
 %----------
 
 %----------
 %% \paragraph{Dynamic Binding}
-
+\paragraph{Ligação Dinâmica}
 %% Object-oriented languages (Scala included) use \emph{dynamic dispatch}
 %% for method invocations.  That is, the code invoked for a method call
 %% depends on the run-time type of the object which contains the method.
@@ -2484,10 +2490,19 @@ um valor do tipo \code{EmptySet} ou \code{NonEmptySet} pode ser usado sempre que
 %% \code{contains} is executed depends on the type of value of \code{s} at run-time.
 %% If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
 %% This behavior is a direct consequence of our substitution model of evaluation.
+Linguagens orientadas a objetos (inclusive Scala) usam \emph{despacho dinâmico} para 
+invocações de métodos. Ou seja, o código invocado por uma chamada de método depende
+do tipo em tempo de execução do objeto que contém o método. Por exemplo, considere
+a expressão \code{s contains 7} onde \code{s} é um valor do tipo declarado \code{s: IntSet}. 
+Qual código para \code{contains} é executado depende do tipo do valor de \code{s} em 
+tempo de execução. Se for um valor \code{EmptySet}, é a implementação de \code{contains} na 
+classe \code{EmptySet} que é executada, e analogamente para valores \code{NonEmptySet}.
+Este comportamento é consequência direta do nosso modelo de substituição da avaliação.
 %----------
 
 %----------
 %% For instance,
+Por exemplo, 
 \begin{lstlisting}
     (new EmptySet).contains(7) 
 
@@ -2515,7 +2530,7 @@ Ou,
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% Dynamic method dispatch is analogous to higher-order function
 %% calls. In both cases, the identity of code to be executed is known
 %% only at run-time. This similarity is not just superficial. Indeed,

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2366,7 +2366,7 @@ abstract class IntSet {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% \code{IntSet} is labeled as an \emph{abstract class}. This has two
 %% consequences.  First, abstract classes may have {\em deferred} members
 %% which are declared but which do not have an implementation. In our
@@ -2375,10 +2375,17 @@ abstract class IntSet {
 %% of that class may be created using \code{new}. By contrast, an
 %% abstract class may be used as a base class of some other class, which
 %% implements the deferred members.
+\code{IntSet} ÅÈ tido como uma {\em classe abstrata}. Isso tem duas consequÅÍncias. 
+Primeiro, classes abstratas podem ter membros {\em protelados (deferred)} que sÅ„o 
+declarados, mas que nÅ„o tem uma implementaÅÁÅ„o. No nosso caso, ambos \code{incl} e 
+\code{contains} sÅ„o tais membros. Segundo, porque uma classe abstrata pode ter 
+membros nÅ„o implementados, nenhum objeto daquela classe pode ser criado usando \code{new}.
+Em contraste, uma classe abstrata pode ser usada como uma classe base de alguma outra
+classe, que implementa os membros que foram postergados. 
 %----------
 
 %----------
-%% \paragraph{Traits}
+ \paragraph{Traits}
 
 %% Instead of \code{abstract class} one also often uses the keyword
 %% \code{trait} in Scala. Traits are abstract classes that are meant to
@@ -2388,9 +2395,18 @@ abstract class IntSet {
 %% components. Another usage scenario is where the trait collects
 %% signatures of some functionality provided by different classes, much
 %% in the way a Java interface would work.
+Ao invÅÈs de \code{classe abstrata} frequentemente usa-se a palavra chave
+\code{trait} em Scala. Traits sÅ„o classes abstratas que desejamos adicionar
+a alguma outra classe. Isso pode ser porque um trait adiciona alguns mÅÈtodos
+ou campos para uma classe pai desconhecida. Por exemplo, um trait \code{Bordered} 
+pode ser usado para adicionar uma borda a vÅ·rios componentes grÅ·ficos. Um outro
+cenÅ·rio de uso ocorre quando o trait coleta assinaturas de alguma funcionalidade 
+provida por diferentes classes, do mesmo modo que uma interface Java faria.
 
 %% Since \code{IntSet} falls in this category, one can alternatively
 %% define it as a trait:
+Como \code{IntSet} pertence a esta categoria, pode-se alternativamente 
+definÅÌ-la como um trait:
 \begin{lstlisting}
 trait IntSet {
   def incl(x: Int): IntSet
@@ -2401,12 +2417,16 @@ trait IntSet {
 
 %----------
 %% \paragraph{Implementing Abstract Classes}
-
+\paragraph{Implementando Classes Abstratas}
 %% Let's say, we plan to implement sets as binary trees.  There are two
 %% possible forms of trees. A tree for the empty set, and a tree
 %% consisting of an integer and two subtrees. Here are their
 %% implementations.
 
+Vamos dizer que planejamos implementar conjuntos como Å·rvores binÅ·rias. HÅ· 
+duas possÅÌveis formas de Å·rvores. Uma Å·rvore para o conjunto vazio, e uma 
+Å·rvore consistindo de um inteiro e duas subÅ·rvores. Aqui estÅ„o suas implementaÅÁÅıes:
+ 
 \begin{lstlisting}
 class EmptySet extends IntSet {
   def contains(x: Int): Boolean = false
@@ -2429,9 +2449,13 @@ class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
 %% Both \code{EmptySet} and \code{NonEmptySet} extend class
 %% \code{IntSet}.  This implies that types \code{EmptySet} and
 %% \code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
+Ambos \code{EmptySet} e \code{NonEmptySet} estendem a classe \code{IntSet}. Isso implica
+que tipos \code{EmptySet} e \code{NonEmptySet} estÅ„o em conformidade com o tipo \code{IntSet} -- 
+um valor do tipo \code{EmptySet} ou \code{NonEmptySet} pode ser usado sempre que um valor 
+ do tipo \code{IntSet} ÅÈ requerido.
 %----------
 
-%----------
+%----------xpto
 %% \begin{exercise} Write methods \code{union} and \code{intersection} to form
 %% the union and intersection between two sets.
 %% \end{exercise}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1,3 +1,5 @@
+
+
 \def\exercise{
    \def\theresult{Exercise~\thesection.\arabic{result}}
    \refstepcounter{result}
@@ -7,9 +9,9 @@
  
 \newcommand{\rewriteby}[1]{\mbox{\tab\tab\rm(#1)}}
 
-\chapter{\label{chap:example-one}A First Example}
+\chapter{\label{chap:example-one}Um primeiro exemplo}
 
-As a first example, here is an implementation of Quicksort in Scala.
+Para começar, apresentamos um primeiro exemplo, a implementação de Quicksort em Scala.
 
 \begin{lstlisting}
 def sort(xs: Array[Int]) {
@@ -35,9 +37,9 @@ def sort(xs: Array[Int]) {
 }
 \end{lstlisting}
 
-The implementation looks quite similar to what one would write in Java
-or C.  We use the same operators and similar control structures.
-There are also some minor syntactical differences. In particular:
+A implementação se parece muito com a que você faria em Java
+ou C. Nós usamos os mesmos operadores e estruturas de controle.
+Existem também algumas pequenas diferenças sintáticas, particularmente:
 \begin{itemize}
 \item
 Definitions start with a reserved word. Function definitions start

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1,4 +1,3 @@
-
 \def\exercise{
    \def\theresult{Exercise~\thesection.\arabic{result}}
    \refstepcounter{result}
@@ -48,8 +47,8 @@ declaração de constantes (chamadas de valores) são iniciadas com a palavra \c
 O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
 O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
-Array types are written \code{Array[T]} rather than \code{T[]}, 
-and array selections are written \code{a(i)} rather than \code{a[i]}.
+A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
+O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
 \item
 Functions can be nested inside other functions. Nested functions can
 access parameters and local variables of enclosing functions. For

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2006,7 +2006,7 @@ desejamos expressar a soma de \code{x} com o valor negativo de \code{y},
 precisamos acrescentar no mínimo um espaço, ou seja, \code{x+ -y}.      
 %----------
 
-%----------xpto
+%----------
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
 O caracter \verb@$@ é reservado para identificadores gerados
@@ -2073,24 +2073,31 @@ Expressões podem ser:
 identificadores tais como \code{x}, \code{isGoodEnough}, \code{*}, ou \code{+-},
  \item
 %% literals, such as \code{0}, \code{1.0}, or \code{"abc"},
+literais, tais como \code{0}, \code{1.0}, ou \code{"abc"},
  \item
 %% field and method selections, such as \code{System.out.println},
+Seleções de campo e método, tal como \code{System.out.println},
  \item
-%% function applications, such as \code{sqrt(x)}, 
+%% function applications, such as \code{sqrt(x)},
+aplicações de função, tal como \code{sqrt(x)},
  \item
 %% operator applications, such as \code{-x} or \code{y + x},
+aplicações de operador, tais como \code{-x} ou \code{y + x},
  \item
 %% conditionals, such as \code{if (x < 0) -x else x},
+condicionais, tal como \code{if (x < 0) -x else x},
  \item
 %% blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
+blocos, tal como \lstinline@{ val x = abs(y) ; x * 2 }@,
  \item
 %% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
+funções anônimas, tais como \code{x => x + 1} ou \code{(x: Int, y: Int) => x + y}.
  \end{itemize}
 %----------
 
-%----------
-%% \subsection*{Definitions:}
-
+%----------xpto
+%% \subsection*{Definitions:
+\subsection*{Definições:}
 \begin{lstlisting}
 Def          =  FunDef  |  ValDef
 FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
@@ -2099,11 +2106,14 @@ Parameters   =  Parameter {',' Parameter}
 Parameter    =  ident ':' ['=>'] Type
 \end{lstlisting}
 %%Definitions can be:
+Definições podem ser:
 \begin{itemize}
 \item
 %%function definitions such as \code{def square(x: Int): Int = x * x},
+definições de função tal como \code{def square(x: Int): Int = x * x},
 \item
 %%value definitions such as \code{val y = square(2)}.
+definições de valor tal como \code{val y = square(2)}.
 \end{itemize}
 %----------
 
@@ -2113,6 +2123,8 @@ Parameter    =  ident ':' ['=>'] Type
 
 %% Scala does not have a built-in type of rational numbers, but it is
 %% easy to define one, using a class. Here's a possible implementation.
+Scala não tem um tipo primitivo para números racionais, mas é fácil 
+definir um, usando uma classe. Aqui está uma possível implementação.
 
 \begin{lstlisting}
 class Rational(n: Int, d: Int) {
@@ -2145,6 +2157,13 @@ class Rational(n: Int, d: Int) {
 %% arithmetic method takes as parameter the right operand of the
 %% operation. The left operand of the operation is always the rational
 %% number of which the method is a member.
+
+Isso define \code{Rational} como uma classe que recebe dois argumentos 
+construtores \code{n} e \code{d}, contendo as partes numéricas do numerador
+e denominador. A classe provê campos que retornam estas partes, bem como
+métodos para a aritmética sobre números racionais. Cada método aritmético 
+recebe como parâmetro o operando direito da operação. O operando esquerdo
+da operação sempre é o número racional do método cujo é membro.   
 %----------
 
 %----------
@@ -2157,12 +2176,22 @@ class Rational(n: Int, d: Int) {
 %% the class to eliminate common factors in the constructor arguments in
 %% order to ensure that numerator and denominator are always in
 %% normalized form.
+\paragraph{Membros Privados}
+A implementação dos números racionais define um método privado \code{gcd} que 
+computa o maior denominador comum de dois inteiros, bem como um campo
+privado \code{g} que contém o \code{gcd} dos argumentos construtores. Esses
+membros são inacessíveis de fora da classe \code{Rational}. São usados na 
+implementação da classe para eliminar fatores comuns nos argumentos construtores
+para garantir que o numerador e o denominador estejam sempre em forma normalizada.    
 %----------
 
 %----------
 %% \paragraph{Creating and Accessing Objects}
 %% As an example of how rational numbers can be used, here's a program
 %% that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
+\paragraph{Criando e Acessando Objetos}
+Como um exemplo de como os números racionais podem ser usados, aqui está um programa 
+que imprime a soma de todos os números $1/i$ onde $i$ está no intervalo de 1 a 10. 
 \begin{lstlisting}
 var i = 1
 var x = new Rational(0, 1)
@@ -2175,6 +2204,10 @@ println("" + x.numer + "/" + x.denom)
 %% The \code{+} takes as left operand a string and as right operand a
 %% value of arbitrary type. It returns the result of converting its right
 %% operand to a string and appending it to its left operand. 
+O \code{+} recebe como operando esquerdo uma cadeia de caracteres e como 
+operando direito um valor de tipo arbitrário. Retorna o resultado de 
+converter seu operando direito em uma cadeia de caracteres e concatená-la 
+a seu operando esquerdo.   
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4660,17 +4660,15 @@ def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
 \end{lstlisting}
 
 %--------------xpto
-
-\paragraph{FoldRight and ReduceRight}
-Applications of \code{foldLeft} and \code{reduceLeft} expand to
-left-leaning trees. \todo{insert pictures}.  They have duals
-\code{foldRight} and \code{reduceRight}, which produce right-leaning
-trees.
+\paragraph{FoldRight e ReduceRight}
+Aplicações de \code{foldLeft} e \code{reduceLeft} expandem para árvores inclinadas à esquerda. 
+\todo{insert pictures}. Eles têm duals \code{foldRight} e \code{reduceRight} que produzem 
+árvores inclinadas à direita.
 \begin{lstlisting}
 List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
 (List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
 \end{lstlisting}
-These are defined as follows.
+Estes são definidos como segue.
 \begin{lstlisting}
   def reduceRight(op: (A, A) => A): A = this match {
     case Nil => error("Nil.reduceRight")
@@ -4682,33 +4680,31 @@ These are defined as follows.
     case x :: xs => op(x, (xs foldRight z)(op))
   }
 \end{lstlisting}
-
-Class \code{List} defines also two symbolic abbreviations for
-\code{foldLeft} and \code{foldRight}:
+A classe  \code{List} define também duas abreviaturas simbólicas para \code{foldLeft}
+e \code{foldRight}:
 \begin{lstlisting}
   def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
   def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
 \end{lstlisting}
-The method names picture the left/right leaning trees of the fold
-operations by forward or backward slashes. The \code{:} points in each
-case to the list argument whereas the end of the slash points to the
-accumulator (or: zero) argument \code{z}. 
-That is, 
+Os nomes dos métodos ilustram a inclinação à esquerda/direita das árvores das operações 
+fold através de barra simples ou invertida. O \code{:} aponta em cada caso para a lista 
+de argumentos enquanto o fim da barra aponta para o acumulador (ou: zero) argumento \code{z}.
+Ou seja,  
 \begin{lstlisting}
 (z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
 (List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
 \end{lstlisting}
-For associative and commutative operators, \code{/:} and
-\code{:\\} are equivalent (even though there may be a difference
-in efficiency).  
+Através de operadores associativos e comutativos, \code{/:} e \code{:\\} são equivalentes
+(mesmo sabendo que podem ser diferentes em eficiência).
+
 %But sometimes, only one of the two operators is
 %appropriate or has the right type:
 
-\begin{exercise} Consider the problem of writing a function \code{flatten},
-which takes a list of element lists as arguments. The result of
-\code{flatten} should be the concatenation of all element lists into a
-single list. Here is an implementation of this method in terms of 
-\code{:\\}.
+\begin{exercise} Considere o problema de escrever uma função \code{flatten}, que recebe 
+uma lista de listas como argumentos. O resultado de \code{flatten} deve ser a concatenação 
+de todos os elementos listas em uma única lista. Aqui está uma implementação deste método 
+em termos de \code{:\\}.
+\end{exercise}
 \begin{lstlisting}
 def flatten[A](xs: List[List[A]]): List[A] =
   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -681,7 +681,7 @@ imediatamente substituído pelo valor pré-computado de \code{e}, logo a express
 precisa ser avaliada novamente.
 %----------
 
-%----------xpto 
+%---------- 
 %% How are expressions evaluated? An expression consisting of operators
 %% and operands is evaluated by repeatedly applying the following
 %% simplification steps.
@@ -696,10 +696,22 @@ precisa ser avaliada novamente.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
+Como as expressões são avaliadas? Uma expressão consistindo de operadores e 
+operandos é avaliada pela repetida aplicação dos seguintes passos de simplificação:
+\begin{itemize}
+\item escolha a operação mais a esquerda.
+\item avalie seu operando
+\item aplique o operador aos valores do operando.
+\end{itemize}
+Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
+direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
+nome pelo valor da definição do lado direito. O processo de avaliação pára assim que 
+encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
+um vetor, ou uma lista.
 %----------
 
 
-%----------
+%----------xpto
 %% \example
 %% Here is an evaluation of an arithmetic expression.
 %% \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2095,8 +2095,8 @@ funções anônimas, tais como \code{x => x + 1} ou \code{(x: Int, y: Int) => x 
  \end{itemize}
 %----------
 
-%----------xpto
-%% \subsection*{Definitions:
+%----------
+%% \subsection*{Definitions}:
 \subsection*{Definições:}
 \begin{lstlisting}
 Def          =  FunDef  |  ValDef
@@ -2221,9 +2221,17 @@ a seu operando esquerdo.
 %% \code{scala.AnyRef} is implicitly assumed (for Java implementations,
 %% this type is an alias for \code{java.lang.Object}. For instance, class
 %% \code{Rational} could equivalently be defined as
+\paragraph{Herança e Sobrecarga}
+Cada classe em Scala tem uma superclasse que ela estende.
+\comment{A exceção é a classe \code{Object}, que não possui superclasse, e
+que é indiretamente estendida para cada outra classe.}
+Se uma classe não menciona sua superclasse em sua definição, o tipo básico 
+\code{scala.AnyRef} é implicitamente assumido (para implementações Java, este
+tipo é um apelido (alias) para \code{java.lang.Object}. Por exemplo, a classe 
+\code{Rational} pode ser equivalentemente definida como      
 \begin{lstlisting}
 class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
+  ... // como antes
 }
 \end{lstlisting}
 %----------
@@ -2234,6 +2242,10 @@ class Rational(n: Int, d: Int) extends AnyRef {
 %% \code{java.lang.Object} defines
 %% a method
 %% \code{toString} which returns a representation of the object as a string:
+Uma classe herda todos os membros de sua superclasse. Pode também redefinir
+(ou: {\em sobrescrever}) alguns membros herdados. Por exemplo, a classe 
+\code{java.lang.Object} define um método \code{toString} que retorna uma 
+representação do objeto como cadeia de caracteres (string): 
 \begin{lstlisting}
 class Object {
   ...
@@ -2242,7 +2254,7 @@ class Object {
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% The implementation of \code{toString} in \code{Object}
 %% forms a string consisting of the object's class name and a number. It
 %% makes sense to redefine this method for objects that are rational

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1478,15 +1478,20 @@ definida sem receber um nome. Como exemplo considere a função anônima quadrad
 \end{lstlisting}
 %----------
   
-%----------xpto
+%----------
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.
+A parte anterior a flecha `\code{=>}' são os parâmetros da função, ao passo que a parte
+seguinte a `\code{=>}' é o seu corpo.
+Por exemplo, aqui está uma função anônima que multiplica seus dois argumentos.
 \begin{lstlisting}
   (x: Int, y: Int) => x * y
 \end{lstlisting}
 %% Using anonymous functions, we can reformulate the first two summation
 %% functions without named auxiliary functions:
+Usando funções anônimas, podemos reformular as duas funções soma sem
+funções auxiliares nomeadas:
 \begin{lstlisting}
 def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
 def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
@@ -1501,13 +1506,20 @@ def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
 %% function of type \code{Int => Int}.  Hence, the parameter type
 %% \code{Int} is redundant and may be omitted. If there is a single
 %% parameter without a type, we may also omit the parentheses around it:
+Frequentemente, o compilador Scala pode deduzir o tipo do parâmetro a partir
+do contexto da função anônima nos casos em que foram omitidos.
+Por exemplo, no caso de \code{sumInts} ou \code{sumSquares}, sabe-se a partir do 
+tipo de \code{sum} que o primeiro parâmetro deve ser uma função de tipo \code{Int => Int}.
+Consequentemente, o tipo do parâmetro \code{Int} é redundante e pode ser omitido. Se
+houver um único parâmetro sem um tipo, também podemos omitir os parâmetros a sua volta. 
+   
 \begin{lstlisting}
 def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
 def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
 \end{lstlisting}
 %----------
 
-%----------
+%----------xpto
 %% Generally, the Scala term
 %% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
 %% defines a function which maps its parameters

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3564,42 +3564,41 @@ class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
 }
 \end{lstlisting}
 
-%----------xpto
+Nas definições acima, `\code{A}' é um {\em parâmetro tipo} da classe
+\code{Stack} e suas subclasses. Parâmetros tipo são nomes arbitrários; eles
+são envolvidos por chaves ao invés de parênteses, portanto podem facilmente 
+distinguidos de parâmetros valor. Aqui está um exemplo de como classes genéricas
+são usadas:
 
-In the definitions above, `\code{A}' is a {\em type parameter} of
-class \code{Stack} and its subclasses.  Type parameters are arbitrary
-names; they are enclosed in brackets instead of parentheses, so that
-they can be easily distinguished from value parameters.  Here is an
-example how the generic classes are used:
 \begin{lstlisting}
 val x = new EmptyStack[Int]
 val y = x.push(1).push(2)
 println(y.pop.top)
 \end{lstlisting}
-The first line creates a new empty stack of \code{Int}'s. Note the
-actual type argument \code{[Int]} which replaces the formal type
-parameter \code{A}.
+A primeira linha cria uma nova pilha vazia de \code{Int}. Observe o tipo argumento 
+\code{[Int]} que substitui o tipo parâmetro formal \code{A}.
 
-It is also possible to parameterize methods with types. As an example,
-here is a generic method which determines whether one stack is a
-prefix of another.
+Também é possível parametrizar métodos com tipos. Como um exemplo, aqui está um
+método genérico que determina se uma pilha é um prefixo de outra.
 \begin{lstlisting}
 def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
   p.isEmpty ||
   p.top == s.top && isPrefix[A](p.pop, s.pop)
 }
 \end{lstlisting}
-The method parameters are called {\em polymorphic}.  Generic methods are
-also called {\em polymorphic}.  The term comes from the Greek, where it
-means ``having many forms''.  To apply a polymorphic method such as
-\code{isPrefix}, we pass type parameters as well as value parameters
-to it. For instance,
+
+Os parâmetros do método são chamados {\em polimórficos}. Métodos genéricos são
+também chamados {\em polimórficos}. O termo tem origem no Grego, onde 
+significa ``que tem muitas formas''. Para aplicar um método polimórfico tal como 
+\code{isPrefix}, passamos parâmetros tipo, bem como parâmetros valor para ele. 
+Por exemplo,  
+
 \begin{lstlisting}
 val s1 = new EmptyStack[String].push("abc")
 val s2 = new EmptyStack[String].push("abx").push(s1.top)
 println(isPrefix[String](s1, s2))
 \end{lstlisting}
-%----------
+%----------xpto
 
 \paragraph{Local Type Inference}
 Passing type parameters such as \code{[Int]} or \code{[String]} all

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -907,7 +907,12 @@ scala> constOne(loop, 2)               // leva a laço infinito
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
 \section{Expressões Condicionais}
-
+O \code{if-else} do Scala leva a uma escolha entre duas alternativas. Sua
+sintaxe é a mesma do \code{if-else} do Java. Mas onde o \code{if-else} do 
+Java pode ser usado somente como uma alternativa entre comandos, Scala 
+permite a mesma sintaxe para escolher entre duas expressões. Isso porque o
+\code{if-else} do Scala serve também como um substituto para a expressão 
+condicional do Java \code{... ? ... : ...}.      
 %----------
 
 %----------
@@ -922,6 +927,16 @@ scala> constOne(loop, 2)               // leva a laço infinito
 %% \code{true} and
 %% \code{false}, comparison operators, boolean negation \code{!} and the
 %% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
+\exemplo\
+\begin{lstlisting}
+scala> def abs(x: Double) = if (x >= 0) x else -x
+abs: (Double)Double
+\end{lstlisting}
+Expressões boleanas em Scala são similares as em Java; são formadas
+a partir de constantes.  
+\code{true} e
+\code{false}, operadores de comparação, negação boleana \code{!} e os 
+operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}. 
 %----------
 
 %----------
@@ -934,6 +949,14 @@ scala> constOne(loop, 2)               // leva a laço infinito
 %% def sqrt(x: Double): Double = ...
 %% \end{lstlisting}
 %% which computes the square root of \code{x}.
+
+%% \section{\label{sec:sqrt}Example: Raiz Quadrada pelo Método de Newton}
+Agora ilustraremos elementos da linguagem intruduzidos até aqui na
+construção de um programa mais interessante. A tarefa é escrever um função  
+ \begin{lstlisting}
+ def sqrt(x: Double): Double = ...
+ \end{lstlisting}
+que computa a raiz quadrada de \code{x}. 
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2935,9 +2935,12 @@ antes que objetos de uma classe abstrata ou trait sejam criados.
 %% keep things simple initially, we restrict ourselves to just numbers
 %% and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
 %% \code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
-%% \begin{lstlisting}
-%% new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
-%% \end{lstlisting}
+ \begin{lstlisting}
+ new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
+ \end{lstlisting}
+%----------
+
+%----------
 %% Now, an evaluator of an expression like this needs to know of what
 %% form it is (either \code{Sum} or \code{Number}) and also needs to
 %% access the components of the expression.  The following
@@ -2965,6 +2968,9 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
   def rightOp: Expr = e2
 }
 \end{lstlisting}
+%----------
+
+%----------
 %%With these classification and access methods, writing an evaluator function is simple:
 \begin{lstlisting}
 def eval(e: Expr): Int = {
@@ -2981,7 +2987,9 @@ def eval(e: Expr): Int = {
 %% new abstract method \code{isProduct} in class \code{Expr} and
 %% implement that method in subclasses \code{Number}, \code{Sum}, and
 %% \code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
+%----------
 
+%----------
 %% The promise of object-oriented programming is that such modifications
 %% should be unnecessary, because they can be avoided by re-using
 %% existing, unmodified code through inheritance. Indeed, a more
@@ -3001,7 +3009,10 @@ class Number(n: Int) extends Expr {
 class Sum(e1: Expr, e2: Expr) extends Expr {
   def eval: Int = e1.eval + e2.eval
 }
-\end{lstlisting}
+\end{lstlisting
+%----------
+
+%----------}
 %%Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
 \begin{lstlisting}
 class Prod(e1: Expr, e2: Expr) extends Expr {
@@ -3015,7 +3026,9 @@ class Prod(e1: Expr, e2: Expr) extends Expr {
 %% possible way we might want to extend the expression example. We might
 %% want to add new {\em operations} on expressions.  For instance, we might
 %% want to add an operation that pretty-prints an expression tree to standard output.
+%----------
 
+%----------
 %% If we have defined all classification and access methods, such an
 %% operation can easily be written as an external function. Here is an
 %% example:
@@ -3054,6 +3067,9 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
   }
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
 
@@ -3067,14 +3083,18 @@ class Sum(e1: Expr, e2: Expr) extends Expr {
 %% forced to have classification and access methods in this case. This
 %% seems to bring us back to square one, with all the problems of
 %% verbosity and extensibility.
+%----------
 
+%----------
 %% Taking a closer look, one observes that the only purpose of the
 %% classification and access functions is to {\em reverse} the data
 %% construction process.  They let us determine, first, which sub-class
 %% of an abstract base class was used and, second, what were the
 %% constructor arguments. Since this situation is quite common, Scala has
 %% a way to automate it with case classes. 
+%----------
 
+%----------
 %% \section{Case Classes and Case Objects}
 
 %% {\em Case classes} and {\em case objects} are defined like a normal
@@ -3094,6 +3114,9 @@ case class Sum(e1: Expr, e2: Expr) extends Expr
 def Number(n: Int) = new Number(n)
 def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
 \end{lstlisting}
+%----------
+
+%----------
 %%would be added. Hence, one can now construct expression trees a bit more concisely, as in
 \begin{lstlisting}
 Sum(Sum(Number(1), Number(2)), Number(3))
@@ -3108,6 +3131,10 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 \begin{lstlisting}
 Sum(Sum(Number(1), Number(2)), Number(3))
 \end{lstlisting} 
+%----------
+
+
+%----------
 %% would be converted to exactly that string, whereas the default
 %% implementation in class \code{AnyRef} would return a string consisting
 %% of the outermost constructor name \code{Sum} and a number.  The
@@ -3119,6 +3146,9 @@ Sum(Sum(Number(1), Number(2)), Number(3))
  \begin{lstlisting}
  Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
  \end{lstlisting}
+%----------
+
+%----------
 %% will yield \code{true}. If \code{Sum} or \code{Number} were not case
 %% classes, the same expression would be \code{false}, since the standard
 %% implementation of \code{equals} in class \code{AnyRef} always treats
@@ -3134,6 +3164,10 @@ Sum(Sum(Number(1), Number(2)), Number(3))
  \begin{lstlisting}
  def n: Int
  \end{lstlisting}
+%----------
+
+
+%----------
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
  \begin{lstlisting}
  def e1: Expr, e2: Expr
@@ -3150,7 +3184,9 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% Case classes allow the constructions of {\em patterns} which refer to
 %% the case class constructor.
 %% \end{enumerate}
+%----------
 
+%----------
 %% \section{Pattern Matching}
 
 %% Pattern matching is a generalization of C or Java's \code{switch}
@@ -3166,6 +3202,9 @@ def eval(e: Expr): Int = e match {
   case Sum(l, r) => eval(l) + eval(r) 
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -3176,7 +3215,9 @@ def eval(e: Expr): Int = e match {
 %% \code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
 %% \code{l} and \code{r} 
 %% to \code{v}$_1$ and \code{v}$_2$, respectively. 
+%----------
 
+%----------
 %% In general, patterns are built from
 %% \begin{itemize}
 %% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
@@ -3191,7 +3232,9 @@ def eval(e: Expr): Int = e match {
 %% upper case letter.  Each variable name may occur only once in a
 %% pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
 %% since the pattern variable \code{x} occurs twice in it.
+%----------
 
+%----------
 %% \paragraph{Meaning of Pattern Matching}
 %% A pattern matching expression 
 \begin{lstlisting}
@@ -3199,6 +3242,9 @@ e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
 \end{lstlisting}
 %% matches the patterns $p_1 \commadots p_n$ in the order they
 %% are written against the selector value \code{e}.
+%----------
+
+%----------
 %% \begin{itemize}
 %% \item
 %% A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
@@ -3217,7 +3263,9 @@ e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
 %% pattern variables are replaced by corresponding constructor arguments.
 %% If none of the patterns matches, the pattern matching expression is
 %% aborted with a \code{MatchError} exception.
+%----------
 
+%----------
 %% \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
 \begin{lstlisting}
      eval(Sum(Number(1), Number(2)))
@@ -3246,7 +3294,9 @@ e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
 
 ->$^*$ 1 + 2 -> 3
 \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Pattern Matching and Methods}
 %% In the previous example, we have used pattern
 %% matching in a function which was defined outside the class hierarchy
@@ -3262,7 +3312,10 @@ abstract class Expr {
   } 
 }
 \end{lstlisting}
+%----------
 
+
+%----------
 %% \begin{exercise} Consider the following definitions representing trees
 %% of integers.  These definitions can be seen as an alternative
 %% representation of \code{IntSet}:
@@ -3282,7 +3335,10 @@ def insert(t: IntTree, v: Int): IntTree = t match { ...
 }
 \end{lstlisting}
 %% \end{exercise}
+%----------
 
+
+%----------
 %% \paragraph{Pattern Matching Anonymous Functions}
 
 %% So far, case-expressions always appeared in conjunction with a
@@ -3301,7 +3357,9 @@ def insert(t: IntTree, v: Int): IntTree = t match { ...
 \end{lstlisting}
 %% where \code{x} is a fresh variable which is not used 
 %% otherwise in the expression.
+%----------
 
+%----------
 %% \chapter{Generic Types and Methods}
 
 %% Classes in Scala can have type parameters. We demonstrate the use of
@@ -3327,11 +3385,16 @@ class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
   def pop = rest
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% Of course, it would also make sense to define an abstraction for a
 %% stack of Strings. To do that, one could take the existing abstraction
 %% for \code{IntStack}, rename it to \code{StringStack} and at the same
 %% time rename all occurrences of type \code{Int} to \code{String}.
+%----------
 
+%----------
 %% A better way, which does not entail code duplication, is to
 %% parameterize the stack definitions with the element type.
 %% Parameterization lets us generalize from a specific instance of a
@@ -3357,6 +3420,9 @@ class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
   def pop = rest
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% In the definitions above, `\code{A}' is a {\em type parameter} of
 %% class \code{Stack} and its subclasses.  Type parameters are arbitrary
 %% names; they are enclosed in brackets instead of parentheses, so that
@@ -3367,6 +3433,9 @@ val x = new EmptyStack[Int]
 val y = x.push(1).push(2)
 println(y.pop.top)
 \end{lstlisting}
+%----------
+
+%----------
 %% The first line creates a new empty stack of \code{Int}'s. Note the
 %% actual type argument \code{[Int]} which replaces the formal type
 %% parameter \code{A}.
@@ -3379,7 +3448,10 @@ def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
   p.isEmpty ||
   p.top == s.top && isPrefix[A](p.pop, s.pop)
 }
-\end{lstlisting}  
+\end{lstlisting}
+%----------
+
+%----------  
 %% The method parameters are called {\em polymorphic}.  Generic methods are
 %% also called {\em polymorphic}.  The term comes from the Greek, where it
 %% means ``having many forms''.  To apply a polymorphic method such as
@@ -3390,7 +3462,9 @@ val s1 = new EmptyStack[String].push("abc")
 val s2 = new EmptyStack[String].push("abx").push(s1.top)
 println(isPrefix[String](s1, s2))
 \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Local Type Inference}
 %% Passing type parameters such as \code{[Int]} or \code{[String]} all
 %% the time can become tedious in applications where generic functions
@@ -3405,7 +3479,9 @@ println(isPrefix[String](s1, s2))
 %% constructors in situations like these.  In the example above, one
 %% could have written \code{isPrefix(s1, s2)} and the missing type argument
 %% \code{[String]} would have been inserted by the type inferencer. 
+%----------
 
+%----------
 %% \section{Type Parameter Bounds}
 
 %% Now that we know how to make classes generic it is natural to
@@ -3419,6 +3495,9 @@ abstract class Set[A] {
   def contains(x: A): Boolean
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% However, if we still want to implement sets as binary search trees, we
 %% encounter a problem. The \code{contains} and \code{incl} methods both
 %% compare elements using methods \code{<} and \code{>}. For
@@ -3431,6 +3510,9 @@ abstract class Set[A] {
     if (x < elem) left contains x
           ^ < $\mbox{\sl not a member of type}$ A.
 \end{lstlisting}
+%----------
+
+%----------
 %% One way to solve the problem is to restrict the legal types that can
 %% be substituted for type \code{A} to only those types that contain methods
 %% \code{<} and \code{>} of the correct types. There is a trait
@@ -3456,6 +3538,9 @@ trait Ordered[A] {
   def compareTo(that: A): Int = compare(that)
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% We can enforce the comparability of a type by demanding
 %% that the type is a subtype of \code{Ordered}. This is done by giving an
 %% upper bound to the type parameter of \code{Set}:
@@ -3468,7 +3553,9 @@ trait Set[A <: Ordered[A]] {
 %% The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
 %% type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
 %% must be comparable to values of the same type.
+%----------
 
+%----------
 %% With this restriction, we can now implement the rest of the generic
 %% set abstraction as we did in the case of \code{IntSet}s before.
 
@@ -3492,11 +3579,16 @@ class NonEmptySet[A <: Ordered[A]]
     else this
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% Note that we have left out the type argument in the object creations
 %% \code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
 %% missing type arguments in constructor calls are inferred from value
 %% arguments and/or the expected result type.
+%----------
 
+%----------
 %% Here is an example that uses the generic set abstraction. Let's first
 %% create a subclass of \lstinline@Ordered@, like this:
 \begin{lstlisting}
@@ -3519,6 +3611,9 @@ val s = new EmptySet[java.io.File]
                     ^ java.io.File $\mbox{\sl does not conform to type}$
                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
 \end{lstlisting}
+%----------
+
+%----------
 %% One probem with type parameter bounds is that they require
 %% forethought: if we had not declared \lstinline@Num@ a subclass of
 %% \lstinline@Ordered@, we would not have been able to use \lstinline@Num@
@@ -3526,7 +3621,9 @@ val s = new EmptySet[java.io.File]
 %% such as \lstinline@Int@, \lstinline@Double@, or
 %% \lstinline@String@ are not subclasses of \lstinline@Ordered@, so
 %% values of these types cannot be used as set elements.
+%----------
 
+%----------
 %% A more flexible design, which admits elements of these types, uses
 %% {\em view bounds} instead of the plain type bounds we have seen so
 %% far. The only change this entails in the example above is in the type
@@ -3536,17 +3633,24 @@ trait Set[A <% Ordered[A]] ...
 class EmptySet[A <% Ordered[A]] ...
 class NonEmptySet[A <% Ordered[A]] ...
 \end{lstlisting}
+%----------
+
+%----------
 %% View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
 %% A view bounded type parameter clause \lstinline@[A <% T]@ only
 %% specifies that the bounded type \lstinline@A@ must be {\em convertible} to
 %% the bound type \lstinline@T@, using an implicit conversion.
+%----------
 
+%----------
 %% The Scala library predefines implicit conversions for a number of
 %% types, including the primitive types and \lstinline@String@.
 %% Therefore, the redesign set abstraction can be instantiated with these
 %% types as well. More explanations on implicit conversions and view
 %% bounds are given in Section~\ref{sec:implicits}.
+%----------
 
+%----------
 %% \section{Variance Annotations}\label{sec:first-arrays}
 
 %% The combination of type parameters and subtyping poses some
@@ -3556,7 +3660,9 @@ class NonEmptySet[A <% Ordered[A]] ...
 %% \code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
 %% then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
 %% This property is called {\em co-variant} subtyping.
+%----------
 
+%----------
 %% In Scala, generic types have by default non-variant subtyping. That
 %% is, with \code{Stack} defined as above, stacks with different element
 %% types would never be in a subtype relation. However, we can enforce
@@ -3565,6 +3671,9 @@ class NonEmptySet[A <% Ordered[A]] ...
 \begin{lstlisting}
 class Stack[+A] {
 \end{lstlisting}
+%----------
+
+%----------
 %% Prefixing a formal type parameter with a \code{+} indicates that
 %% subtyping is covariant in that parameter. 
 %% Besides \code{+}, there is also a prefix \code{-} which indicates
@@ -3572,7 +3681,9 @@ class Stack[+A] {
 %% Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
 %% that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
 %% case of stacks would be rather surprising!).
+%----------
 
+%----------
 %% In a purely functional world, all types could be co-variant. However,
 %% the situation changes once we introduce mutable data. Consider the
 %% case of arrays in Java or .NET. Such arrays are represented in Scala
@@ -3584,11 +3695,16 @@ class Array[A] {
   def update(index: Int, elem: A)
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% The class above defines the way Scala arrays are seen from Scala user
 %% programs. The Scala compiler will map this abstraction to the
 %% underlying arrays of the host system in most cases where this
 %% possible.
+%----------
 
+%----------
 %% In Java, arrays are indeed covariant; that is, for reference types
 %% \code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
 %% \code{Array[T]} is a subtype of \code{Array[S]}. This might seem
@@ -3600,6 +3716,9 @@ val y: Array[Any] = x
 y(0) = new Rational(1, 2)  // this is syntactic sugar for
                            // y.update(0, new Rational(1, 2))
 \end{lstlisting}
+%----------
+
+%----------
 %% In the first line, a new array of strings is created. In the second
 %% line, this array is bound to a variable \code{y}, of type
 %% \code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
@@ -3608,20 +3727,26 @@ y(0) = new Rational(1, 2)  // this is syntactic sugar for
 %% OK, since type \code{Rational} is a subtype of the element type
 %% \code{Any} of the array \code{y}. We thus end up storing a rational
 %% number in an array of strings, which clearly violates type soundness. 
+%----------
 
+%----------
 %% Java solves this problem by introducing a run-time check in the third
 %% line which tests whether the stored element is compatible with the
 %% element type with which the array was created. We have seen in the
 %% example that this element type is not necessarily the static element
 %% type of the array being updated. If the test fails, an
 %% \code{ArrayStoreException} is raised.
+%----------
 
+%----------
 %% Scala solves this problem instead statically, by disallowing the
 %% second line at compile-time, because arrays in Scala have non-variant
 %% subtyping. This raises the question how a Scala compiler verifies that
 %% variance annotations are correct. If we had simply declared arrays
 %% co-variant, how would the potential problem have been detected?
+%----------
 
+%----------
 %% Scala uses a conservative approximation to verify soundness of
 %% variance annotations.  A covariant type parameter of a class may only
 %% appear in co-variant positions inside the class.  Among the co-variant
@@ -3637,11 +3762,16 @@ class Array[+A] {
                                  $\mbox{\sl appears in contravariant position.}$
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% So far, so good. Intuitively, the compiler was correct in rejecting
 %% the \code{update} procedure in a co-variant class because \code{update}
 %% potentially changes state, and therefore undermines the soundness of
 %% co-variant subtyping. 
+%----------
 
+%----------
 %% However, there are also methods which do not mutate state, but where a
 %% type parameter still appears contra-variantly. An example is
 %% \code{push} in type \code{Stack}. Again the Scala compiler will reject
@@ -3652,11 +3782,16 @@ class Stack[+A] {
               ^ $\mbox{\sl covariant type parameter}$ A
                 $\mbox{\sl appears in contravariant position.}$
 \end{lstlisting}
+%----------
+
+%----------
 %% This is a pity, because, unlike arrays, stacks are purely functional data
 %% structures and therefore should enable co-variant subtyping. However,
 %% there is a a way to solve the problem by using a polymorphic method
 %% with a lower type parameter bound.
+%----------
 
+%----------
 %% \section{Lower Bounds}
 
 %% We have seen upper bounds for type parameters. In a type parameter
@@ -3666,7 +3801,9 @@ class Stack[+A] {
 %% \code{T >: S}, the type parameter \code{T} is restricted to range only
 %% over {\em supertypes} of type \code{S}. (One can also combine lower and
 %% upper bounds, as in \code{T >: S <: U}.)
+%----------
 
+%----------
 %% Using lower bounds, we can generalize the \code{push} method in
 %% \code{Stack} as follows.
 \begin{lstlisting}
@@ -3678,7 +3815,9 @@ class Stack[+A] {
 %% \code{push}. Instead, it appears as lower bound for another type
 %% parameter of a method, which is classified as a co-variant position.
 %% Hence, the Scala compiler accepts the new definition of \code{push}.
+%----------
 
+%----------
 %% In fact, we have not only solved the technical variance problem but
 %% also have generalized the definition of \code{push}.  Before, we were
 %% required to push only elements with types that conform to the declared
@@ -3687,14 +3826,18 @@ class Stack[+A] {
 %% accordingly. For instance, we can now push an \code{AnyRef} onto a
 %% stack of \code{String}s, but the resulting stack will be a stack of
 %% \code{AnyRef}s instead of a stack of \code{String}s!
+%----------
 
+%----------
 %% In summary, one should not hesitate to add variance annotations to
 %% your data structures, as this yields rich natural subtyping
 %% relationships. The compiler will detect potential soundness
 %% problems. Even if the compiler's approximation is too conservative, as
 %% in the case of method \code{push} of class \code{Stack}, this will
 %% often suggest a useful generalization of the contested method.
+%----------
 
+%----------
 %% \section{Least Types}
 
 %% Scala does not allow one to parameterize objects with types. That's
@@ -3704,6 +3847,9 @@ class Stack[+A] {
 \begin{lstlisting}
 object EmptyStack extends Stack[Nothing] { ... }
 \end{lstlisting}
+%----------
+
+%----------
 %% The bottom type \code{Nothing} contains no value, so the type
 %% \code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
 %% contains no elements. Furthermore, \code{Nothing} is a subtype of all
@@ -3714,6 +3860,9 @@ object EmptyStack extends Stack[Nothing] { ... }
 \begin{lstlisting}
 val s = EmptyStack.push("abc").push(new AnyRef())
 \end{lstlisting}
+%----------
+
+%----------
 %%Let's analyze the type assignment for this expression in detail.  The
 %%\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
 %%method
@@ -3727,19 +3876,26 @@ push[B >: Nothing](elem: B): Stack[B] .
 \begin{lstlisting}
 push[B >: String](elem: B): Stack[B] .
 \end{lstlisting}
+%----------
+
+%----------
 %% The final part of the value definition above is the application of
 %% this method to \code{new AnyRef()}. Local type inference will
 %% determine that the type parameter \code{b} should this time be
 %% instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
 %% Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
+%----------
 
+%----------
 %% Besides \code{Nothing}, which is a subtype of every other type, there
 %% is also the type \code{Null}, which is a subtype of
 %% \code{scala.AnyRef}, and every class derived from it. The \code{null}
 %% literal in Scala is the only value of that type. This makes
 %% \code{null} compatible with every reference type, but not with a value
 %% type such as \code{Int}.
+%----------
 
+%----------
 %% We conclude this section with the complete improved definition of
 %% stacks. Stacks have now co-variant subtyping, the \code{push} method
 %% has been generalized, and the empty stack is represented by a single
@@ -3766,7 +3922,9 @@ class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
 %% commonly used families of generic classes, tuples and functions. The
 %% discussion of another common class, lists, is deferred to the next
 %% chapter.
+%----------
 
+%----------
 %% \section{Tuples}
 
 %% Sometimes, a function needs to return more than one result. For
@@ -3777,6 +3935,9 @@ class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
 case class TwoInts(first: Int, second: Int)
 def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
 \end{lstlisting}
+%----------
+
+%----------
 %% However, having to define a new class for every possible pair of
 %% result types is very tedious. In Scala one can use instead a
 %% generic class \lstinline@Tuple$2$@, which is defined as follows:
@@ -3788,11 +3949,16 @@ case class Tuple2[A, B](_1: A, _2: B)
 \begin{lstlisting}
 def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
 \end{lstlisting}
+%----------
+
+%----------
 %% As usual, type parameters to constructors can be omitted if they are
 %% deducible from value arguments. There exist also tuple classes for
 %% every other number of elements (the current Scala implementation
 %% limits this to tuples of some reasonable number of elements).  
+%----------
 
+%----------
 %% \comment{
 %% Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
 %% \code{Triple} for \code{Tuple3}).  With these conventions,
@@ -3801,6 +3967,9 @@ def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
 def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
 \end{lstlisting}
 %% }
+%----------
+
+%----------
 %% How are elements of tuples accessed? Since tuples are case classes,
 %% there are two possibilities. One can either access a tuple's fields
 %% using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
@@ -3815,6 +3984,9 @@ divmod(x, y) match {
     println("quotient: " + n + ", rest: " + d)
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% Note that type parameters are never used in patterns; it would have
 %% been illegal to write case \code{Tuple2[Int, Int](n, d)}.
 
@@ -3830,6 +4002,9 @@ divmod(x, y) match {
   case (n, d) => println("quotient: " + n + ", rest: " + d)
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% \section{Functions}\label{sec:functions}
 
 %% Scala is a functional language in that functions are first-class
@@ -3844,6 +4019,9 @@ trait Function1[-A, +B] {
   def apply(x: A): B
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% Besides \code{Function1}, there are also definitions of for functions
 %% of all other arities (the current implementation implements this only
 %% up to a reasonable limit).  That is, there is one definition for each
@@ -3851,14 +4029,18 @@ trait Function1[-A, +B] {
 %% ~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
 %% for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
 %% T_n, S$]@~.
+%----------
 
+%----------
 %% Scala uses the same syntax $f(x)$ for function application, no matter
 %% whether $f$ is a method or a function object. This is made possible by
 %% the following convention: A function application $f(x)$ where $f$ is
 %% an object (as opposed to a method) is taken to be a shorthand for
 %% \lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
 %% function type is inserted automatically where this is necessary.
+%----------
 
+%----------
 %% That's also why we defined array subscripting in
 %% Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
 %% array \code{a}, the subscript operation \code{a(i)} is taken to be a
@@ -3871,6 +4053,9 @@ val f: (AnyRef => Int)  =  x => x.hashCode()
 val g: (String => Int)  =  f
 g("abc")
 \end{lstlisting}
+%----------
+
+%----------
 %% It's sound to bind the value \code{g} of type \code{String => Int} to
 %% \code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
 %% do with function of type \code{String => Int} is pass it a string in
@@ -3880,7 +4065,9 @@ g("abc")
 %% in its argument type whereas it is covariant in its result type.
 %% In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
 %% $S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
+%----------
 
+%----------
 %% \example Consider the Scala code
 \begin{lstlisting}
 val plus1: (Int => Int)  =  (x: Int) => x + 1
@@ -3907,7 +4094,9 @@ val plus1: Function1[Int, Int] = {
 }
 plus1.apply(2)
 \end{lstlisting}
- 
+%----------
+
+%---------- 
 %% \chapter{Lists}
 
 %% Lists are an important data structure in many Scala programs.  
@@ -3924,7 +4113,9 @@ val empty = List()
 %% is, elements of a list cannot be changed by assignment. Second, 
 %% lists have a recursive structure, whereas arrays are flat. Third,
 %% lists support a much richer set of operations than arrays usually do.
+%----------
 
+%----------
 %% \section{Using Lists}
 
 %% \paragraph{The List type}
@@ -3937,7 +4128,9 @@ val nums : List[Int]       = List(1, 2, 3, 4)
 val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
 val empty: List[Int]       = List()
 \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{List constructors}
 %% All lists are built from two more fundamental constructors, \code{Nil}
 %% and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
@@ -3954,6 +4147,9 @@ val diag3  = (1 :: (0 :: (0 :: Nil))) ::
              (0 :: (0 :: (1 :: Nil))) :: Nil
 val empty  = Nil
 \end{lstlisting}
+%----------
+
+%----------
 %% The `\code{::}' operation associates to the right: \code{A :: B :: C} is
 %% interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
 %% parentheses in the definitions above. For instance, we can write
@@ -3961,7 +4157,9 @@ val empty  = Nil
 \begin{lstlisting}
 val nums  =  1 :: 2 :: 3 :: 4 :: Nil
 \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Basic operations on lists}
 %% All operations on lists can be expressed in terms of the following three:
 
@@ -3971,7 +4169,9 @@ val nums  =  1 :: 2 :: 3 :: 4 :: Nil
 %% & first element,\\
 %% \code{isEmpty} & returns \code{true} iff the list is empty
 %% \end{tabular}
+%----------
 
+%----------
 %% These operations are defined as methods of list objects. So we invoke
 %% them by selecting from the list that's operated on. Examples:
 \begin{lstlisting}
@@ -3983,7 +4183,9 @@ diag3.head      = List(1, 0, 0)
 \end{lstlisting}
 %% The \code{head} and \code{tail} methods are defined only for non-empty
 %% lists.  When selected from an empty list, they throw an exception.
+%----------
 
+%----------
 %% As an example of how lists can be processed, consider sorting the
 %% elements of a list of numbers into ascending order. One simple way to
 %% do so is {\em insertion sort}, which works as follows: To sort a
@@ -3996,11 +4198,15 @@ def isort(xs: List[Int]): List[Int] =
   if (xs.isEmpty) Nil
   else insert(xs.head, isort(xs.tail))
 \end{lstlisting}
+%----------
 
+%----------
 %% \begin{exercise} Provide an implementation of the missing function
 %% \code{insert}.
 %% \end{exercise}
+%----------
 
+%----------
 %% \paragraph{List patterns} In fact, \code{::} is defined as a case
 %% class in Scala's standard library. Hence, it is possible to decompose
 %% lists by pattern matching, using patterns composed from the \code{Nil}
@@ -4019,7 +4225,9 @@ def insert(x: Int, xs: List[Int]): List[Int] = xs match {
   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
 }
 \end{lstlisting}
+%----------
 
+%----------
 %% \section{Definition of class List I: First Order Methods}
 %% \label{sec:list-first-order}
 
@@ -4030,6 +4238,9 @@ def insert(x: Int, xs: List[Int]): List[Int] = xs match {
 package scala
 abstract class List[+A] {
 \end{lstlisting}
+%----------
+
+%----------
 %% \code{List} is an abstract class, so one cannot define elements by
 %% calling the empty \code{List} constructor (e.g. by
 %% \code{new List}).  The class has a type parameter \code{a}. It is
@@ -4040,7 +4251,9 @@ abstract class List[+A] {
 %% classes of Scala.
 %%  \code{List} defines a number of methods, which are
 %% explained in the following.
+%----------
 
+%----------
 %% \paragraph{Decomposing lists}
 %% First, there are the three basic methods \code{isEmpty},
 %% \code{head}, \code{tail}. Their implementation in terms of pattern
@@ -4059,7 +4272,9 @@ def tail: List[A] = this match {
   case x :: xs => xs
 }
 \end{lstlisting}
+%----------
 
+%----------
 %%The next function computes the length of a list.
 \begin{lstlisting}
 def length: Int = this match {
@@ -4069,7 +4284,9 @@ def length: Int = this match {
 \end{lstlisting}
 %% \begin{exercise} Design a tail-recursive version of \code{length}.
 %% \end{exercise}
+%----------
 
+%----------
 %% The next two functions are the complements of \code{head} and
 %% \code{tail}.
 \begin{lstlisting}
@@ -4088,6 +4305,9 @@ def last: A = this match {
   case x :: xs  => xs.last
 }
 \end{lstlisting}
+%----------
+
+%----------
 %% The implementation of \code{init} is analogous.
 
 %% The next three functions return a prefix of the list, or a suffix, or
@@ -4101,13 +4321,18 @@ def drop(n: Int): List[A] =
 
 def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
 \end{lstlisting}
+%----------
+
+%----------
 %% \code{(xs take n)} returns the first \code{n} elements of list
 %% \code{xs}, or the whole list, if its length is smaller than \code{n}.
 %% \code{(xs drop n)} returns all elements of \code{xs} except the
 %% \code{n} first ones. Finally, \code{(xs split n)} returns a pair
 %% consisting of the lists resulting from \code{xs take n} and
 %% \code{xs drop n}.
+%----------
 
+%----------
 %% The next function returns an element at a given index in a list.
 %% It is thus analogous to array subscripting. Indices start at 0.
 \begin{lstlisting}
@@ -4118,7 +4343,9 @@ def apply(n: Int): A = drop(n).head
 %% function. For instance, to pick the 3'rd element of a list \code{xs},
 %% one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
 %% expression expands into the first.
+%----------
 
+%----------
 %% With \code{take} and \code{drop}, we can extract sublists consisting
 %% of consecutive elements of the original list.  To extract the sublist
 %% $xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
@@ -4126,7 +4353,9 @@ def apply(n: Int): A = drop(n).head
 \begin{lstlisting}
 xs.drop(m).take(n - m)
 \end{lstlisting}
+%----------
 
+%----------
 %%\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
 %%Given two lists
 \begin{lstlisting}
@@ -4143,7 +4372,9 @@ def zip[B](that: List[B]): List[(a,b)] =
   if (this.isEmpty || that.isEmpty) Nil
   else (this.head, that.head) :: (this.tail zip that.tail)
 \end{lstlisting}
+%----------
 
+%----------
 %% \paragraph{Consing lists.}
 %% Like any infix operator, \code{::}
 %% is also implemented as a method of an object. In this case, the object
@@ -4153,12 +4384,17 @@ def zip[B](that: List[B]): List[(a,b)] =
 \begin{lstlisting}
     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
 \end{lstlisting}
+%----------
+
+%----------
 %% Note, however, that operands of a binary operation are in each case
 %% evaluated from left to right.  So, if \code{D} and \code{E} are
 %% expressions with possible side-effects, \code{D :: E} is translated to
 %% \lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
 %% order of operand evaluation.
+%----------
 
+%----------
 %% Another difference between operators ending in a `\code{:}' and other
 %% operators concerns their associativity.  Operators ending in
 %% `\code{:}' are right-associative, whereas other operators are
@@ -4166,6 +4402,9 @@ def zip[B](that: List[B]): List[(a,b)] =
 \begin{lstlisting}
     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
 \end{lstlisting}
+%----------
+
+%----------
 %%The definition of \code{::} as a method in
 %%class \code{List} is as follows:
 \begin{lstlisting}
@@ -4177,7 +4416,9 @@ def ::[B >: A](x: B): List[B] = new scala.::(x, this)
 %% is in this case a list of \code{B}'s. This
 %% is expressed by the type parameter \code{B} with lower bound \code{A}
 %% in the signature of \code{::}. 
+%----------
 
+%----------
 %% \paragraph{Concatenating lists}
 %% An operation similar to \code{::} is list concatenation, written
 %% `\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
@@ -4188,6 +4429,9 @@ def ::[B >: A](x: B): List[B] = new scala.::(x, this)
 xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
                   =   zs.:::(ys).:::(xs)
 \end{lstlisting}
+%----------
+
+%----------
 %%Here is the implementation of the \code{:::} method:
 \begin{lstlisting}
   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
@@ -4195,6 +4439,8 @@ xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
     case p :: ps => this.:::(ps).::(p)
   }
 \end{lstlisting}
+%----------
+
 
 %% \paragraph{Reversing lists} Another useful operation
 %% is list reversal. There is a method \code{reverse} in \code{List} to

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4593,30 +4593,24 @@ object List { ...
     if (from >= end) Nil else from :: range(from + 1, end)
 \end{lstlisting}
 
-%------------xpto
-
-For example, \code{List.range(2, n)}
-generates the list of all integers from 2 up to and excluding $n$.
-The function \code{isPrime} can now simply be defined as follows.
+Por exemplo, \code{List.range(2, n)} gera a lista de todos os inteiros de $2$ até, excluindo, $n$.
+A função \code{isPrime} pode agora ser defida como segue. 
 \begin{lstlisting}
 def isPrime(n: Int) =
   List.range(2, n) forall (x => n % x != 0)
 \end{lstlisting}
-We see that the mathematical definition of prime-ness has been
-translated directly into Scala code. 
+Vemos que a definição matemática de primalidade pode ser traduzida diretamente em código Scala.
 
-Exercise: Define \code{forall} and \code{exists} in terms of \code{filter}.
+Exercício: Defina \code{forall} e \code{exists} em termos de \code{filter}.
 
-
-\paragraph{Folding and Reducing Lists}
-Another common operation is to combine the elements of a list with
-some operator.  For instance:
+\paragraph{Desdobrando (folding) e Reduzindo Listas}
+Uma outra operação comum é combinar os elementos de uma lista com algum operador. Por exemplo:
 \begin{lstlisting}
 sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
 product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
 \end{lstlisting}
-Of course, we can implement both functions with a
-recursive scheme:
+
+De fato, podemos implementar ambas as funções por meio de um esquema recursivo:
 \begin{lstlisting}
 def sum(xs: List[Int]): Int = xs match {
   case Nil => 0
@@ -4627,20 +4621,20 @@ def product(xs: List[Int]): Int = xs match {
   case y :: ys => y * product(ys)
 }
 \end{lstlisting}
-But we can also use the generalization of this program scheme embodied
-in the \code{reduceLeft} method of class \code{List}.  This method
-inserts a given binary operator between adjacent elements of a given list.
-E.g.\ 
+
+Mas também podemos usar a generalização deste esquema de programa incorporado no método 
+\code{reduceLeft} da classe \code{List}. Este método insere um dado operador binário entre
+elementos adjacentes de uma dada lista. Ou seja, 
 \begin{lstlisting}
 List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
 \end{lstlisting}
-Using \code{reduceLeft}, we can make the common pattern
-in \code{sum} and \code{product} apparent:
+Usando \code{reduceLeft}, podemos tornar o padrão comum emas \code{sum} e \code{product}
+aparente:
 \begin{lstlisting}
 def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
 def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
 \end{lstlisting}
-Here is the implementation of \code{reduceLeft}.
+Aqui está a implementação de \code{reduceLeft}.
 \begin{lstlisting}
   def reduceLeft(op: (A, A) => A): A = this match {
     case Nil     => error("Nil.reduceLeft")
@@ -4652,19 +4646,20 @@ Here is the implementation of \code{reduceLeft}.
   }
 }
 \end{lstlisting}
-We see that the \code{reduceLeft} method is defined in terms of
-another generally useful method, \code{foldLeft}.  The latter takes as
-additional parameter an {\em accumulator} \code{z}, which is returned
-when \code{foldLeft} is applied on an empty list. That is,
+
+Vemos que o método \code{reduceLeft} é definido em termos de um outro método, geralmente útil, 
+\code{foldLeft}. O último pega como parâmetro adicional um {\em acumulador} \code{z}, que é 
+retornado quando \code{foldLeft} é aplicado sobre uma lista vazia. Ou seja, 
 \begin{lstlisting}
 (List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
 \end{lstlisting}
-The \code{sum} and \code{product} methods can be defined alternatively
-using \code{foldLeft}:
+Os métodos \code{sum} e \code{product} podem ser defidos alternativamente usando \code{foldLeft}:
 \begin{lstlisting}
 def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
 def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
 \end{lstlisting}
+
+%--------------xpto
 
 \paragraph{FoldRight and ReduceRight}
 Applications of \code{foldLeft} and \code{reduceLeft} expand to

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -49,12 +49,19 @@ O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto
 \item
 A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
 O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
+%----------
+%\item
+%Functions can be nested inside other functions. Nested functions can
+%access parameters and local variables of enclosing functions. For
+%instance, the name of the array \code{xs} is visible in functions
+%\code{swap} and \code{sort1}, and therefore need not be passed as a
+%parameter to them.
 \item
-Functions can be nested inside other functions. Nested functions can
-access parameters and local variables of enclosing functions. For
-instance, the name of the array \code{xs} is visible in functions
-\code{swap} and \code{sort1}, and therefore need not be passed as a
-parameter to them.
+Funções podem ser aninhadas umas dentro das outras. Funções aninhadas podem
+acessar parâmetros e variáveis locais de suas funções externas. Por
+exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e 
+\code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
+%----------
 \end{itemize}
 So far, Scala looks like a fairly conventional language with some
 syntactic peculiarities. In fact it is possible to write programs in a

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -138,6 +138,12 @@ maiores ou iguais ao pivô.}
 %% implementation returns a new sorted array and leaves the argument
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
+Tanto a implementação imperativa quanto a funcional tem mesma complexidade
+assintótica---$O(N;log(N))$ no caso médio e $O(Nˆ2)$ no pior caso. Mas onde
+a implementação imperativa opera localmente, modificando o vetor original,
+a implementação funcional retorna um novo vetor ordenado e deixa o vetor
+original inalterado. A implementação funcional, portanto, requer mais
+memória  transiente que a imperativa.
 %----------
 
 %----------
@@ -148,6 +154,13 @@ maiores ou iguais ao pivô.}
 %% standard Scala library, and which itself is implemented in
 %% Scala. Because arrays are instances of \verb@Seq@ all sequence
 %% methods are available for them.
+A implementação funcional faz parecer que Scala é uma linguagem
+especializada para operações funcionais sobre vetores. De fato, não é;
+todas as operações usadas no exemplo são simples métodos de biblioteca
+de uma classe {\em sequência} \code{Seq[T]} que é parte da biblioteca
+padrão Scala, e onde ela mesma é implementada em Scala. Como vetores são 
+instâncias de \verb@Seq@, todos os métodos de sequência estão disponíveis
+para eles.
 %----------
 
 %----------
@@ -157,6 +170,12 @@ maiores ou iguais ao pivô.}
 %% array consisting of all the elements of the original array for which the
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
+Em particular, há o método \code{filter} que recebe como argumento uma
+(\em função predicado}. Esta função predicado deve mapear elementos do 
+vetor para valores boleanos. O resultado de \code{filter} é um vetor
+consistindo de todos os elementos do vetor original para o qual a função
+predicado é verdadeira. O método \code{filter} de um objeto tipo
+\code{Array[T]} portanto tem a assinatura. 
 %----------
 
 
@@ -169,6 +188,10 @@ def filter(p: T => Boolean): Array[T]
 %% of type \code{t} and return a \code{Boolean}.  Functions like
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
+Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
+do tipo \code{t} e retornam um \code{Boolean}. Funções como \code{filter}
+que recebem uma outra função como argumento ou retornam uma função como
+resultado são chamadas {\em funções de alta ordem.}     
 %----------
 
 %----------
@@ -181,6 +204,10 @@ def filter(p: T => Boolean): Array[T]
 %% for binary infix operators which start with a letter. Hence, the
 %% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
 %% method call ~\lstinline@xs.filter(pivot >)@.
+Scala não faz distinção entre nomes de identificadores e nomes de operadores.
+um identificador pode ser ou uma sequência de letras ou digitos que começam
+com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
+
 %----------
 
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1,5 +1,5 @@
 \def\exercise{
-   \def\theresult{Exercise~\thesection.\arabic{result}}
+   \def\theresult{Exercício~\thesection.\arabic{result}}
    \refstepcounter{result}
    \trivlist\item[\hskip
    \labelsep{\bf \theresult}]}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1862,25 +1862,33 @@ O próximo exemplo mostra que funções que retornam funções também podem ser
 muito úteis.
 %----------
 
-%----------xpto
+%----------
 %% Consider again fixed point iterations. We started with the observation
 %% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
 %% Then we made the iteration converge by averaging successive values.
 %% This technique of {\em average damping} is so general that it
 %% can be wrapped in another function.
+Considere novamente iterações de ponto fixo. Começamos observando que 
+$\sqrt(x)$ é um ponto fixo da função \code{y => x / y}. Então fazemos
+a iteração convergir tirando a média de sucessivos valores. Essa técnica
+de {\em amortecimento da média} é tão genérica que pode ser denotada
+em outra função.
 \begin{lstlisting}
 def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
 \end{lstlisting}
 %% Using \code{averageDamp}, we can reformulate the square root function
 %% as follows.
+Usando \code{averageDamp}, podemos reformular a função da raiz quadrada
+como segue. 
 \begin{lstlisting}
 def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
 \end{lstlisting}
 %% This expresses the elements of the algorithm as clearly as possible.
-
+Isto expressa os elementos do algoritmo tão claramente quanto possível.
 \begin{exercise} 
 %%Write a function for cube roots using \code{fixedPoint} and 
 %% \code{averageDamp}.
+Escreva uma função para a raiz cúbica usando \code{fixedPoint} e \code{averageDamp}.  
 \end{exercise}
 %----------
 
@@ -1896,9 +1904,17 @@ def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
 %% reuse. The highest possible level of abstraction is not always the
 %% best, but it is important to know abstraction techniques, so that one
 %% can use abstractions where appropriate.
+Vimos no capítulo anterior que funções são abstrações essenciais porque 
+nos permitem introduzir métodos genéricos de computação como explícitos,
+elementos nomeados em nossa linguagem de programação. O presente capítulo
+mostrou que tais abstrações podem ser combinados por funções de alta ordem
+para criar mais abstrações. Como programadores, devemos procurar por oportunidades 
+de reuso e abstração. O mais alto nível possível de abstração nem sempre é 
+o melhor, mas é importante saber técnicas de abstração, de modo que possamos
+usá-las quando apropriado. 
 %----------
 
-%----------
+%----------xpto
 %% \section{Language Elements Seen So Far}
 
 %% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1914,9 +1914,9 @@ o melhor, mas é importante saber técnicas de abstração, de modo que possamos
 usá-las quando apropriado. 
 %----------
 
-%----------xpto
+%----------
 %% \section{Language Elements Seen So Far}
-
+\section{Elementos da Linguagem Vistos Até Aqui}
 %% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
 %% covered Scala's language elements to express expressions and types
 %% comprising of primitive data and functions.  The context-free syntax
@@ -1924,21 +1924,31 @@ usá-las quando apropriado.
 %% form, where `\code{|}' denotes alternatives, \code{[...]} denotes
 %% option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
 %% (0 or more occurrences).
-
+ Os capítulos ~\ref{chap:simple-funs} e \ref{chap:first-class-funs} trataram
+elementos da linguagem Scala para expressar tipos e expressões relacionados a
+tipos primitivos e funções. A sintaxe livre de contexto desses elementos da
+linguagem são dados abaixo em formato Backus-Naur estendido, onde `\code{|}'
+denotam alternativas, \code{[...]} denotam opção  (0 ou 1 ocorrência), e  
+\lstinline@{...}@ denotam (0 ou mais ocorrências). 
 %% \subsection*{Characters}
-
+\subsection*{Caracteres}
 %% Scala programs are sequences of (Unicode) characters. We distinguish the
 %% following character sets:
+Programas em Scala são sequência de caracteres (Unicode). Distinguimos os
+seguintes conjuntos de caracteres.
  \begin{itemize}
  \item
 %% whitespace, such as `\code{ }', tabulator, or newline characters,
+espaço em branco, tal como `\code{ }', tabulação, ou caracter de mudança de linha (newline), 
  \item
 %% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
+letras `\code{a}' a `\code{z}', `\code{A}' a `\code{Z}',    
  \item
 %% digits \code{`0'} to `\code{9}',
+digitos `\code{0}' a `\code{9}',   
  \item
 %% the delimiter characters
-
+caracteres delimitadores
  \begin{lstlisting}
  .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
  \end{lstlisting}
@@ -1946,21 +1956,27 @@ usá-las quando apropriado.
 %% operator characters, such as `\code{#}' `\code{+}',
 %% `\code{:}'. Essentially, these are printable characters which are
 %% in none of the character sets above.
+caracteres operadores, tal como `\code{#}', `\code{+}' e `\code{:}'.
+Essencialmente, há caracteres imprimíveis que não estão em nenhum dos 
+conjuntos de caracteres acima.   
  \end{itemize}
 
 %% \subsection*{Lexemes:}
+\subsection*{Lexemas:}
 
 \begin{lstlisting}
 ident    =  letter {letter | digit}
          |  operator { operator }
          |  ident '_' ident
-literal  =  $\mbox{``as in Java''}$
+literal  =  $\mbox{``como em Java''}$
 \end{lstlisting}
 
 %% Literals are as in Java. They define numbers, characters, strings, or
 %% boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
 %% \code{"he said \"hi!\""}, or \code{true}.
-
+Literais são como em Java. Eles definem números, caracteres, cadeias de caracteres, ou 
+valores boleanos. Exemplos de literais tais como \code{0}, \code{1.0e10}, \code{'x'},
+\code{"ele disse \"oi!\""}, ou \code{true}.
 %% Identifiers can be of two forms. They either start with a letter,
 %% which is followed by a (possibly empty) sequence of letters or
 %% symbols, or they start with an operator character, which is followed
@@ -1968,6 +1984,12 @@ literal  =  $\mbox{``as in Java''}$
 %% identifiers may contain underscore characters `\code{_}'. Furthermore,
 %% an underscore character may be followed by either sort of
 %% identifier. Hence, the following are all legal identifiers:
+Identificadores podem ter duas formas. Eles ou iniciam por uma letra, que é 
+seguida por uma sequência (possivelmente vazia) de letras ou símbolos, ou podem 
+iniciar com um caracter operador, seguido por uma sequência (possivelmente vazia) de
+caracteres operadores. Ambas as formas podem conter caracteres ``underscore'' `\code{_}'.
+Além disso, um caracter underscore pode ser seguido por quaisquer identificadores.
+Consequentemente, todos a seguir são identificadores legais:  
  \begin{lstlisting}
  x     Room10a     +     --     foldl_:     +_vector
  \end{lstlisting}
@@ -1977,9 +1999,14 @@ literal  =  $\mbox{``as in Java''}$
 %% \code{y}. If we want to express the sum of \code{x} with the
 %% negated value of \code{y}, we need to add at least one space,
 %% e.g. \code{x+ -y}.
+Segue desta regra que identificadores operadores subsequentes precisam ser
+separados por espaço em branco. Por exemplo, a entrada \code{x+-y} é entendida 
+como a sequência de três ``tokens'' \code{x}, \code{+-} e \code{y}. Se
+desejamos expressar a soma de \code{x} com o valor negativo de \code{y}, 
+precisamos acrescentar no mínimo um espaço, ou seja, \code{x+ -y}.      
 %----------
 
-%----------
+%----------xpto
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4053,62 +4053,56 @@ trait Function1[-A, +B] {
 }
 \end{lstlisting}
 
-%-------------xpto
+Ao lado de \code{Funciton1}, há também definições para funções de todas as outras 
+aridades (a implementação corrente implementa isto somente até um limite razoável).
+Ou seja, há uma definição para cada possível número de parâmetros de funções. Sintaxe para 
+tipos de funções em Scala ~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ é apenas uma abreviatura 
+para o tipo parametrizado  ~\lstinline@Function$n$[$T_1 \commadots T_n, S$]@~.
 
-Besides \code{Function1}, there are also definitions of for functions
-of all other arities (the current implementation implements this only
-up to a reasonable limit).  That is, there is one definition for each
-possible number of function parameters.  Scala's function type syntax
-~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
-for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
-T_n, S$]@~.
+Scala usa a mesma sintaxe $f(x)$ para aplicações de funções, não importa se 
+$f$ é um método ou um objeto função. Isto é possível pela seguinte convenção:
+Uma aplicação de função $f(x)$ onde $f$ é um objeto (em contraste com um método)
+é tomado para ser um atalho para \lstinline@$f$.apply($x$)@. Consequentemente, 
+o método \code{apply} de um tipo de função é inserido automaticamente onde isso 
+é necessário.
 
-Scala uses the same syntax $f(x)$ for function application, no matter
-whether $f$ is a method or a function object. This is made possible by
-the following convention: A function application $f(x)$ where $f$ is
-an object (as opposed to a method) is taken to be a shorthand for
-\lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
-function type is inserted automatically where this is necessary.
+Isso justifica o porquê definimos subscritos de vetores na Seção~\ref{sec:first-arrays} 
+através de um método \code{apply}. Para cada vetor \code{a}, a operação subscritora \code{a(i)} 
+é tomada como um atalho para \code{a.apply(i)}.
 
-That's also why we defined array subscripting in
-Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
-array \code{a}, the subscript operation \code{a(i)} is taken to be a
-shorthand for \code{a.apply(i)}.
+Funções são exemplos em que uma declaração de um parâmetro tipo 
+contra-variante é útil. Por exemplo, considere o seguinte código:
 
-Functions are an example where a contra-variant type parameter
-declaration is useful. For example, consider the following code:
 \begin{lstlisting}
 val f: (AnyRef => Int)  =  x => x.hashCode()
 val g: (String => Int)  =  f
 g("abc")
 \end{lstlisting}
-It's sound to bind the value \code{g} of type \code{String => Int} to
-\code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
-do with function of type \code{String => Int} is pass it a string in
-order to obtain an integer. Clearly, the same works for function
-\code{f}: If we pass it a string (or any other object), we obtain an
-integer.  This demonstrates that function subtyping is contra-variant
-in its argument type whereas it is covariant in its result type.
-In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
-$S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
 
-\example Consider the Scala code
+É correto ligar o valor \code{g} de tipo \code{String => Int} a \code{f}, que 
+é do tipo \code{AnyRef => Int}. De fato, tudo o que se pode fazer com uma 
+função do tipo \code{String => Int} é passar-lhe uma string para se obter um inteiro.
+Isso demonstra que subtipificar funções é contra-variante nos tipos dos argumentos, enquanto 
+é covariante no tipo do seu resultado. Em resumo, $S \Rightarrow T$ é um subtipo de $S' \Rightarrow T'$,
+desde que  $S'$ seja um subtipo de $S$ e $T$ seja um subtipo de $T'$.
+
+\example Considere o código Scala 
 \begin{lstlisting}
 val plus1: (Int => Int)  =  (x: Int) => x + 1
 plus1(2)
 \end{lstlisting}
-This is expanded into the following object code.
+Isso é expandido no seguinte código objeto.
 \begin{lstlisting}
 val plus1: Function1[Int, Int] = new Function1[Int, Int] {
   def apply(x: Int): Int = x + 1
 }
 plus1.apply(2)
 \end{lstlisting}
-Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
-represents an instance of an {\em anonymous class}. It combines the
-creation of a new \code{Function1} object with an implementation of 
-the \code{apply} method (which is abstract in \code{Function1}).
-Equivalently, but more verbosely, one could have used a local class:
+Aqui, a criação do objeto \lstinline@new Function1[Int, Int]{ ... }@
+representa uma instância de uma {\em classe anônima}. Combina a criação 
+de um novo objeto \code{Function1} com uma implementação do método \code{apply}
+(que é abstrato dentro de \code{Function1}). Equivalentemente, mas mais
+prolixo, podería-se usar uma classe local:
 \begin{lstlisting}
 val plus1: Function1[Int, Int] = {
   class Local extends Function1[Int, Int] {
@@ -4118,7 +4112,7 @@ val plus1: Function1[Int, Int] = {
 }
 plus1.apply(2)
 \end{lstlisting}
-%----------
+%----------xpto
 
 \chapter{Lists}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4279,14 +4279,11 @@ def last: A
 def init: List[A]
 \end{lstlisting}
 
-
-%----------xpto
-
-\code{xs.last} returns the last element of list \code{xs}, whereas
-\code{xs.init} returns all elements of \code{xs} except the last.
-Both functions have to traverse the entire list, and are thus less
-efficient than their \code{head} and \code{tail} analogues.
-Here is the implementation of \code{last}.
+\code{xs.last} retorna o último elemento da lista \code{xs}, enquanto 
+\code{xs.init} retorna todos os elementos de \code{xs} exceto o último.
+Ambas as funções tem de atravessar toda a lista, e são, portanto, menos 
+eficientes que seus análogos \code{head} e \code{tail}.
+Aqui está a implementação de \code{last}.
 \begin{lstlisting}
 def last: A = this match {
   case Nil      => error("Nil.last")
@@ -4294,10 +4291,9 @@ def last: A = this match {
   case x :: xs  => xs.last
 }
 \end{lstlisting}
-The implementation of \code{init} is analogous.
+A implementação de \code{init} é análoga.
 
-The next three functions return a prefix of the list, or a suffix, or
-both.
+As próximas três funções retornam um prefixo da lista, ou um sufixo, ou ambos.
 \begin{lstlisting}
 def take(n: Int): List[A] =
   if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
@@ -4307,104 +4303,100 @@ def drop(n: Int): List[A] =
 
 def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
 \end{lstlisting}
-\code{(xs take n)} returns the first \code{n} elements of list
-\code{xs}, or the whole list, if its length is smaller than \code{n}.
-\code{(xs drop n)} returns all elements of \code{xs} except the
-\code{n} first ones. Finally, \code{(xs split n)} returns a pair
-consisting of the lists resulting from \code{xs take n} and
-\code{xs drop n}.
+\code{(xs take n)} retorna os primeiros \code{n} elementos da lista 
+\code{xs}, ou a lista inteira, caso seu tamanho seja menor que \code{n}.
+\code{(xs drop n)} retorna todos os elementos de \code{xs} exceto os 
+\code{n} primeiros. Finalmente, \code{(xs split n)} retorna um par
+consistindo das listas resultantes de \code{xs take n} e \code{xs drop n}.
 
-The next function returns an element at a given index in a list.
-It is thus analogous to array subscripting. Indices start at 0.
+A próxima função retorna um elemento de uma dada posição na lista.
+É, portanto, análoga ao subscrito de vetor. Índices começam em 0. 
 \begin{lstlisting}
 def apply(n: Int): A = drop(n).head
 \end{lstlisting}
-The \code{apply} method has a special meaning in Scala. An object with
-an \code{apply} method can be applied to arguments as if it was a
-function. For instance, to pick the 3'rd element of a list \code{xs},
-one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
-expression expands into the first.
+O método \code{apply} tem um significado especial em Scala. Um objeto com 
+um método \code{apply} pode ser aplicado a argumentos como se fosse uma função.
+Por exemplo, para pegar o terceiro elemento de uma lista \code{xs}, pode-se 
+escrever ou \code{xs.apply(3)} ou \code{xs(3)}---a última expressão expande na primeira.
 
-With \code{take} and \code{drop}, we can extract sublists consisting
-of consecutive elements of the original list.  To extract the sublist
-$xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
+Com \code{take} e \code{drop}, podemos extrair sublistas consistindo de elementos 
+consecutivos da lista original. Para extrair a sublista $xs_m \commadots xs_{n-1}$ da
+lista \code{xs}, use:
 
 \begin{lstlisting}
 xs.drop(m).take(n - m)
 \end{lstlisting}
-%----------
 
-\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
-Given two lists
+\paragraph{Zipando listas} A próxima função combina duas listas em uma lista de pares.
+Dadas duas listas
 \begin{lstlisting}
 xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
 ys = List(y$_1$, ..., y$_n$)   ,
 \end{lstlisting}
-\code{xs zip ys} constructs the list
-\lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
-If the two lists have different lengths, the longer one of the two is
-truncated. Here is the definition of \code{zip} -- note that it is a
-polymorphic method.
+
+\code{xs zip ys} constrói a lista \lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
+Se as duas listas tiverem tamanhos diferentes, a maior das duas é truncada. Aqui está 
+a definição de \code{zip}---observe que trata-se de um método polimórfico. 
+
 \begin{lstlisting}
 def zip[B](that: List[B]): List[(a,b)] =
   if (this.isEmpty || that.isEmpty) Nil
   else (this.head, that.head) :: (this.tail zip that.tail)
 \end{lstlisting}
-%----------
 
-\paragraph{Consing lists.}
-Like any infix operator, \code{::}
-is also implemented as a method of an object. In this case, the object
-is the list that is extended. This is possible, because operators
-ending with a `\code{:}' character are treated specially in Scala.  
-All such operators are treated as methods of their right operand. E.g.,
+\paragraph{Consing listas.}
+
+Como qualquer outro operador infixo, \code{::} também é implementado como um 
+método de um objeto. Neste caso, o objeto é a lista que é estendida. Isto é 
+possível porque operadores terminados com um caracter `\code{:}' são tratados
+de modo especial em Scala. Todos esses operadores são tratados como métodos 
+de seus operandos direitos. Ou seja, 
 \begin{lstlisting}
     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
 \end{lstlisting}
-Note, however, that operands of a binary operation are in each case
-evaluated from left to right.  So, if \code{D} and \code{E} are
-expressions with possible side-effects, \code{D :: E} is translated to
-\lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
-order of operand evaluation.
+Observe, entretanto, que operandos de uma operação binária são em cada caso
+avaliados da esquerda para a direita. Logo, se \code{D} e \code{E} são 
+expressões com possíveis efeitos colaterais, \code{D :: E} é traduzido para 
+\lstinline@{val x = D; E.::(x)}@ de modo a manter a ordem esquerda-para-direita
+da avaliação dos operandos.
 
-Another difference between operators ending in a `\code{:}' and other
-operators concerns their associativity.  Operators ending in
-`\code{:}' are right-associative, whereas other operators are
-left-associative.  E.g.,
+Outra diferença entre operadores terminando com um `\code{:}' e outros 
+operadores é concernente à associatividade. Operadores terminados com 
+`\code{:}' são associativos à direita, enquanto outros operadores são 
+associativos à esquerda. Isto é,
 \begin{lstlisting}
     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
 \end{lstlisting}
-The definition of \code{::} as a method in
-class \code{List} is as follows:
+
+
+A definição de \code{::} como um método na classe \code{List} é a seguinte:
 \begin{lstlisting}
 def ::[B >: A](x: B): List[B] = new scala.::(x, this)
 \end{lstlisting}
-Note that \code{::} is defined for all elements \code{x} of type
-\code{B} and lists of type \code{List[A]} such that the type \code{B}
-of \code{x} is a supertype of the list's element type \code{A}. The result
-is in this case a list of \code{B}'s. This
-is expressed by the type parameter \code{B} with lower bound \code{A}
-in the signature of \code{::}. 
+Observe que \code{::} é definido para todos os elementos \code{x} de tipo
+\code{B} e listas do tipo \code{List[A]} tais como o tipo \code{B} de \code{x} é 
+um supertipo dos elementos da lista de tipo \code{A}. O resultado neste caso é 
+uma lista de \code{B}s. Isto é expresso pelo tipo parâmetro \code{B} com ligação 
+fraca \code{A} na assinatura de \code{::}.
 
-\paragraph{Concatenating lists}
-An operation similar to \code{::} is list concatenation, written
-`\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
-all elements of \code{xs}, followed by all elements of \code{ys}.
-Because it ends in a colon, \code{:::} is right-associative and is
-considered as a method of its right-hand operand. Therefore,
+
+\paragraph{Concatenando listas}
+Uma operação similar a \code{::} é a concatenação de listas, escrita `\code{:::}'.
+O resultado de \code{(xs ::: ys)} é uma lista consistindo de todos os elementos 
+de \code{xs}, seguidos para todos os elementos de \code{ys}. Como termina em dois pontos, 
+\code{:::} é associativo à direita e é considerado método de seu operando direito. Por isso,
 \begin{lstlisting}
 xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
                   =   zs.:::(ys).:::(xs)
 \end{lstlisting}
-Here is the implementation of the \code{:::} method:
+Aqui está a implementação do método \code{:::}:
 \begin{lstlisting}
   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
     case Nil => this
     case p :: ps => this.:::(ps).::(p)
   }
 \end{lstlisting}
-%----------
-
+%----------xpto
 
 \paragraph{Reversing lists} Another useful operation
 is list reversal. There is a method \code{reverse} in \code{List} to

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3642,13 +3642,12 @@ implementação anterior de, digamos, \code{contains} levará a um erro de compi
           ^ < $\mbox{\sl not a member of type}$ A.
 \end{lstlisting}
 
-%----------xpto
-One way to solve the problem is to restrict the legal types that can
-be substituted for type \code{A} to only those types that contain methods
-\code{<} and \code{>} of the correct types. There is a trait
-\code{Ordered[A]} in the standard class library Scala which represents
-values which are comparable (via \code{<} and \code{>}) to values of
-type \code{A}. This trait is defined as follows:
+Um modo de resolver o problema é restringir os tipos legais que podem ser
+substituídos pelo tipo \code{A} àqueles que contenham os métodos \code{<} e 
+\code{>} do tipos corretos. Na biblioteca de classes padrão do Scala há 
+o trait \code{Ordered[A]} que representa valores que podem ser comparados (via \code{<}
+e \code{>}) a valores do tipo \code{A}. Esse trait é definido como segue:
+
 \begin{lstlisting}
 /** A class for totally ordered data. */
 trait Ordered[A] {
@@ -3668,21 +3667,22 @@ trait Ordered[A] {
   def compareTo(that: A): Int = compare(that)
 }
 \end{lstlisting}
-We can enforce the comparability of a type by demanding
-that the type is a subtype of \code{Ordered}. This is done by giving an
-upper bound to the type parameter of \code{Set}:
+Podemos forçar a compatibilidade de um tipo demandando que esse tipo seja
+subtipo de \code{Ordered}. Isto é feito dando um limite superior ao 
+parâmetro tipo de \code{Set}:
+
 \begin{lstlisting}
 trait Set[A <: Ordered[A]] {
   def incl(x: A): Set[A]
   def contains(x: A): Boolean
 }
 \end{lstlisting}
-The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
-type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
-must be comparable to values of the same type.
+A declaração de parâmetro \code{A <: Ordered[A]} introduz \code{A} como um 
+parâmetro tipo que deve ser um subtipo de \code{Ordered[A]}, ou seja, seus 
+valores devem ser comparáveis a valores de mesmo tipo.
 
-With this restriction, we can now implement the rest of the generic
-set abstraction as we did in the case of \code{IntSet}s before.
+Com esta restrição, podemos agora implementar o restante da abstração genérica 
+de conjunto como fizemos anteriormente no caso de \code{IntSet}. 
 
 \begin{lstlisting}
 class EmptySet[A <: Ordered[A]] extends Set[A] {
@@ -3704,13 +3704,15 @@ class NonEmptySet[A <: Ordered[A]]
     else this
 }
 \end{lstlisting}
-Note that we have left out the type argument in the object creations
-\code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
-missing type arguments in constructor calls are inferred from value
-arguments and/or the expected result type.
 
-Here is an example that uses the generic set abstraction. Let's first
-create a subclass of \lstinline@Ordered@, like this:
+Observe que deixamos de fora o tipo argumento na criações dos objetos 
+\code{new NonEmptySet(...)}. Do mesmo modo que para métodos polimórficos, 
+tipos de argumentos faltantes nas chamadas de contrutores são inferidos a 
+partir do valor dos argumentos e/ou o tipo esperado do resultado. 
+
+Aqui está um exemplo que usa a abstração genérica de conjunto. Vamos primeiro 
+criar uma subclasse de \lstinline@Ordered@, como esta:
+
 \begin{lstlisting}
 case class Num(value: Double) extends Ordered[Num] {
   def compare(that: Num): Int =
@@ -3719,18 +3721,20 @@ case class Num(value: Double) extends Ordered[Num] {
     else 0
 }
 \end{lstlisting}
-Then:
+Então:
 \begin{lstlisting}
 val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
 s.contains(Num(1.5))
 \end{lstlisting}
-This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
-However, the following example is in error.
+Isto está OK, pois o tipo \code{Num} implementa o trait \code{Ordered[Num]}.
+Entretanto, o exemplo seguinte está errado. 
 \begin{lstlisting}
 val s = new EmptySet[java.io.File]
                     ^ java.io.File $\mbox{\sl does not conform to type}$
                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
 \end{lstlisting}
+%----------xpto
+
 One probem with type parameter bounds is that they require
 forethought: if we had not declared \lstinline@Num@ a subclass of
 \lstinline@Ordered@, we would not have been able to use \lstinline@Num@

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6408,9 +6408,8 @@ for (i <- Iterator.range(1, 100))
   println(i * i)
 \end{lstlisting}
 
-\paragraph{Zip} Method \code{zip} takes another iterator and
-returns an iterator consisting of pairs of corresponding elements
-returned by the two iterators.
+\paragraph{Zip} O método \code{zip} recebe um outro iterador e retorna um iterador que consiste
+de pares dos respectivos elementos retornados pelos dois iteradores.
 \begin{lstlisting}
   def zip[B](that: Iterator[B]) = new Iterator[(A, B)] {
     def hasNext = Iterator.this.hasNext && that.hasNext
@@ -6419,7 +6418,7 @@ returned by the two iterators.
 }
 \end{lstlisting}
 
-\section{Constructing Iterators}
+\section{Construindo Iteradores}
 
 Concrete iterators need to provide implementations for the two
 abstract methods \code{next} and \code{hasNext} in class

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2736,7 +2736,7 @@ abstract class Int extends AnyVal {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% Class \code{Int} can in principle also be implemented using just
 %% objects and classes, without reference to a built in type of
 %% integers. To see how, we consider a slightly simpler problem, namely
@@ -2744,7 +2744,10 @@ abstract class Int extends AnyVal {
 %% numbers. Here is the definition of an abstract class \code{Nat}:
 A classe \code{Int} pode em princípio também ser implementada usando
 apenas objetos e classes, sem referência a um tipo construído para 
-inteiros. Para ver como, consideraremos 
+inteiros. Para ver como, vamos considerar um problema um pouco mais 
+simples, especificamente como implementar um tipo \code{Nat} de 
+números naturais, ou seja, inteiros não negativo. Aqui está uma definição 
+para uma classe abstrata \code{Nat}:
 \begin{lstlisting}
 abstract class Nat {
   def isZero: Boolean
@@ -2761,10 +2764,15 @@ abstract class Nat {
 %% \code{Zero} and a subclass \code{Succ} (for successor). Each number
 %% \code{N} is represented as \code{N} applications of the \code{Succ}
 %% constructor to \code{Zero}:
+Para implementar as operações da classe \code{Nat}, nós definimos um
+sub-objeto \code{Zero} e uma subclasse \code{Succ} (para sucessor). Cada 
+número \code{N} é representado como \code{N} aplicações do construtor \code{Succ}
+até zero: 
  \[
  \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
  \]
 %% The implementation of the \code{Zero} object is straightforward:
+A implementação do objeto \code{Zero} é direta:
 \begin{lstlisting}
 object Zero extends Nat {
   def isZero: Boolean = true
@@ -2783,6 +2791,12 @@ object Zero extends Nat {
 %% with the given error message.
 
 %% Here is the implementation of the successor class:
+
+A implementação das funções  predecessor e subtração sobre \code{Zero} leva a 
+um \code{Erro}, que aborta o programa com uma mensagem de erro.
+
+Aqui está uma implementação da classe sucessor: 
+
 \begin{lstlisting}
 class Succ(x: Nat) extends Nat  {
   def isZero: Boolean = false
@@ -2799,7 +2813,11 @@ class Succ(x: Nat) extends Nat  {
 %% Note the implementation of method \code{successor}. To create the
 %% successor of a number, we need to pass the object itself as an
 %% argument to the \code{Succ} constructor.  The object itself is
-%% referenced by the reserved name \code{this}.   
+%% referenced by the reserved name \code{this}.
+Observe a implementação do método \code{successor}. Para criar o 
+sucessor de um número, precisamos passar o próprio objeto como um 
+argumento para o construtor \code{Succ}. O próprio objeto é referenciado
+por uma palavra reservada \code{this}.   
 %----------
 
 %----------
@@ -2807,17 +2825,26 @@ class Succ(x: Nat) extends Nat  {
 %% call with the constructor argument as receiver. The recursion will
 %% terminate once the receiver is the \code{Zero} object (which is
 %% guaranteed to happen eventually because of the way numbers are formed).
+As implementações de \code{+} e \code{-}, cada uma contém uma chamada 
+recursiva com o argumento do costrutor como destinatário. A recursão 
+terminará assim que o destinatário for o objeto \code{Zero} (o que é 
+garantido de acontecer eventualmente dado o modo com que os números são formados).
 %----------
 
 %----------
 %% \begin{exercise} Write an implementation \code{Integer} of integer numbers
 %% The implementation should support all operations of class \code{Nat}
 %% while adding two methods
+\begin{exercise}
+Escreva uma implementação \code{Integer} dos números inteiros. A implementação deve
+suportar todas as operações da classe \code{Nat} e mais dois métodos.
+
 \begin{lstlisting}
 def isPositive: Boolean
 def negate: Integer
 \end{lstlisting}
-%% The first method should return \code{true} if the number is positive. The second method should negate the number.
+%% The first method should return \code{true} if the number is positive.
+%% The second method should negate the number.
 %% Do not use any of Scala's standard numeric classes in your
 %% implementation. (Hint: There are two possible ways to implement
 %% \code{Integer}. One can either make use the existing implementation of
@@ -2826,19 +2853,29 @@ def negate: Integer
 %% \code{Integer}, using the three subclasses \code{Zero} for 0, 
 %% \code{Succ} for positive numbers and \code{Pred} for negative numbers.)
 %% \end{exercise}
+O primeiro método deve retornar \code{true} se o número for positivo. O segundo 
+método deve negativar o número. Não utilize qualquer classe numérica padrão Scala
+em sua implementação. (Dica: Há duas formas para implementar \code{Integer}. Uma
+pode ou fazer uso da implementação existente de \code{Nat}, representando um inteiro 
+como um número natural e um sinal. Ou pode-se generalizar a implementação dada de 
+\code{Nat} para \code{Integer}, usando as três subclasses \code{Zero} para 0, 
+\code{Succ} para números positivos e \code{Pred} para números negativos. 
+\end{exercise}
 %----------
 
 %----------
 %% \subsection*{Language Elements Introduced In This Chapter}
-
-%% \textbf{Types:}
+\subsection*{Elementos da Linguagem Introduzidos Neste Capítulo}
+ \textbf{Types:}
  \begin{lstlisting}
  Type         = ...  |  ident
  \end{lstlisting}
 
 %% Types can now be arbitrary identifiers which represent classes.
+Tipos podem agora ser identificadores arbitrários que representam classes.
 
 %% \textbf{Expressions:}
+\textbf{Expressões:}
  \begin{lstlisting}
  Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
  \end{lstlisting}
@@ -2846,10 +2883,14 @@ def negate: Integer
 %% An expression can now be an object creation, or
 %% a selection \code{E.m} of a member \code{m}
 %% from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
+Uma expressão pode agora ser uma criação de objeto, ou uma seleção
+\code{E.m} de um membro \code{m} a partir de uma expressão valorada objeto \code{E},
+ou pode ser a palavra reservada \code{this}.
 %----------
 
 %----------
 %% \textbf{Definitions and Declarations:}
+ \textbf{Definições e Declarações}
 \begin{lstlisting}
 Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
 ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
@@ -2865,6 +2906,7 @@ ValDcl       = 'val' ident ':' Type
 \end{lstlisting}
 
 %%A definition can now be a class, trait or object definition such as
+Uma definição pode agora ser uma definição de classe, trait ou objeto, tal como  
 \begin{lstlisting}
 class C(params) extends B { defs }
 trait T extends B { defs }
@@ -2872,14 +2914,21 @@ object O extends B { defs }
 \end{lstlisting}
 %% The definitions \code{defs} in a class, trait or object may be
 %% preceded by modifiers \code{private} or \code{override}.
+As definições \code{defs} na classe, trait ou objeto podem ser 
+precedidas pelos modificadores \code{private} ou \code{override}.
 
 %% Abstract classes and traits may also contain declarations. These
 %% introduce {\em deferred} functions or values with their types, but do
 %% not give an implementation. Deferred members have to be implemented in
 %% subclasses before objects of an abstract class or trait can be created.
+Classes abstratas e traits podem também conter declarações. Isso introduz
+funções {\em deferred} (postergadas) ou valores com seus tipos, mas não 
+dão uma implementação. Membros deferred devem ser implementados nas subclasses 
+antes que objetos de uma classe abstrata ou trait sejam criados. 
 %----------
 
 
+%----------xpto
 %% \chapter{Case Classes and Pattern Matching}
 
 %% Say, we want to write an interpreter for arithmetic expressions.  To

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -299,7 +299,7 @@ resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
 enquanto a função teste produzir verdadeiro.
 %----------
 
-%----------xpto
+%----------
 %% Scala's \lstinline@Unit@ type roughly corresponds to \lstinline@void@
 %% in Java; it is used whenever a function does not return an interesting
 %% result. In fact, because Scala is an expression-oriented language,
@@ -333,6 +333,10 @@ def swap(i: Int, j: Int) {
 %% \lstinline@return@ keyword is not necessary. Note that functions
 %% returning an explicit value always need an ``='' before their
 %% body or defining expression.  
+O valor resultante desta função é simplesmente sua última expressão---uma
+palavra chave \lstinline@return@ não é necessária. Observe que funções 
+que retornam um valor explícito sempre precisam de um ``='' antes de
+seus corpos ou expressões de definição.
 %----------
 
 \chapter{Programming with Actors and Messages}
@@ -346,6 +350,14 @@ def swap(i: Int, j: Int) {
 %% its incoming messages which is represented as a queue. It can work
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
+Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
+é particularmente afim. Considere a tarefa de implementar um serviço
+de leilão eletrônico. Podemos usar um modelo de processo no estilo 
+actor do Erlang para implementar os participantes do leilão. Actors são 
+objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
+para suas mensagens de entrada que é representada para uma fila. Pode
+trabalhar sequencialmente nas mensagens da sua caixa de correio, ou buscar 
+por mensagens que casam com algum padrão. 
 %----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
@@ -370,9 +382,13 @@ case object AuctionOver                      extends AuctionReply
 %% and that communicates with the seller and winning bidder to close the
 %% transaction. We present an overview of a simple implementation
 %% here.
+Para cada item negociado há um actor leiloeiro que publica a 
+informação sobre o item negociado, que aceita ofertas de clientes
+e que comunica com o vendedor e com o vencedor para fechar a transação.
+Apresentamos uma visão superficial de uma implementação aqui.
 %----------
 
-%----------
+%----------xpto
 %% As a first step, we define the messages that are exchanged during an
 %% auction. There are two abstract base classes
 %% \code{AuctionMessage} for messages from clients to the auction

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6716,28 +6716,24 @@ estão visíveis. Nós sabemos que o tipo genérico \lstinline@A@ do método
 o parâmetro implícito \lstinline@Monoid[Int]@ é o \lstinline@intMonoid@ e por isso este objeto será passado
 como parâmetro implícito.
 
-A discussão mostra também que 
-This discussion also shows that implicit parameters are inferred after
-any type arguments are inferred. 
+A discussão mostra também que parâmetros implícitos são inferidos depois que o tipo dos outros parâmetros
+são inferidos.
 
-\subsection*{Implicit Conversions}
+\subsection*{Conversões Implícitas}
 
-Say you have an expression $E$ of type $T$ which is expected to type
-$S$. $T$ does not conform to $S$ and is not convertible to $S$ by
-some other predefined conversion. Then the Scala compiler will try to
-apply as last resort an implicit conversion $I(E)$. Here, $I$ is an
-identifier denoting an implicit definition or parameter that is
-accessible without a prefix at the point of the conversion, that can
-be applied to arguments of type $T$ and whose result type conforms to the
-expected type $S$.
+Digamos que você tenha uma expressão $E$ do tipo $T$ onde é esperado um tipo
+$S$. $T$ não é um sub-tipo de $S$ e nem é conversível para $S$ por alguma conversão pré-definida. 
+Nesse caso, o compilador Scala irá tentar como um último recurso uma conversão implícita  $I(E)$. 
+Onde, $I$ é um identificador que denota a definição implícita ou parâmetro que seja acessível sem prefixo
+no ponto da conversão e que contenha uma função ao qual podem ser usados como argumentos valores do tipo  $T$ 
+e cujo resultado seja do tipo $S$ ou sub-tipo do mesmo.
 
-Implicit conversions can also be applied in member
-selections. Given a selection $E.x$ where $x$ is not a member of the
-type $E$, the Scala compiler will try to insert an implicit conversion
-$I(E).x$, so that $x$ is a member of $I(E)$.
+Conversões Implícitas podem também ser usadas na seleção de membros.
+Dada a chamada $E.x$ onde $x$ não é um membro do tipo $E$, o compilador
+Scala irá tentar inserir uma conversão implícita $I(E).x$, de maneira que $x$ seja um membro de $I(E)$.
 
-Here is an example of an implicit conversion function that converts
-integers into instances of class \lstinline@scala.Ordered@:
+Aqui está um exemplo de uma função de conversão implícita que converte 
+inteiros em instâncias da classe \lstinline@scala.Ordered@:
 \begin{lstlisting}
 implicit def int2ordered(x: Int): Ordered[Int] = new Ordered[Int] {
   def compare(y: Int): Int =

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3463,16 +3463,19 @@ abstract class Expr {
 \end{lstlisting}
 
 %----------xpto
-\begin{exercise} Consider the following definitions representing trees
-of integers.  These definitions can be seen as an alternative
-representation of \code{IntSet}:
+\begin{exercise} Considere as seguintes definições representando árvores de inteiros. 
+Estas definições podem ser vistas como uma representação alternativa para \code{IntSet}: 
+
 \begin{lstlisting}
 abstract class IntTree
 case object EmptyTree extends IntTree
 case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
 \end{lstlisting}
-Complete the following implementations of function \code{contains} and \code{insert} for 
-\code{IntTree}'s.
+
+
+Complete as implementações a seguir da função \code{contains} e \code{insert} para 
+\code{IntTree}.
+
 \begin{lstlisting}
 def contains(t: IntTree, v: Int): Boolean = t match { ...
   ...
@@ -3483,26 +3486,28 @@ def insert(t: IntTree, v: Int): IntTree = t match { ...
 \end{lstlisting}
 \end{exercise}
 
-\paragraph{Pattern Matching Anonymous Functions}
 
-So far, case-expressions always appeared in conjunction with a
-\verb@match@ operation. But it is also possible to use
-case-expressions by themselves. A block of case-expressions such as
+\paragraph{Funções Anônimas e Casamento de Padrões}
+
+Até aqui, expressões case sempre apareceram conjuntamente com uma operação 
+\verb@match@. Mas é também possível usar expressões case por elas mesmas. Um
+bloco de expressões case tal como  
+
+
 \begin{lstlisting}
 { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
 \end{lstlisting}
-is seen by itself as a function which matches its arguments
-against the patterns $P_1 \commadots P_n$, and produces the result of
-one of $E_1 \commadots E_n$. (If no pattern matches, the function
-would throw a \code{MatchError} exception instead).
-In other words, the expression above is seen as a shorthand for the anonymous function
+
+é visto como uma função que casa seus argumentos contra os padrões $P_1 \commadots P_n$,
+e produz o resultado de um dos $E_1 \commadots E_n$. (Se nenhum padrão casar, a função 
+produzirá uma  exceção \code{MatchError}. 
+Em outras palavras, a expressão acima é vista como um atalho para a função anônima
 \begin{lstlisting}
 (x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
 \end{lstlisting}
-where \code{x} is a fresh variable which is not used 
-otherwise in the expression.
+onde \code{x} é uma variável nova que não é usada a não ser dentro da expressão.
 
-\chapter{Generic Types and Methods}
+\chapter{Tipos Genéricos e Métodos}
 
 Classes in Scala can have type parameters. We demonstrate the use of
 type parameters with functional stacks as an example. Say, we want to

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -7344,39 +7344,33 @@ Também extendemos o significado da substituição para ambientes que serão def
   }
   val emptySubst = new Subst { def lookup(t: Tyvar): Type = t }
 \end{lstlisting}
-Representamos substituições como funções
-We represent substitutions as functions, of type \code{Type =>
-Type}. This is achieved by making class \code{Subst} inherit from the
-unary function type \code{Function1[Type, Type]}\footnote{
-The class inherits the function type as a mixin rather than as a direct 
-superclass. This is because in the current Scala implementation, the
-\code{Function1} type is a Java interface, which cannot be used as a direct
-superclass of some other class.}.
-To be an instance
-of this type, a substitution \code{s} has to implement an \code{apply}
-method that takes a \code{Type} as argument and yields another
-\code{Type} as result. A function application \code{s(t)} is then
-interpreted as \code{s.apply(t)}.
+Representamos substituições como funções do tipo \code{Type =>
+Type}. Isto pode ser obtido fazendo com que a classe  \code{Subst} herde da tipo função unária  
+\code{Function1[Type, Type]}\footnote{
+A classe herda do tipo função como um mixin, ao invés de uma super-classe direta.
+Isto ocorre porque na implementação atual de Scala, o tipo \code{Function1} é uma interface Java que
+não pode ser uma super-classe de uma outra classe.}.
+Para ser uma instância de \code{Subst}, uma substituição \code{s} tem que implementar o método \code{apply}
+que recebe como argumento um \code{Type} e retorna um outro 
+\code{Type} como resultado. A função aplicação \code{s(t)} é interpretada como \code{s.apply(t)}.
 
-The \code{lookup} method is abstract in class \code{Subst}.  There are
-two concrete forms of substitutions which differ in how they
-implement this method.  One form is defined by the \code{emptySubst} value,
-the other is defined by the \code{extend} method in class
-\code{Subst}.
+O método \code{lookup} é abstrato na classe \code{Subst}.  Existem duas formas concretas de substituição
+que diferem em como elas implementam este método. Uma forma é definida pelo valor \code{emptySubst} e a outra
+é definida pelo método \code{extend} na classe \code{Subst}.
 
-The next data type describes type schemes, which consist of a type and
-a list of names of type variables which appear universally quantified
-in the type scheme. 
-For instance, the type scheme $\forall a\forall b.a \!\arrow\! b$ would be represented in the type checker as:
+O próximo tipo de dado descreve esquemas de tipos, que consistem de um tipo
+e uma lista de nomes de tipos variáveis que aparecem universalmente quantificados
+no esquema de tipos.
+Por exemplo o esquema de tipos $\forall a\forall b.a \!\arrow\! b$ seria representado no checador de tipos como:
 \begin{lstlisting}
 TypeScheme(List(Tyvar("a"), Tyvar("b")), Arrow(Tyvar("a"), Tyvar("b"))) .
 \end{lstlisting}
-The class definition of type schemes does not carry an extends
-clause; this means that type schemes extend directly class
-\code{AnyRef}.  Even though there is only one possible way to
-construct a type scheme, a case class representation was chosen
-since it offers convenient ways to decompose an instance of this type into its
-parts.
+A deinição da classe esquema de tipos nã contém uma cláusula extends;
+isso quer dizer que um esquema de tipos herda diretamente da classe
+\code{AnyRef}.  Embora exista apenas uma única maneira de construir um
+esquema de tipos, uma representação usando classe case foi escolhida, pois
+oferece formas convenientes de acessar as partes de uma instância deste tipo.
+
 \begin{lstlisting}
   case class TypeScheme(tyvars: List[Tyvar], tpe: Type) {
     def newInstance: Type = {
@@ -7384,6 +7378,7 @@ parts.
     }
   }
 \end{lstlisting}
+
 Type scheme objects come with a method \code{newInstance}, which
 returns the type contained in the scheme after all universally type
 variables have been renamed to fresh variables. The implementation of
@@ -7562,9 +7557,9 @@ object predefined {
   )
 }
 \end{lstlisting}
-Here's an example how the type inferencer can be used.
-Let's define a function \code{showType} which returns the type of
-a given term computed in the predefined environment
+Aqui está um exemplo de como o sistema de inferência de tipos pode ser
+usado. Vamos definir a função \code{showType} que retorna os tipos de um dado
+termo computado em um dado ambiente
 \code{Predefined.env}:
 \begin{lstlisting}
 object testInfer {
@@ -7577,11 +7572,11 @@ object testInfer {
         "\n reason: " + msg
     }
 \end{lstlisting}
-Then the application
+Então a aplicação
 \begin{lstlisting}
 > testInfer.showType(Lam("x", App(App(Var("cons"), Var("x")), Var("nil"))))
 \end{lstlisting}
-would give the response
+retornará a resposta
 \begin{lstlisting}
 > (a6->List[a6])
 \end{lstlisting}
@@ -7688,7 +7683,7 @@ trait MiniMLParsers extends CharParsers {
     } yield t
 }
 \end{lstlisting}
-Here are some sample MiniML programs and the output the type inferencer gives for each of them:
+Aqui estão alguns exemplos de programas MiniML e a saída que o sistema de inferência de tipos retorna para cada um deles:
 \begin{lstlisting}
 > java testInfer
 | "\x.\f.f(f x);"
@@ -7727,7 +7722,7 @@ que o marcador ``;'' não seja necessária para indicar o fim de uma entrada.
 \end{exercise}
 }
 
-\begin{exercise}\label{execcise:hm-extend} Extenda o \comment{parser} Mini-ML e a inferência de tipos
+\begin{exercise}\label{execcise:hm-extend} Extenda o \comment{parser} Mini-ML e o sistema de inferência de tipos
 com uma construção \code{letrec} que permita a definição recursiva de funções. 
 Sintaxe:
 \begin{lstlisting}
@@ -7753,9 +7748,9 @@ podem ser implementados em Scala.
 \section{Sinais e Monitores}
 
 \example
-The {\em monitor} provides the basic means for mutual exclusion
-of processes in Scala. Every instance of class \code{AnyRef} can be
-used as a monitor by calling one or more of the methods below.
+Um {\em monitor} provê mecanismos básicos para processos mutuamente exclusivos
+em Scala. Toda instância de \code{AnyRef} pode ser usada como um monitor através
+da chamada de um ou mais dos métodos apresentados a seguir.
 \begin{lstlisting}
   def synchronized[A] (e: => A): A
   def wait()

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4702,8 +4702,8 @@ Através de operadores associativos e comutativos, \code{/:} e \code{:\\} são e
 \begin{exercise} Considere o problema de escrever uma função \code{flatten}, que recebe 
 uma lista de listas como argumentos. O resultado de \code{flatten} deve ser a concatenação 
 de todos os elementos listas em uma única lista. Aqui está uma implementação deste método 
-em termos de \code{:\\}.
-\end{exercise}
+em termos de 
+\code{:\\}.
 \begin{lstlisting}
 def flatten[A](xs: List[List[A]]): List[A] =
   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
@@ -4736,19 +4736,19 @@ class List[+A] { ...
 Agora falta preencher \code{z?} e \code{op?}. Vamos tentar deduzir a partir dos exemplos.
 \begin{lstlisting}
   Nil
-= Nil.reverse                 // pela especificação 
+= Nil.reverse                 // pela especifica\c{c}\~{a}o 
 = (z /: Nil)(op)              // pelo template para reverse
-= (Nil foldLeft z)(op)        // pela definição de /:
-= z                           // pela definição de foldLeft
+= (Nil foldLeft z)(op)        // pela defini\c{c}\~{a}o de /:
+= z                           // pela defini\c{c}\~{a}o de foldLeft
 \end{lstlisting}
 Consequentemente, \code{z?} deve ser \code{Nil}. Para deduzir o segundo operando, vamos estudar
 o inverso de uma lista de tamanho um.
 \begin{lstlisting}
   List(x)
-= List(x).reverse             // pela especificação 
+= List(x).reverse             // pela especifica\c{c}\~{a}o 
 = (Nil /: List(x))(op)        // pelo template para reverse, com  z = Nil
-= (List(x) foldLeft Nil)(op)  // pela definição de /:
-= op(Nil, x)                  // pela definição de foldLeft
+= (List(x) foldLeft Nil)(op)  // pela defini\c{c}\~{a}o de /:
+= op(Nil, x)                  // pela defini\c{c}\~{a}o de foldLeft
 \end{lstlisting}
 Consequentemente, \code{op(Nil, x)} é igual a \code{List(x)}, o que é o mesmo que \code{x :: Nil}.
 Isto sugere pegar como \code{op} o operador \code{::} com seus operandos trocados. Consequentemente,

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3819,28 +3819,28 @@ racional é guardado no vetor. Isso também está OK, pois o tipo \code{Rational
 um subtipo do tipo do elemento \code{Any} do vetor \code{y}. Acabamos por 
 guardar um número racional em um vetor de strings, o que claramente viola
 a integridade do tipo.
-%----------xpto
 
-Java solves this problem by introducing a run-time check in the third
-line which tests whether the stored element is compatible with the
-element type with which the array was created. We have seen in the
-example that this element type is not necessarily the static element
-type of the array being updated. If the test fails, an
-\code{ArrayStoreException} is raised.
+Java resolve este problema introduzindo checagem em tempo de execução na 
+terceira linha que testa se o elemento guardado é compatível com o tipo
+de elemento para o qual o vetor foi criado. Vimos no exemplo que este 
+tipo de elemento não é necessariamente o tipo estático de elemento do 
+vetor que está sendo atualizado. Se o teste falhar, é dado um 
+\code{ArrayStoreException}.
 
-Scala solves this problem instead statically, by disallowing the
-second line at compile-time, because arrays in Scala have non-variant
-subtyping. This raises the question how a Scala compiler verifies that
-variance annotations are correct. If we had simply declared arrays
-co-variant, how would the potential problem have been detected?
+Ao invés disto, Scala resolve este problema estáticamente, rejeitando a
+segunda linha em tempo de compilação, porque vetores em Scala tem 
+subtipificação não variante. Isso nos leva a questão de como o 
+compilador Scala verifica que anotações de variância são corretas.
+Se simplesmente declararmos vetores como covariantes, como detectar
+este potencial problema?
 
-Scala uses a conservative approximation to verify soundness of
-variance annotations.  A covariant type parameter of a class may only
-appear in co-variant positions inside the class.  Among the co-variant
-positions are the types of values in the class, the result types of
-methods in the class, and type arguments to other covariant types. Not
-co-variant are types of formal method parameters. Hence, the following
-class definition would have been rejected
+Scala usa uma aproximação conservadora para verificar a integridade de
+anotações de variância. Um parâmetro tipo covariante de uma classe pode 
+somente aparecer em posições covariantes dentro da classe. Apesar de
+posições covariantes serem tipos de valores na classe, o tipo resultante
+dos métodos na classe, e tipos argumentos para outros tipos covariantes. 
+Não covariantes são tipos de parâmetros formais de métodos. Logo, a seguinte 
+definição de classe seria rejeitada
 \begin{lstlisting}
 class Array[+A] {
   def apply(index: Int): A
@@ -3849,6 +3849,8 @@ class Array[+A] {
                                  $\mbox{\sl appears in contravariant position.}$
 }
 \end{lstlisting}
+%----------xpto
+
 So far, so good. Intuitively, the compiler was correct in rejecting
 the \code{update} procedure in a co-variant class because \code{update}
 potentially changes state, and therefore undermines the soundness of

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6614,23 +6614,22 @@ Todas as regras válidas para definição de valores se aplicam também para val
 
 \chapter{Parâmetros Implícitos e Conversões}\label{sec:implicits}
 
-Implicit parameters and conversions are powerful tools for
-custimizing existing libraries and for creating high-level
-abstractions. As an example, let's start with an abstract class of
-semi-groups that support an unspecified \lstinline@add@ operation.
+Parâmetros implícitos e conversões são ferramentas poderosas para personalizar bibliotecas
+existentes e para criar abstrações de alto-nível.
+Como exemplo, vamos começar com uma classe abstrata \lstinline@SemiGroup@ que contém uma operação não especificada chamada \lstinline@add@.
 \begin{lstlisting}
 abstract class SemiGroup[A] {
   def add(x: A, y: A): A
 }
 \end{lstlisting}
-Here's a subclass \lstinline@Monoid@ of \lstinline@SemiGroup@ which adds a
-\lstinline@unit@ element.
+Aqui está a sub-classe abstrata \lstinline@Monoid@ que herda de  \lstinline@SemiGroup@ e inclui um novo elemento
+\lstinline@unit@.
 \begin{lstlisting}
 abstract class Monoid[A] extends SemiGroup[A] {
   def unit: A
 }
 \end{lstlisting}
-Here are two implementations of monoids:
+Aqui estão duas implementações de \lstinline@Monoid@:
 \begin{lstlisting}
 object stringMonoid extends Monoid[String] {
   def add(x: String, y: String): String = x.concat(y)
@@ -6642,23 +6641,21 @@ object intMonoid extends Monoid[Int] {
   def unit: Int = 0
 }
 \end{lstlisting}
-A \lstinline@sum@ method, which works over arbitrary
-monoids, can be written in plain Scala as follows.
+O método \lstinline@sum@, que funciona com monoids arbitrários pode ser escrito em Scala da seguinte forma:
 \begin{lstlisting}
 def sum[A](xs: List[A])(m: Monoid[A]): A =
   if (xs.isEmpty) m.unit
   else m.add(xs.head, sum(m)(xs.tail)
 \end{lstlisting}
-This \lstinline@sum@ method can be called as follows:
+O método \lstinline@sum@ pode ser chamado da seguinte forma:
 \begin{lstlisting}
 sum(List("a", "bc", "def"))(stringMonoid)
 sum(List(1, 2, 3))(intMonoid)
 \end{lstlisting}
-All this works, but it is not very nice. The problem is that the
-monoid implementations have to be passed into all code that uses them.
-We would sometimes wish that the system could figure out the correct
-arguments automatically, similar to what is done when type arguments
-are inferred. This is what implicit parameters provide.
+Embora tudo isso funcione, o código não fica muito limpo. O problema
+é que as implementações de monoid tem que ser passada para todo o código que as usa.
+Nós gostaríamos que o sistema conseguisse descobrir os argumentos de forma correta e automática, semelhante
+ao que é feito quando o tipo de parâmetros é inferido. Isto é o que os parâmetros implícitos permite.
 
 \subsection*{Implicit Parameters: The Basics}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5047,10 +5047,7 @@ Para mostrar que a propriedade \code{P(t)} vale para todas as árvores de um cer
       mostre que  \code{P(s$_1$) $\wedge$ ... $\wedge$ P(s$_n$) => P(t)}. 
 \end{itemize} 
 
-%------------xpto
-
-\example Recall our definition of \code{IntSet} with 
-operations \code{contains} and \code{incl}:
+\example Lembre de nossa definição de \code{IntSet} com operações \code{contains} e \code{incl}:
 
 \begin{lstlisting}
 abstract class IntSet {
@@ -5075,33 +5072,31 @@ case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
     else this
 }
 \end{lstlisting}
-(With \code{case} added, so that we can use factory methods instead of \code{new}).
+(Com \code{case} adicionado, podemos usar métodos de fábrica ao invés de \code{new}).
 
-What does it mean to prove the correctness of this implementation?
+O que significa provar a correção desta implementação?
 \es
-\bsh{Laws of IntSet}
+\bsh{Leis do IntSet}
 
-One way to state and prove the correctness of an implementation is
-to prove laws that hold for it.
+Um modo de declarar e provar a correção de uma implementação é provar leis que valem para ela.
 
-In the case of \code{IntSet}, three such laws would be:
 
-For all sets \code{s}, elements \code{x}, \code{y}:
+No caso de \code{IntSet}, três dessas leis serão:
 
+
+Para todos os conjuntos \code{s}, elementos \code{x}, \code{y}:
 \begin{lstlisting}
 Empty contains x          \= =  false
 (s incl x) contains x     \> =  true
 (s incl x) contains y     \> =  s contains y         if x $\neq$ y
 \end{lstlisting}
 
-(In fact, one can show that these laws characterize the desired data
-type completely).
-
-How can we establish that these laws hold?
+(De fato, podemos mostrar que estas leis caracterizam o tipo de dado desejado completamente).
+Como podemos estabelecer que essas leis valem?
 
 \emph{Proposition 1}: \code{Empty contains x =  false}.
 
-\emph{Proof}: By the definition of \code{contains} in \code{Empty}.
+\emph{Proof}: Pela definição de \code{contains} in \code{Empty}.
 \es\bs
 \emph{Proposition 2}: \code{(xs incl x) contains x = true}
 
@@ -5143,12 +5138,11 @@ How can we establish that these laws hold?
 \emph{Proposition 3}: If \code{x $\neq$ y} then
 \code{xs incl y contains x  =  xs contains x}.
 
-\emph{Proof:} See blackboard.
+\emph{Proof:} Veja o blackboard.
 \es
 \bsh{Exercise}
 
-Say we add a \code{union} function to \code{IntSet}:
-
+Digamos que adicionamos a função \code{union} à  \code{IntSet}:
 \begin{lstlisting}
 class IntSet { ...
   def union(other: IntSet): IntSet
@@ -5160,18 +5154,17 @@ class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
   def union(other: IntSet): IntSet = l union r union other incl x
 }
 \end{lstlisting}
+A correção de \code{union} pode ser incluída com a seguinte lei:
 
-The correctness of \code{union} can be subsumed with the following
-law:
-
-\emph{Proposition 4}: 
+\emph{Proposição 4}: 
 \code{(xs union ys) contains x  =  xs contains x || ys contains x}.
-Is that true ? What hypothesis is missing ? Show a counterexample.
 
-Show Proposition 4 using structural induction on \code{xs}.
+Será verdadeiro? Que hipótese está faltando? Mostre um contra-exemplo.
+
+Mostre a Proposição 4 usando indução estrutural sobre \code{xs}.
 \es
 \comment{
-
+%----------------xpto
 \emph{Proof:} By induction on \code{xs}.
 
 \Case{\code{Empty}}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3154,10 +3154,15 @@ bem comum, Scala tem um modo de automatizá-lo para classes case.
 
 %----------xpto
 %% \section{Case Classes and Case Objects}
+\section{Classes Case e Objetos Case}
 
 %% {\em Case classes} and {\em case objects} are defined like a normal
 %% classes or objects, except that the definition is prefixed with the modifier
 %% \code{case}.  For instance, the definitions
+{\em Classes Case} e {\em objetos case} são definidos como classes e objetos 
+normais, exceto que a definição é prefixada com um modificador \code{case}. 
+Por exemplo, as definições:
+
 \begin{lstlisting}
 abstract class Expr
 case class Number(n: Int) extends Expr
@@ -3167,7 +3172,14 @@ case class Sum(e1: Expr, e2: Expr) extends Expr
 %% The \code{case} modifier in front of a class or object 
 %% definition has the following effects.
 %% \begin{enumerate}
-%% \item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
+%% \item Case classes implicitly come with a constructor function, with the same name as the class. 
+%%In our example, the two functions
+intruduzem \code{Number} e \code{Sum} como classes case.
+O modificador \code{case} em frente a uma definição de classe ou objeto tem 
+os seguintes efeitos.
+\begin{enumerate}
+\item Classes case implicitamente vem com uma função construtora, com o mesmo nome da classe.
+No nosso exemplo, as duas funções
 \begin{lstlisting}
 def Number(n: Int) = new Number(n)
 def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
@@ -3241,7 +3253,7 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% \item 
 %% Case classes allow the constructions of {\em patterns} which refer to
 %% the case class constructor.
-%% \end{enumerate}
+ \end{enumerate}
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -554,7 +554,14 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par�
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussão precedente 
+A discussão precedente deu uma idéia de programação distribuída em Scala. Isso
+dá a sensação que Scala tem um rico conjunto de construtores que suportam
+processos actor, envio e recebimento de mensagens, programação com timeouts etc.
+De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
+oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
+ele mesma implementada em Scala, baseado no modelo thread subjacente à linguagem 
+hospedeira (Java ou .NET). A implementação de todas as características da 
+classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
 %----------
 
 %----------
@@ -572,6 +579,7 @@ A discussão precedente
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
+
 %----------
 
 %----------

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3395,24 +3395,26 @@ Um construtor padrão $C(p_1 \commadots p_n)$ casa com todos os valores que são
 do tipo \code{C} (ou um subtipo dele) e que foram construídos com argumentos \code{C}
 casando com padrões $p_1 \commadots p_n$.
 
+\item 
+Uma variável padrão \code{x} casa com qualquer valor e liga o nome da variável àquele valor.
 
 \item 
-Uma variável padrão \code{x} casa qualquer valor e liga o nome da variável àquele valor.
+O caracter padrão `\code{_}' casa com qualquer valor, mas não liga um nome àquele valor.
+
+\item 
+Um padrão constante \code{C} casa um valor que é igual (em termos de \code{==}) para \code{C}.
+
+\end{itemize}
+
+
+
+A expressão de casamento de padrões reescreve no lado direito do primeiro case cujo
+padrão casa com o valor seletor. Referências as variáveis padrão são substituídas pelos 
+correspondentes argumentos construtores. Se nenhum dos padrões casar, a expressão 
+de casamento de padrões é abortada com um erro \code{MatchError}.  
 
 
 %----------xpto
-\item 
-The wildcard pattern `\code{_}' matches any value but does not bind a name to that value. 
-\item A constant pattern \code{C} matches a value which is
-equal (in terms of \code{==}) to \code{C}.
-\end{itemize}
-The pattern matching expression rewrites to the right-hand-side of the
-first case whose pattern matches the selector value. References to
-pattern variables are replaced by corresponding constructor arguments.
-If none of the patterns matches, the pattern matching expression is
-aborted with a \code{MatchError} exception.
-
-%----------
 \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
 \begin{lstlisting}
      eval(Sum(Number(1), Number(2)))

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3796,32 +3796,30 @@ class Array[A] {
 }
 \end{lstlisting}
 
-%----------xpto
+A classe acima define o modo que vetores em Scala são vistos a partir de programas 
+Scala do usuário. O compilador Scala mapeará esta abstração aos vetores subjacentes
+do sistema hospedeiro sempre que possível.
 
-The class above defines the way Scala arrays are seen from Scala user
-programs. The Scala compiler will map this abstraction to the
-underlying arrays of the host system in most cases where this
-possible.
+Em Java, vetores são, de fato, covariantes; ou seja, para os tipos referenciados \code{T} e 
+\code{S}, se \code{T} é um subtipo de \code{S}, então \code{Array[T]} é um subtipo de 
+\code{Array[S]}. Isso pode parecer natural, mas leva a problemas de segurança que requerem
+checagem especial em tempo de execução. Aqui está um exemplo: 
 
-In Java, arrays are indeed covariant; that is, for reference types
-\code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
-\code{Array[T]} is a subtype of \code{Array[S]}. This might seem
-natural but leads to safety problems that require special runtime
-checks. Here is an example:
 \begin{lstlisting}
 val x = new Array[String](1)
 val y: Array[Any] = x
-y(0) = new Rational(1, 2)  // this is syntactic sugar for
+y(0) = new Rational(1, 2)  // isto é syntactic sugar para
                            // y.update(0, new Rational(1, 2))
 \end{lstlisting}
-In the first line, a new array of strings is created. In the second
-line, this array is bound to a variable \code{y}, of type
-\code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
-\code{Array[String]} is a subtype of \code{Array[Any]}. Finally, in
-the last line a rational number is stored in the array. This is also
-OK, since type \code{Rational} is a subtype of the element type
-\code{Any} of the array \code{y}. We thus end up storing a rational
-number in an array of strings, which clearly violates type soundness. 
+Na primeira linha, um novo vetor de strings é criado. Na segunda linha, 
+este vetor é ligado a uma variável \code{y}, de tipo \code{Array[Any]}. 
+Assumindo vetores como covariantes, isto está OK, pois \code{Array[String]}
+é um subtipo de \code{Array[Any]}. Finalmente, na última linha, um número 
+racional é guardado no vetor. Isso também está OK, pois o tipo \code{Rational} é 
+um subtipo do tipo do elemento \code{Any} do vetor \code{y}. Acabamos por 
+guardar um número racional em um vetor de strings, o que claramente viola
+a integridade do tipo.
+%----------xpto
 
 Java solves this problem by introducing a run-time check in the third
 line which tests whether the stored element is compatible with the

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4226,34 +4226,28 @@ def insert(x: Int, xs: List[Int]): List[Int] = xs match {
 }
 \end{lstlisting}
 
-%----------xpto
-
-
-\section{Definition of class List I: First Order Methods}
+\section{Definição da classe List I: Métodos de Primeira Ordem}
 \label{sec:list-first-order}
 
-Lists are not built in in Scala; they are defined by an abstract class
-\code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
-In the following we present a tour through class \code{List}.
+Listas não são construídas em Scala; elas são definidas por uma classe abstrata
+\code{List}, que vem com duas subclasses para \code{::} e \code{Nil}. A seguir
+apresentaremos um tour através da classe \code{List}.
+
 \begin{lstlisting}
 package scala
 abstract class List[+A] {
 \end{lstlisting}
-\code{List} is an abstract class, so one cannot define elements by
-calling the empty \code{List} constructor (e.g. by
-\code{new List}).  The class has a type parameter \code{a}. It is
-co-variant in this parameter, which means that
-\code{List[S] <: List[T]} for all types \code{S} and \code{T} such that
-\code{S <: T}.  The class is situated in the package
-\code{scala}. This is a package containing the most important standard
-classes of Scala.
- \code{List} defines a number of methods, which are
-explained in the following.
 
-\paragraph{Decomposing lists}
-First, there are the three basic methods \code{isEmpty},
-\code{head}, \code{tail}. Their implementation in terms of pattern
-matching is straightforward:
+\code{List} é uma classe abstrata, logo não pode-se definir elementos 
+chamando o construtor de \code{List} vazia (ou seja, através de \code{new List}).
+A classe tem uma tipo parâmetro \code{a}. É covariante nesse parâmetro, o que 
+significa que \code{List[S] <: List[T]} para todos os tipos \code{S} e \code{T} tal que 
+\code{S <: T}. A classe está no pacote \code{scala}. Este pacote contém as mais 
+importantes classes Scala. \code{List} define um número de métodos, que são explicados a seguir.
+
+\paragraph{Decompondo listas}
+Primeiro, há os três métodos básicos \code{isEmpty}, \code{head}, \code{tail}.
+Suas implementações em termos de casamento de padrões são diretas:
 \begin{lstlisting}
 def isEmpty: Boolean = this match {
   case Nil => true
@@ -4268,24 +4262,26 @@ def tail: List[A] = this match {
   case x :: xs => xs
 }
 \end{lstlisting}
-%----------
 
-The next function computes the length of a list.
+A próxima função computa o tamanho de uma lista.
 \begin{lstlisting}
 def length: Int = this match {
   case Nil => 0
   case x :: xs => 1 + xs.length
 }
 \end{lstlisting}
-\begin{exercise} Design a tail-recursive version of \code{length}.
+\begin{exercise} Escreva uma versão recursiva de cauda de \code{length}.
 \end{exercise}
 
-The next two functions are the complements of \code{head} and
-\code{tail}.
+As próximas duas funções são o complemento para \code{head} e \code{tail}.
 \begin{lstlisting}
 def last: A
 def init: List[A]
 \end{lstlisting}
+
+
+%----------xpto
+
 \code{xs.last} returns the last element of list \code{xs}, whereas
 \code{xs.init} returns all elements of \code{xs} except the last.
 Both functions have to traverse the entire list, and are thus less

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -9,7 +9,7 @@
 
 \chapter{\label{chap:example-one}Um primeiro exemplo}
 
-Para começar, apresentamos um primeiro exemplo, a implementação de Quicksort em Scala.
+Para comeÃ§ar, apresentamos um primeiro exemplo, a implementaÃ§Ã£o de Quicksort em Scala.
 
 \begin{lstlisting}
 def sort(xs: Array[Int]) {
@@ -35,20 +35,20 @@ def sort(xs: Array[Int]) {
 }
 \end{lstlisting}
 
-A implementação se parece muito com a que você faria em Java
-ou C. Nós usamos os mesmos operadores e estruturas de controle.
-Existem também algumas pequenas diferenças sintáticas, particularmente:
+A implementaÃ§Ã£o se parece muito com a que vocÃª faria em Java
+ou C. NÃ³s usamos os mesmos operadores e estruturas de controle.
+Existem tambÃ©m algumas pequenas diferenÃ§as sintÃ¡ticas, particularmente:
 \begin{itemize}
 \item
-As declarações começam usando palavras reservadas. Particularmente, declarações de funções são iniciadas
-com a palavra \code{def}, declarações de variáveis são iniciadas com a palavra \code{var} e
-declaração de constantes (chamadas de valores) são iniciadas com a palavra \code{val}.
+As declaraÃ§Ãµes comeÃ§am usando palavras reservadas. Particularmente, declaraÃ§Ãµes de funÃ§Ãµes sÃ£o iniciadas
+com a palavra \code{def}, declaraÃ§Ãµes de variÃ¡veis sÃ£o iniciadas com a palavra \code{var} e
+declaraÃ§Ã£o de constantes (chamadas de valores) sÃ£o iniciadas com a palavra \code{val}.
 \item
-O tipo de um parâmetro em uma função é declarado após o nome do parâmetro seguido de dois pontos(:).
+O tipo de um parÃ¢metro em uma funÃ§Ã£o Ã© declarado apÃ³s o nome do parÃ¢metro seguido de dois pontos(:).
 O tipo pode ser omitido quando o compilador for capaz de inferi-lo pelo contexto.
 \item
-A  declaração de vetores do tipo \code{T} é feita usando a expressão \code{Array[T]} ao invés de \code{T[]}. 
-O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invés de \code{a[i]}.
+A  declaraÃ§Ã£o de vetores do tipo \code{T} Ã© feita usando a expressÃ£o \code{Array[T]} ao invÃ©s de \code{T[]}. 
+O i-Ã©simo elemento de um vetor \code{a} Ã© acessado usando \code{a(i)} ao invÃ©s de \code{a[i]}.
 %----------
 %\item
 %Functions can be nested inside other functions. Nested functions can
@@ -57,10 +57,10 @@ O i-ésimo elemento de um vetor \code{a} é acessado usando \code{a(i)} ao invé
 %\code{swap} and \code{sort1}, and therefore need not be passed as a
 %parameter to them.
 \item
-Funções podem ser aninhadas umas dentro das outras. Funções aninhadas podem
-acessar parâmetros e variáveis locais de suas funções externas. Por
-exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e 
-\code{sort1}, e portanto não precisam ser passadas como um parâmetro para elas.
+FunÃ§Ãµes podem ser aninhadas umas dentro das outras. FunÃ§Ãµes aninhadas podem
+acessar parÃ¢metros e variÃ¡veis locais de suas funÃ§Ãµes externas. Por
+exemplo, o nome do vetor \code{xs} Ã© visÃ­vel nas funÃ§Ãµes \code{swap} e 
+\code{sort1}, e portanto nÃ£o precisam ser passadas como um parÃ¢metro para elas.
 %----------
 \end{itemize}
 
@@ -76,13 +76,13 @@ exemplo, o nome do vetor \code{xs} é visível nas funções \code{swap} e
 %completely different. Here is Quicksort again, this time written in
 %functional style.
 Pelo que vimos, Scala se parece com uma linguagem bem convencional 
-com algumas peculiaridades sintáticas. De fato é possível escrever
-programas em estilo imperativo ou orientado a objetos. Isto é 
-importante, porque é uma das coisas que facilitam combinar componentes
+com algumas peculiaridades sintÃ¡ticas. De fato Ã© possÃ­vel escrever
+programas em estilo imperativo ou orientado a objetos. Isto Ã© 
+importante, porque Ã© uma das coisas que facilitam combinar componentes
 Scala com componentes escritos em linguagens convencionais, tais como Java,
 C\# ou Visual Basic.
-Entretanto, também é possível escrever programas num estilo completamente
-diferente. Aqui está o Quicksort novamente, desta vez escrito em 
+Entretanto, tambÃ©m Ã© possÃ­vel escrever programas num estilo completamente
+diferente. Aqui estÃ¡ o Quicksort novamente, desta vez escrito em 
 estilo funcional.
 %----------
 \begin{lstlisting}
@@ -114,19 +114,19 @@ def sort(xs: Array[Int]): Array[Int] = {
 %% less than or greater or equal to pivot.}
 %% \item The result is obtained by appending the three sub-arrays together.
 %% \end{itemize}
-O programa funcional captura a essência do algoritmo quicksort de modo conciso:
+O programa funcional captura a essÃªncia do algoritmo quicksort de modo conciso:
 \begin{itemize}
-\item Se o vetor está vazio ou consiste de um único elemento, já está ordenado,
-      então retorne imediatamente.
-\item Se o vetor não está vazio, escolha um elemento do meio do vetor como pivô.
+\item Se o vetor estÃ¡ vazio ou consiste de um Ãºnico elemento, jÃ¡ estÃ¡ ordenado,
+      entÃ£o retorne imediatamente.
+\item Se o vetor nÃ£o estÃ¡ vazio, escolha um elemento do meio do vetor como pivÃ´.
 \item Particione o vetor em dois subvetores contendo, respectivamente os elementos
- que são menores que o elemento pivô, maiores que, e um terceiro vetor que contém
- elementos iguais ao pivô.
-\item Ordene os dois primeiros subvetores por uma chamada recursiva da função de 
-ordenação.\footnote{Isso não é exatamente o que o algoritmo imperativo faz; este 
-último particiona o vetor em dois subvetores contendo elementos menores que ou 
-maiores ou iguais ao pivô.}
-\item O resultado é obtido pela concatenação dos três subvetores.
+ que sÃ£o menores que o elemento pivÃ´, maiores que, e um terceiro vetor que contÃ©m
+ elementos iguais ao pivÃ´.
+\item Ordene os dois primeiros subvetores por uma chamada recursiva da funÃ§Ã£o de 
+ordenaÃ§Ã£o.\footnote{Isso nÃ£o Ã© exatamente o que o algoritmo imperativo faz; este 
+Ãºltimo particiona o vetor em dois subvetores contendo elementos menores que ou 
+maiores ou iguais ao pivÃ´.}
+\item O resultado Ã© obtido pela concatenaÃ§Ã£o dos trÃªs subvetores.
 \end{itemize}
 %----------
 
@@ -138,12 +138,12 @@ maiores ou iguais ao pivô.}
 %% implementation returns a new sorted array and leaves the argument
 %% array unchanged. The functional implementation thus requires more
 %% transient memory than the imperative one.
-Tanto a implementação imperativa quanto a funcional tem mesma complexidade
-assintótica -- $O(N;log(N))$ no caso médio e $O(Nœô¤æ2)$ no pior caso. Mas onde
-a implementação imperativa opera localmente, modificando o vetor original,
-a implementação funcional retorna um novo vetor ordenado e deixa o vetor
-original inalterado. A implementação funcional, portanto, requer mais
-memória transiente que a imperativa.
+Tanto a implementaÃ§Ã£o imperativa quanto a funcional tem mesma complexidade
+assintÃ³tica -- $O(N;log(N))$ no caso mÃ©dio e $O(NË†2)$ no pior caso. Mas onde
+a implementaÃ§Ã£o imperativa opera localmente, modificando o vetor original,
+a implementaÃ§Ã£o funcional retorna um novo vetor ordenado e deixa o vetor
+original inalterado. A implementaÃ§Ã£o funcional, portanto, requer mais
+memÃ³ria transiente que a imperativa.
 %----------
 
 %----------
@@ -154,12 +154,12 @@ memória transiente que a imperativa.
 %% standard Scala library, and which itself is implemented in
 %% Scala. Because arrays are instances of \verb@Seq@ all sequence
 %% methods are available for them.
-A implementação funcional faz parecer que Scala é uma linguagem
-especializada para operações funcionais sobre vetores. De fato, não é;
-todas as operações usadas no exemplo são simples métodos de biblioteca
-de uma classe {\em sequência} \code{Seq[T]} que é parte da biblioteca
-padrão Scala, e onde ela mesma é implementada em Scala. Como vetores são 
-instâncias de \verb@Seq@, todos os métodos de sequência estão disponíveis
+A implementaÃ§Ã£o funcional faz parecer que Scala Ã© uma linguagem
+especializada para operaÃ§Ãµes funcionais sobre vetores. De fato, nÃ£o Ã©;
+todas as operaÃ§Ãµes usadas no exemplo sÃ£o simples mÃ©todos de biblioteca
+de uma classe {\em sequÃªncia} \code{Seq[T]} que Ã© parte da biblioteca
+padrÃ£o Scala, e onde ela mesma Ã© implementada em Scala. Como vetores sÃ£o 
+instÃ¢ncias de \verb@Seq@, todos os mÃ©todos de sequÃªncia estÃ£o disponÃ­veis
 para eles.
 %----------
 
@@ -170,11 +170,11 @@ para eles.
 %% array consisting of all the elements of the original array for which the
 %% given predicate function is true. The \code{filter} method of an object
 %% of type \code{Array[T]} thus has the signature
-Em particular, há o método \code{filter} que recebe como argumento uma
-{\em função predicado}. Esta função predicado deve mapear elementos do 
-vetor para valores boleanos. O resultado de \code{filter} é um vetor
-consistindo de todos os elementos do vetor original para o qual a função
-predicado é verdadeira. O método \code{filter} de um objeto tipo
+Em particular, hÃ¡ o mÃ©todo \code{filter} que recebe como argumento uma
+{\em funÃ§Ã£o predicado}. Esta funÃ§Ã£o predicado deve mapear elementos do 
+vetor para valores boleanos. O resultado de \code{filter} Ã© um vetor
+consistindo de todos os elementos do vetor original para o qual a funÃ§Ã£o
+predicado Ã© verdadeira. O mÃ©todo \code{filter} de um objeto tipo
 \code{Array[T]} portanto tem a assinatura. 
 %----------
 
@@ -188,11 +188,11 @@ def filter(p: T => Boolean): Array[T]
 %% of type \code{t} and return a \code{Boolean}.  Functions like
 %% \code{filter} that take another function as argument or return one as
 %% result are called {\em higher-order} functions.
-Aqui, \code{T=>Boolean} é o tipo das funções que recebem um elemento 
+Aqui, \code{T=>Boolean} Ã© o tipo das funÃ§Ãµes que recebem um elemento 
 do tipo \code{T} e retornam um valor booleano do tipo \code{Boolean}. 
-Funções como \code{filter} 
-que recebem uma outra função como argumento ou retornam uma função como
-resultado são chamadas {\em funções de alta ordem.}     
+FunÃ§Ãµes como \code{filter} 
+que recebem uma outra funÃ§Ã£o como argumento ou retornam uma funÃ§Ã£o como
+resultado sÃ£o chamadas {\em funÃ§Ãµes de alta ordem.}     
 %----------
 
 %----------
@@ -205,15 +205,15 @@ resultado são chamadas {\em funções de alta ordem.}
 %% for binary infix operators which start with a letter. Hence, the
 %% expression ~\lstinline@xs filter (pivot >)@~ is equivalent to the
 %% method call ~\lstinline@xs.filter(pivot >)@.
-Scala não faz distinção entre nomes de identificadores e nomes de operadores.
-um identificador pode ser ou uma sequência de letras ou digitos que começam
-com uma letra, ou podem ser uma sequência de caracteres especiais, tais como 
+Scala nÃ£o faz distinÃ§Ã£o entre nomes de identificadores e nomes de operadores.
+um identificador pode ser ou uma sequÃªncia de letras ou digitos que comeÃ§am
+com uma letra, ou podem ser uma sequÃªncia de caracteres especiais, tais como 
 ``\code{+}'', ``\code{*}'', ou ``\code{:}''.  Qualquer identificador pode
-ser usado como operador infixo em Scala. A operação binária $E;op;E'$ é sempre
-interpretado como a chamada de método $E.op(E')$. Isso vale também para 
-operadores binários infixos que iniciam com uma letra. Consequentemente,
-a expressão  ~\lstinline@xs filter (pivot >)@~ é equivalente à chamada de
-método ~\lstinline@xs.filter(pivot >)@.
+ser usado como operador infixo em Scala. A operaÃ§Ã£o binÃ¡ria $E;op;E'$ Ã© sempre
+interpretado como a chamada de mÃ©todo $E.op(E')$. Isso vale tambÃ©m para 
+operadores binÃ¡rios infixos que iniciam com uma letra. Consequentemente,
+a expressÃ£o  ~\lstinline@xs filter (pivot >)@~ Ã© equivalente Ã  chamada de
+mÃ©todo ~\lstinline@xs.filter(pivot >)@.
 %----------
 
 
@@ -231,25 +231,25 @@ método ~\lstinline@xs.filter(pivot >)@.
 %% summarize, \code{xs.filter(pivot >)} returns a list consisting
 %% of all elements of the list \code{xs} that are smaller than
 %% \code{pivot}.
-No programa quicksort, \code{filter} é aplicado três vezes a um argumento 
-de função anônima. O primeiro argumento, \code{pivot >}, representa uma 
-função que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
-Este é um exemplo de uma {\em função parcialmente aplicada}. Um outro modo, 
-equivalente de se escrever esta função, que torna o argumento oculto explicito
-é ~\lstinline@x => pivot > x@. A função é anônima, ou seja, não é definida
-com um nome. O tipo do parâmetro  \code{x} é omitido porque um compilador Scala 
-pode inferí-lo automáticamente a partir do contexto onde a função é usada.
+No programa quicksort, \code{filter} Ã© aplicado trÃªs vezes a um argumento 
+de funÃ§Ã£o anÃ´nima. O primeiro argumento, \code{pivot >}, representa uma 
+funÃ§Ã£o que recebe um argumento $x$ e retorna o valor ~\lstinline@pivot > $x$@.
+Este Ã© um exemplo de uma {\em funÃ§Ã£o parcialmente aplicada}. Um outro modo, 
+equivalente de se escrever esta funÃ§Ã£o, que torna o argumento oculto explicito
+Ã© ~\lstinline@x => pivot > x@. A funÃ§Ã£o Ã© anÃ´nima, ou seja, nÃ£o Ã© definida
+com um nome. O tipo do parÃ¢metro  \code{x} Ã© omitido porque um compilador Scala 
+pode inferÃ­-lo automÃ¡ticamente a partir do contexto onde a funÃ§Ã£o Ã© usada.
 Resumindo, \code{xs.filter(pivot >)} retorna uma lista consistindo de todos os 
-elementos da lista \code{xs} que são menores que \code{pivot}.  
+elementos da lista \code{xs} que sÃ£o menores que \code{pivot}.  
 %----------
 
 %----------
 %% Looking again in detail at the first, imperative implementation of
 %% Quicksort, we find that many of the language constructs used in the
 %% second solution are also present, albeit in a disguised form.
-Olhando novamente em detalhes para a primeira, implementação imperativa
+Olhando novamente em detalhes para a primeira, implementaÃ§Ã£o imperativa
 do Quicksort, percebemos que muitos dos construtores da linguagem 
-usados na segunda solução estão presentes, embora de modo distinto.
+usados na segunda soluÃ§Ã£o estÃ£o presentes, embora de modo distinto.
 %----------
 
 
@@ -263,23 +263,23 @@ usados na segunda solução estão presentes, embora de modo distinto.
 %% Of course, a compiler is free (if it is moderately smart, even expected)
 %% to recognize the special case of calling the \code{+} method over
 %% integer arguments and to generate efficient inline code for it.
-Por exemplo, operadores binários padrão, tais como \code{+}, \code{-},
-ou \code{<} não são tratados de modo especial. Assim como \code{append}, 
-são métodos de seus operandos esquerdos. Consequentemente, a expressão 
-\code{i+1} é vista como a invocação de \code{i.+(1)} do método \code{+}      
-do valor inteiro de \code{i}. De fato, um compilador é livre (se 
+Por exemplo, operadores binÃ¡rios padrÃ£o, tais como \code{+}, \code{-},
+ou \code{<} nÃ£o sÃ£o tratados de modo especial. Assim como \code{append}, 
+sÃ£o mÃ©todos de seus operandos esquerdos. Consequentemente, a expressÃ£o 
+\code{i+1} Ã© vista como a invocaÃ§Ã£o de \code{i.+(1)} do mÃ©todo \code{+}      
+do valor inteiro de \code{i}. De fato, um compilador Ã© livre (se 
 moderadamente esperto, ainda que  esperado) para reconhecer o caso 
-especial da chamada de método \code{+} sobre argumentos inteiros e 
-para gerar código inline eficiente para isso.  
+especial da chamada de mÃ©todo \code{+} sobre argumentos inteiros e 
+para gerar cÃ³digo inline eficiente para isso.  
 %----------
 
 %----------
 %% For efficiency and better error diagnostics the \code{while} loop is a
 %% primitive construct in Scala. But in principle, it could have just as
 %% well been a predefined function. Here is a possible implementation of it:
-Por eficiência e melhor detecção de erros o laço \code{while} é um construtor 
-primitivo em Scala. Mas em princípio, poderia do mesmo modo ser uma função 
-predefinida. Aqui está uma possível implementação para ele: 
+Por eficiÃªncia e melhor detecÃ§Ã£o de erros o laÃ§o \code{while} Ã© um construtor 
+primitivo em Scala. Mas em princÃ­pio, poderia do mesmo modo ser uma funÃ§Ã£o 
+predefinida. Aqui estÃ¡ uma possÃ­vel implementaÃ§Ã£o para ele: 
 %----------
 \begin{lstlisting}
 def While (p: => Boolean) (s: => Unit) {
@@ -293,11 +293,11 @@ def While (p: => Boolean) (s: => Unit) {
 %% parameter it takes a command function which also takes no parameters
 %% and yields a result of type \lstinline@Unit@. \code{While} invokes the
 %% command function as long as the test function yields true.
-A função \code{While} recebe como primeiro parâmetro uma função teste,
-que não recebe parâmetros e produz um valor boleano. Como segundo parâmetro 
-recebe uma função comando que também não recebe parâmetros e produz como 
-resultado o tipo  \lstinline@Unit@. \code{While} invoca a função comando
-enquanto a função teste produzir verdadeiro.
+A funÃ§Ã£o \code{While} recebe como primeiro parÃ¢metro uma funÃ§Ã£o teste,
+que nÃ£o recebe parÃ¢metros e produz um valor boleano. Como segundo parÃ¢metro 
+recebe uma funÃ§Ã£o comando que tambÃ©m nÃ£o recebe parÃ¢metros e produz como 
+resultado o tipo  \lstinline@Unit@. \code{While} invoca a funÃ§Ã£o comando
+enquanto a funÃ§Ã£o teste produzir verdadeiro.
 %----------
 
 %----------
@@ -312,13 +312,13 @@ enquanto a função teste produzir verdadeiro.
 %% ``expression-oriented'' formulation of the \lstinline@swap@ function
 %% in the first implementation of quicksort, which makes this explicit:
 O tipo Scala \lstinline@Unit@ corresponde grosseiramente ao \lstinline@void@
-no Java; é usado sempre que uma função não retornar um resultado interessante.
-De fato, porque Scala é uma linguagem orientada a expressões, cada função 
-retorna algum resultado. Se nenhuma expressão de retorno é  explicitamente
-fornecida, o valor \lstinline@()@, que é pronunciado ``unit'', é assumido.
-Este valor é do tipo \lstinline@Unit@. Funções que retornam ``unit'' são 
-também chamadas {\em procedimentos}. Aqui está uma formulação mais 
-``orientada a expressão'' da função \lstinline@swap@ na primeira implementação
+no Java; Ã© usado sempre que uma funÃ§Ã£o nÃ£o retornar um resultado interessante.
+De fato, porque Scala Ã© uma linguagem orientada a expressÃµes, cada funÃ§Ã£o 
+retorna algum resultado. Se nenhuma expressÃ£o de retorno Ã©  explicitamente
+fornecida, o valor \lstinline@()@, que Ã© pronunciado ``unit'', Ã© assumido.
+Este valor Ã© do tipo \lstinline@Unit@. FunÃ§Ãµes que retornam ``unit'' sÃ£o 
+tambÃ©m chamadas {\em procedimentos}. Aqui estÃ¡ uma formulaÃ§Ã£o mais 
+``orientada a expressÃ£o'' da funÃ§Ã£o \lstinline@swap@ na primeira implementaÃ§Ã£o
 do quicksort, que explicita isto:
 %----------
 
@@ -334,10 +334,10 @@ def swap(i: Int, j: Int) {
 %% \lstinline@return@ keyword is not necessary. Note that functions
 %% returning an explicit value always need an ``='' before their
 %% body or defining expression.  
-O valor resultante desta função é simplesmente sua última expressão---uma
-palavra chave \lstinline@return@ não é necessária. Observe que funções 
-que retornam um valor explícito sempre precisam de um ``='' antes de
-seus corpos ou expressões de definição.
+O valor resultante desta funÃ§Ã£o Ã© simplesmente sua Ãºltima expressÃ£o---uma
+palavra chave \lstinline@return@ nÃ£o Ã© necessÃ¡ria. Observe que funÃ§Ãµes 
+que retornam um valor explÃ­cito sempre precisam de um ``='' antes de
+seus corpos ou expressÃµes de definiÃ§Ã£o.
 %----------
 
 \chapter{Programando com Atores e Mensagens}
@@ -351,14 +351,14 @@ seus corpos ou expressões de definição.
 %% its incoming messages which is represented as a queue. It can work
 %% sequentially through the messages in its mailbox, or search for
 %% messages matching some pattern.
-Aqui está um exemplo que mostra uma área de aplicação para a qual Scala 
-é particularmente indicada. Considere a tarefa de implementar um serviço
-de leilão eletrônico. Podemos usar um modelo de processo no estilo 
-actor do Erlang para implementar os participantes do leilão. Actors são 
-objetos para os quais as mensagens são enviadas. Cada actor tem uma caixa de correio 
-para suas mensagens de entrada que é representada para uma fila. Pode
+Aqui estÃ¡ um exemplo que mostra uma Ã¡rea de aplicaÃ§Ã£o para a qual Scala 
+Ã© particularmente indicada. Considere a tarefa de implementar um serviÃ§o
+de leilÃ£o eletrÃ´nico. Podemos usar um modelo de processo no estilo 
+actor do Erlang para implementar os participantes do leilÃ£o. Actors sÃ£o 
+objetos para os quais as mensagens sÃ£o enviadas. Cada actor tem uma caixa de correio 
+para suas mensagens de entrada que Ã© representada para uma fila. Pode
 trabalhar sequencialmente nas mensagens da sua caixa de correio, ou buscar 
-por mensagens que casam com algum padrão. 
+por mensagens que casam com algum padrÃ£o. 
 %----------
 \begin{lstlisting}[style=floating,label=fig:simple-auction-msgs,caption=Message
     Classes for an Auction Service]
@@ -383,11 +383,11 @@ case object AuctionOver                      extends AuctionReply
 %% and that communicates with the seller and winning bidder to close the
 %% transaction. We present an overview of a simple implementation
 %% here.
-Para cada item negociado há um actor leiloeiro que publica a 
-informação sobre o item negociado, que aceita ofertas de clientes
-e que se comunica com o vendedor e com o vencedor do leilão 
-para fechar a transação. Apresentamos uma visão superficial de uma
- implementação aqui.
+Para cada item negociado hÃ¡ um actor leiloeiro que publica a 
+informaÃ§Ã£o sobre o item negociado, que aceita ofertas de clientes
+e que se comunica com o vendedor e com o vencedor do leilÃ£o 
+para fechar a transaÃ§Ã£o. Apresentamos uma visÃ£o superficial de uma
+ implementaÃ§Ã£o aqui.
 %----------
 
 %----------
@@ -397,10 +397,10 @@ para fechar a transação. Apresentamos uma visão superficial de uma
 %% service, and \code{AuctionReply} for replies from the service to the
 %% clients.  For both base classes there exists a number of cases, which
 %% are defined in Figure~\ref{fig:simple-auction-msgs}.
-Como primeiro passo, definimos as mensagens que são trocadas durante um
-leilão. Há duas classes base abstratas \code{AuctionMessage} para mensagens 
-de clientes do serviço de leilão, e \code{AuctionReply} para respostas 
-do serviço aos clientes. Para ambas as classes base há um número de casos 
+Como primeiro passo, definimos as mensagens que sÃ£o trocadas durante um
+leilÃ£o. HÃ¡ duas classes base abstratas \code{AuctionMessage} para mensagens 
+de clientes do serviÃ§o de leilÃ£o, e \code{AuctionReply} para respostas 
+do serviÃ§o aos clientes. Para ambas as classes base hÃ¡ um nÃºmero de casos 
 definidos na Figura~\ref{fig:simple-auction-msgs}.
 %----------
 
@@ -446,16 +446,11 @@ class Auction(seller: Actor, minBid: Int, closing: Date) extends Actor {
 %% might well be ultimately mapped to small XML documents. We expect
 %% automatic tools to exist that convert between XML documents and
 %% internal data structures like the ones defined above.
-Para cada classe base, há um número de {\em classes case} que definem
+Para cada classe base, hÃ¡ um nÃºmero de {\em classes case} que definem
 o formato de mensagens particulares dentro da classe. Estas mensagens
-podem em último caso ser mapeadas a pequenos documentos XML. Esperamos
-que hajam ferramentas automáticas que convertam entre documentos XML e 
+podem em Ãºltimo caso ser mapeadas a pequenos documentos XML. Esperamos
+que hajam ferramentas automÃ¡ticas que convertam entre documentos XML e 
 estruturas de dados internas, tais como as definidas acima.
-% Vinicius - Parei aqui. -> Basile, porque voce nao traduzi Ator?? 
-%
-% Resp: por que trata-se de um modelo de concorrência (o nome do modelo) 
-% usado por Scala que foi inspirado no modelo do Erlang:
-%      http://ruben.savanne.be/articles/concurrency-in-erlang-scala
 %----------
 
 %----------
@@ -473,19 +468,19 @@ estruturas de dados internas, tais como as definidas acima.
 %% message. Before finally stopping, it stays active for another period
 %% determined by the \code{timeToShutdown} constant and replies to
 %% further offers that the auction is closed.
-A Figura~\ref{fig:simple-auction} apresenta uma implementação Scala para a classe
-\code{Auction} para actors do leilão que coordenam os lances sobre um item. Objetos
-para esta classe são criados pela indicação
+A Figura~\ref{fig:simple-auction} apresenta uma implementaÃ§Ã£o Scala para a classe
+\code{Auction} para actors do leilÃ£o que coordenam os lances sobre um item. Objetos
+para esta classe sÃ£o criados com as informaÃ§Ãµes:
 \begin{itemize}
-\item Um actor vendedor que precisa ser notificado quando o leilão terminou,
-\item o lance mínimo,
-\item a data de quando o leilão foi fechado.
+\item Um actor vendedor que precisa ser notificado quando o leilÃ£o terminou,
+\item o lance mÃ­nimo,
+\item a data de quando o leilÃ£o foi fechado.
 \end{itemize}  
-O comportamento do actor é definido por seu método \code{act}. Este método seleciona
-repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, até que o 
-leilão seja fechado, o que é sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
-finalmente parar, permanece ativo para um outro período determinado pela constante 
-\code{timeToShutdown} e replica para ofertas posteriores que o leilão está fechado.    
+O comportamento do actor Ã© definido por seu mÃ©todo \code{act}. Este mÃ©todo seleciona
+repetidamente (usando \code{receiveWithin}) uma mensagem e reage a ela, atÃ© que o 
+leilÃ£o seja fechado, o que Ã© sinalizado por uma mensagem \code{TIMEOUT}. Antes de 
+finalmente parar, permanece ativo para um outro perÃ­odo determinado pela constante 
+\code{timeToShutdown} e replica para ofertas posteriores que o leilÃ£o estÃ¡ fechado.    
 %----------
 
 %----------
@@ -500,14 +495,14 @@ finalmente parar, permanece ativo para um outro período determinado pela consta
 %% messages matching the pattern. The \code{receiveWithin} method selects
 %% the first message in the mailbox which matches one of these patterns
 %% and applies the corresponding action to it.
-Aqui estão algumas explicações extras sobre os construtores usados neste programa:
+Aqui estÃ£o algumas explicaÃ§Ãµes extras sobre os construtores usados neste programa:
 \begin{itemize}
 \item
-O método \code{receiveWithin} da classe \code{Actor} recebe como parâmetro um prazo dado
-em milisegundos e uma função que processa mensagens na caixa de correio. A função é dada
-por uma sequência de cases que especificam um padrão e uma ação para mensagens que 
-casam com o padrão. O método \code{receiveWithin} seleciona a primeira mensagem da 
-caixa de correio que casa com um destes padrões e aplica a ação correspondente a ele. 
+O mÃ©todo \code{receiveWithin} da classe \code{Actor} recebe como parÃ¢metro um prazo dado
+em milisegundos e uma funÃ§Ã£o que processa mensagens na caixa de correio. A funÃ§Ã£o Ã© dada
+por uma sequÃªncia de cases que especificam um padrÃ£o e uma aÃ§Ã£o para mensagens que 
+casam com o padrÃ£o. O mÃ©todo \code{receiveWithin} seleciona a primeira mensagem da 
+caixa de correio que casa com um destes padrÃµes e aplica a aÃ§Ã£o correspondente a ele. 
 %----------
 
 
@@ -519,10 +514,10 @@ caixa de correio que casa com um destes padrões e aplica a ação correspondent
 %% to the enclosing \code{receiveWithin} method. \code{TIMEOUT} is a
 %% special message, which is triggered by the \code{Actor} implementation itself.
 \item
-O último case de \code{receiveWithin} é guardado por um padrão \code{TIMEOUT}.  
-Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrão é disparado
-após o prazo que foi passado como argumento para o método envolvente \code{receiveWithin}.
-\code{TIMEOUT} é uma mensagem especial, que é disparada pela própria implementação do 
+O Ãºltimo case de \code{receiveWithin} Ã© guardado por um padrÃ£o \code{TIMEOUT}.  
+Se nenhuma outra mensagem foi recebida nesse meio tempo, este padrÃ£o Ã© disparado
+apÃ³s o prazo que foi passado como argumento para o mÃ©todo envolvente \code{receiveWithin}.
+\code{TIMEOUT} Ã© uma mensagem especial, que Ã© disparada pela prÃ³pria implementaÃ§Ã£o do 
 \code{Actor}.    
 %----------
 
@@ -537,10 +532,10 @@ após o prazo que foi passado como argumento para o método envolvente \code{rec
 %% parameter.
 %% \end{itemize}
 \item
-Mensagens de resposta são enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
-\code{!} é usado aqui como um operador binário com um actor e uma mensagem como argumentos.
-Isto é equivalente em Scala ao chamado de método \code{destino.!(AlgumaMensagem)}, ou seja, 
-a invocação do método \code{!} do actor destino com a mensagem dada como parâmetro.
+Mensagens de resposta sÃ£o enviadas usando sintaxe da forma \code{destino ! AlgumaMensagem}.
+\code{!} Ã© usado aqui como um operador binÃ¡rio com um actor e uma mensagem como argumentos.
+Isto Ã© equivalente em Scala ao chamado de mÃ©todo \code{destino.!(AlgumaMensagem)}, ou seja, 
+a invocaÃ§Ã£o do mÃ©todo \code{!} do actor destino com a mensagem dada como parÃ¢metro.
 \end{itemize}    
 %----------
 
@@ -554,14 +549,14 @@ a invocação do método \code{!} do actor destino com a mensagem dada como par
 %% thread model of the host language (e.g. Java, or .NET).
 %% The implementation of all features of class \code{Actor} used here is
 %% given in Section~\ref{sec:actors}.
-A discussão precedente deu uma idéia de programação distribuída em Scala. Isso
-dá a sensação que Scala tem um rico conjunto de construtores que suportam
-processos actor, envio e recebimento de mensagens, programação com timeouts etc.
-De fato, o oposto é verdadeiro. Todos os construtores discutidos acima são 
-oferecidos como métodos na classe biblioteca \code{Actor}. Aquela classe é
-ele mesma implementada em Scala, baseado no modelo thread subjacente à linguagem 
-hospedeira (Java ou .NET). A implementação de todas as características da 
-classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.     
+A discussÃ£o precedente deu uma idÃ©ia de programaÃ§Ã£o distribuÃ­da em Scala.Pode parecer 
+que Scala tenha um rico conjunto de construtores que suportam
+processos actor, envio e recebimento de mensagens, programaÃ§Ã£o com timeouts etc.
+De fato, o oposto Ã© verdadeiro. Todos os construtores discutidos acima sÃ£o 
+oferecidos como mÃ©todos na classe biblioteca \code{Actor}. Aquela classe Ã©
+ele mesma implementada em Scala, baseado no modelo thread subjacente Ã  linguagem 
+hospedeira (Java ou .NET). A implementaÃ§Ã£o de todas as caracterÃ­sticas da 
+classe \code{Actor} usada aqui Ã© dada na SeÃ§Ã£o~\ref{sec:actors}.     
 %----------
 
 %----------
@@ -579,38 +574,37 @@ classe \code{Actor} usada aqui é dada na Seção~\ref{sec:actors}.
 %% library modules. For instance, the actor communication constructs
 %% presented above can be regarded as one such domain specific language,
 %% which conceptually extends the Scala core.
-As vantagens da abordagem baseada em biblioteca são a relativa simplicidade
-da linguagem núcleo e a flexibilidade para os criadores de biblioteca. Como 
-a linguagem núcleo não precisa especificar detalhes da comunicação dos 
-processos de alto nível, pode ser mantida mais simples e geral. Como
-um modelo particular de mensagens numa caixa de correio é um módulo biblioteca, 
-pode ser modificado livremente se um diferente modelo for necessário em algumas 
-aplicações. A abordagem requer, entretanto, que a linguagem núcleo seja expressiva
-o suficiente para prover as abstrações linguísticas necessárias de um modo 
+As vantagens da abordagem baseada em biblioteca sÃ£o a relativa simplicidade
+da linguagem nÃºcleo e a flexibilidade para os criadores de biblioteca. Como 
+a linguagem nÃºcleo nÃ£o precisa especificar detalhes da comunicaÃ§Ã£o dos 
+processos de alto nÃ­vel, pode ser mantida mais simples e geral. Como
+um modelo particular de mensagens numa caixa de correio Ã© um mÃ³dulo biblioteca, 
+pode ser modificado livremente se um diferente modelo for necessÃ¡rio em algumas 
+aplicaÃ§Ãµes. A abordagem requer, entretanto, que a linguagem nÃºcleo seja expressiva
+o suficiente para prover as abstraÃ§Ãµes linguÃ­sticas necessÃ¡rias de um modo 
 conveniente. Scala foi criada com isto em mente; um de seus maiores objetivos de 
-design foi deixá-la flexível o suficiente para atuar como uma conveniente linguagem
-hospedeira para domínios de linguagens específicos implementados por módulos de 
-biblioteca. Por exemplo, a construção de comunicação actor apresentada acima
-pode ser vista como um desses domínios específicos de linguagem, que conceitualmente
-estendem o núcleo Scala.  
+projeto foi deixÃ¡-la flexÃ­vel o suficiente para atuar como uma conveniente linguagem
+hospedeira para linguagens de domÃ­nios especÃ­ficos (DSL) implementados por mÃ³dulos de 
+biblioteca. Por exemplo, a construÃ§Ã£o de comunicaÃ§Ã£o actor apresentada acima
+pode ser vista como um dessas linguagens de domÃ­nios especÃ­ficos, que conceitualmente
+estendem o nÃºcleo Scala.  
 %----------
 
 %----------
-% Vinicius - comecei traducao aqui.
 %%\chapter{\label{chap:simple-funs}Expressions and Simple Functions}
-\chapter{\label{chap:simple-funs}Expressões e Funções Simples}
+\chapter{\label{chap:simple-funs}ExpressÃµes e FunÃ§Ãµes Simples}
 
 %% The previous examples gave an impression of what can be done with
 %% Scala.  We now introduce its constructs one by one in a more
 %% systematic fashion. We start with the smallest level, expressions and
 %% functions.
 Os exemplos anteriores deram uma ideia do que pode ser feito com Scala. Agora,
-introduzimos as suas construções de linguagem uma a uma de uma maneira mais sistemática.
-Vamos começar com os menores elementos: expressões e funções.
+introduzimos as suas construÃ§Ãµes de linguagem uma a uma de uma maneira mais sistemÃ¡tica.
+Vamos comeÃ§ar com os menores elementos: expressÃµes e funÃ§Ãµes.
 
 
 %%\section{Expressions And Simple Functions}
-\section{Expressões e Funções Simples}
+\section{ExpressÃµes e FunÃ§Ãµes Simples}
 
 %% A Scala system comes with an interpreter which can be seen as a fancy
 %% calculator. A user interacts with the calculator by typing in
@@ -618,8 +612,8 @@ Vamos começar com os menores elementos: expressões e funções.
 %% types. For example:
 %----------
 Scala vem com um interpretador que pode ser visto como uma calculadora sofisticada.
-O usuário interage com a calculadora digitando expressões. A calculadora retorna o
-resultado do cálculo e o seu tipo de dado. Por exemplo: 
+O usuÃ¡rio interage com a calculadora digitando expressÃµes. A calculadora retorna o
+resultado do cÃ¡lculo e o seu tipo de dado. Por exemplo: 
 
 \begin{lstlisting}
 scala> 87 + 145
@@ -633,8 +627,8 @@ unnamed2: java.lang.String = hello world!
 \end{lstlisting}
 %It is also possible to name a sub-expression and use the name instead
 %of the expression afterwards:
-Também é possível dar nome a uma sub-expressão e usar o nome, ao invés da expressão, 
-nas expressões seguintes:
+TambÃ©m Ã© possÃ­vel dar nome a uma sub-expressÃ£o e usar o nome, ao invÃ©s da expressÃ£o, 
+nas expressÃµes seguintes:
 \begin{lstlisting}
 scala> def scale = 5
 scale: Int
@@ -658,12 +652,9 @@ unnamed4: Double = 62.83185307179586
 %% Definitions start with the reserved word \code{def}; they introduce a
 %% name which stands for the expression following the \code{=} sign.  The
 %% interpreter will answer with the introduced name and its type.
-Definições começam com a palavra reservada \code{def}. Elas introduzem um nome
-que representa a expressão que vem depois do símbolo \code{=}. O intepretrador
+DefiniÃ§Ãµes comeÃ§am com a palavra reservada \code{def}. Elas introduzem um nome
+que representa a expressÃ£o que vem depois do sÃ­mbolo \code{=}. O intepretrador
 responde com o nome introduzido e o seu tipo de dado.
-% Vinicius - parei traducao aqui.
-
-
 
 %----------
 %% Executing a definition such as \code{def x = e} will not evaluate the
@@ -673,11 +664,11 @@ responde com o nome introduzido e o seu tipo de dado.
 %% evaluation of the definition. If \code{x} is then used subsequently,
 %% it is immediately replaced by the pre-computed value of
 %% \code{e}, so that the expression need not be evaluated again.
-Executando uma definição tal como \code{def x = e} não avaliará a expressão \code{e}. 
-Ao invés \code{e} é avaliado sempre que \code{x} for usado. Alternativamente, Scala 
-oferece um valor definição \code{val x = e}, o qual avalia o lado direito de \code{e}
-como parte da avaliação da definição. Se \code{x} é então usado subsequentemente, é 
-imediatamente substituído pelo valor pré-computado de \code{e}, logo a expressão não 
+Executando uma definiÃ§Ã£o tal como \code{def x = e} nÃ£o avaliarÃ¡ a expressÃ£o \code{e}. 
+Ao invÃ©s \code{e} Ã© avaliado sempre que \code{x} for usado. Alternativamente, Scala 
+oferece um valor definiÃ§Ã£o \code{val x = e}, o qual avalia o lado direito de \code{e}
+como parte da avaliaÃ§Ã£o da definiÃ§Ã£o. Se \code{x} Ã© entÃ£o usado subsequentemente, Ã© 
+imediatamente substituÃ­do pelo valor prÃ©-computado de \code{e}, logo a expressÃ£o nÃ£o 
 precisa ser avaliada novamente.
 %----------
 
@@ -696,17 +687,17 @@ precisa ser avaliada novamente.
 %% right-hand side.  The evaluation process stops once we have reached a
 %% value. A value is some data item such as a string, a number, an array,
 %% or a list.
-Como as expressões são avaliadas? Uma expressão consistindo de operadores e 
-operandos é avaliada pela repetida aplicação dos seguintes passos de simplificação:
+Como as expressÃµes sÃ£o avaliadas? Uma expressÃ£o consistindo de operadores e 
+operandos Ã© avaliada pela repetida aplicaÃ§Ã£o dos seguintes passos de simplificaÃ§Ã£o:
 \begin{itemize}
-\item escolha a operação mais a esquerda.
+\item escolha a operaÃ§Ã£o mais a esquerda.
 \item avalie seu operando
 \item aplique o operador aos valores do operando.
 \end{itemize}
-Um nome definido por \code{def} é avaliado substituindo o nome pela definição do lado
-direito (não avaliada). Um nome definido por \code{val} é avaliado pela substituição do 
-nome pelo valor da definição do lado direito. O processo de avaliação pára assim que 
-encontrarmos um valor. Um valor é algum dado, tal como uma cadeia de caracteres, um número, 
+Um nome definido por \code{def} Ã© avaliado substituindo o nome pela definiÃ§Ã£o do lado
+direito (nÃ£o avaliada). Um nome definido por \code{val} Ã© avaliado pela substituiÃ§Ã£o do 
+nome pelo valor da definiÃ§Ã£o do lado direito. O processo de avaliaÃ§Ã£o para assim que 
+encontrarmos um valor. Um valor Ã© algum dado, tal como uma cadeia de caracteres, um nÃºmero, 
 um vetor, ou uma lista.
 %----------
 
@@ -725,7 +716,7 @@ um vetor, ou uma lista.
 %% called {\em reduction}.
 
 \example
-Aqui está uma avaliação de uma expressão aritmética.
+Aqui estÃ¡ uma avaliaÃ§Ã£o de uma expressÃ£o aritmÃ©tica.
 
 \begin{lstlisting}
 $\,\,\,$   (2 * pi) * radius
@@ -734,15 +725,15 @@ $\rightarrow$  6.283185307179586 * radius
 $\rightarrow$  6.283185307179586 * 10
 $\rightarrow$  62.83185307179586
 \end{lstlisting}
-O processo de simplificar gradualmente expressões para valores é 
-chamado {\em redução}.
+O processo de simplificar gradualmente expressÃµes para valores Ã© 
+chamado {\em reduÃ§Ã£o}.
 %----------
 
 
 \section{Parameters}
 
 %% Using \code{def}, one can also define functions with parameters. For example:
-Usando \code{def}, pode-se também definir funções com parâmetros. Por exemplo:
+Usando \code{def}, pode-se tambÃ©m definir funÃ§Ãµes com parÃ¢metros. Por exemplo:
 \begin{lstlisting}
 scala> def square(x: Double) = x * x
 square: (Double)Double
@@ -763,7 +754,8 @@ scala> sumOfSquares(3, 2 + 2)
 unnamed3: Double = 25.0
 \end{lstlisting}
 
-%----------
+% Vinicius - parei revisao  aqui. - Antes daqui, tudo OK!
+%----------xpto
 %% Function parameters follow the function name and are always enclosed
 %% in parentheses.  Every parameter comes with a type, which is indicated
 %% following the parameter name and a colon.  At the present time, we
@@ -772,13 +764,11 @@ unnamed3: Double = 25.0
 %% standard types, so we can write numeric types as in Java. For instance
 %% \code{double} is a type alias of \code{scala.Double} and \code{int} is
 %% a type alias for \code{scala.Int}.
-Parâmetros de funções seguem o nome da função e sempre são envolvidos por
-parênteses. Cada parâmetro vem com um tipo que segue o nome do parâmetro
-e dois pontos. Até aqui, só precisamos de tipos numéricos, tal como o tipo
-\code{scala.Double} dos números de precisão dupla. Scala define {\em tipos
-aliases} para alguns tipos básicos, logo podemos escrever tipos numéricos 
-como em Java. Por exemplo, \code{double} é um tipo alias de \code{scala.Double}
-e \code{int} é um tipo alias para \code{scala.Int}.       
+
+
+ParÃ¢metros de funÃ§Ãµes seguem o nome da funÃ§Ã£o e sempre sÃ£o envolvidos por
+parÃªnteses. Cada parÃ¢metro vem com um tipo que segue o nome do parÃ¢metro
+e dois pontos. AtÃ© aqui, sÃ³ precisamos de tipos numÃ©ricos   
 %----------
 
 %----------
@@ -788,11 +778,6 @@ e \code{int} é um tipo alias para \code{scala.Int}.
 %% the function's right hand side, and at the same time all formal
 %% parameters of the function are replaced by their corresponding actual
 %% arguments.
-Funções com parâmetros são avaliadas analogamente a operadores em expressões.
-Primeiro, os argumentos da função são avaliados (da esquerda para direita). 
-Então, a aplicação da função é substituído pelo lado direito da função, e
-ao mesmo tempo todos os parâmetros formais são substituídos pelos seus 
-argumentos atuais. 
 %----------
 
 \example\ 
@@ -813,10 +798,6 @@ $\rightarrow$  25
 %% values before rewriting the function application.  One could instead
 %% have chosen to apply the function to unreduced arguments. This would
 %% have yielded the following reduction sequence:
-O exemplo mostra que o interpretador reduz argumentos de funções a valores 
-antes de reescrever a aplicação da função. Pode-se ao invés escolher aplicar
-a função a argumentos não reduzidos. Isto levará a seguinte sequência de 
-redução: 
 %----------
 
 \begin{lstlisting}
@@ -836,10 +817,6 @@ $\rightarrow$  25
 %% expressions that use only pure functions and that therefore can be
 %% reduced with the substitution model, both schemes yield the same final
 %% values.  
-A segunda ordem de avaliação é conhecida como \emph{chamada por nome},
-e a primeira por \emph{chamada por valor}. Para expressões que se utilizam
-apenas de funções e que portanto podem ser reduzidas com o modelo de 
-substituição, ambos os esquemas levam ao mesmo valor final.
 %----------
 
 %----------
@@ -849,13 +826,8 @@ substituição, ambos os esquemas levam ao mesmo valor final.
 %% Call-by-value is usually more efficient than call-by-name, but a
 %% call-by-value evaluation might loop where a call-by-name evaluation
 %% would terminate. Consider:
-Chamada por valor tem a vantagem de evitar avaliações repetidas de argumentos.
-Chamada por nome tem a vantagem de evitar avaliações de argumentos quando o 
-parâmetro não é usado pela função. Chamada por valor é geralmente mais 
-eficiente que chamada por nome, mas uma avaliação de chamada por valor
-pode entrar em laço infinito, enquanto uma avaliação de chamada por nome 
-termina. Considere: 
 %----------
+
 \begin{lstlisting}
 scala> def loop: Int = loop
 loop: Int
@@ -867,9 +839,6 @@ first: (Int,Int)Int
 %% Then \code{first(1, loop)} reduces with call-by-name to \code{1},
 %% whereas the same term reduces with call-by-value repeatedly to itself,
 %% hence evaluation does not terminate.
-Então \code{first(1, loop)} é reduzido com uma chamada por nome a \code{1},
-enquanto o mesmo termo, através de uma chamada por valor reduz a si mesmo 
-repetidamente, logo a avaliação não termina.  
 %----------
 \begin{lstlisting}
 $\,\,\,$   first(1, loop)
@@ -880,8 +849,7 @@ $\rightarrow$  ...
 %----------
 %% Scala uses call-by-value by default, but it switches to call-by-name evaluation
 %% if the parameter type is preceded by \code{=>}.
-Scala usa chamada por valor por default, mas muda para avaliação de chamada por nome 
-se o tipo do parâmetro for precedido por \code{=>}. 
+
 \example\ 
  
 \begin{lstlisting}
@@ -891,8 +859,8 @@ constOne: (Int,=> Int)Int
 scala> constOne(1, loop)
 unnamed0: Int = 1
 
-scala> constOne(loop, 2)               // leva a laço infinito
-^C                                     // para a execução com Ctrl-C
+scala> constOne(loop, 2)               // gives an infinite loop.
+^C                                     // stops execution with Ctrl-C
 \end{lstlisting}
 %----------
 
@@ -906,13 +874,6 @@ scala> constOne(loop, 2)               // leva a laço infinito
 %% same syntax to choose between two expressions. That's why Scala's
 %% \code{if-else} serves also as a substitute for Java's conditional
 %% expression \code{ ... ? ... : ...}.
-\section{Expressões Condicionais}
-O \code{if-else} do Scala leva a uma escolha entre duas alternativas. Sua
-sintaxe é a mesma do \code{if-else} do Java. Mas onde o \code{if-else} do 
-Java pode ser usado somente como uma alternativa entre comandos, Scala 
-permite a mesma sintaxe para escolher entre duas expressões. Isso porque o
-\code{if-else} do Scala serve também como um substituto para a expressão 
-condicional do Java \code{... ? ... : ...}.      
 %----------
 
 %----------
@@ -927,16 +888,6 @@ condicional do Java \code{... ? ... : ...}.
 %% \code{true} and
 %% \code{false}, comparison operators, boolean negation \code{!} and the
 %% boolean operators $\,$\code{&&}$\,$ and $\,$\code{||}.
-\exemplo\
-\begin{lstlisting}
-scala> def abs(x: Double) = if (x >= 0) x else -x
-abs: (Double)Double
-\end{lstlisting}
-Expressões boleanas em Scala são similares as em Java; são formadas
-a partir de constantes.  
-\code{true} e
-\code{false}, operadores de comparação, negação boleana \code{!} e os 
-operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}. 
 %----------
 
 %----------
@@ -949,14 +900,6 @@ operadores boleanos  $\,$\code{&&}$\,$ and $\,$\code{||}.
 %% def sqrt(x: Double): Double = ...
 %% \end{lstlisting}
 %% which computes the square root of \code{x}.
-
-%% \section{\label{sec:sqrt}Example: Raiz Quadrada pelo Método de Newton}
-Agora ilustraremos elementos da linguagem intruduzidos até aqui na
-construção de um programa mais interessante. A tarefa é escrever um função  
- \begin{lstlisting}
- def sqrt(x: Double): Double = ...
- \end{lstlisting}
-que computa a raiz quadrada de \code{x}. 
 %----------
 
 %----------
@@ -967,21 +910,14 @@ que computa a raiz quadrada de \code{x}.
 %% example, the next three columns indicate the guess \code{y}, the
 %% quotient \code{x/y}, and their average for the first approximations of
 %% $\sqrt 2$.
-Um modo comum de se computar raizes quadradas é pelo método das aproximações
-sucessivas de Newton. Inicia-se com um palpite inicial \code{y} (digamos:
-\code{y = 1}). Então melhora-se repetidamente o atual palpite \code{y} 
-tomando-se a média de \code{y} e \code{x/y}. Como um exemplo, as próximas
-três colunas indicam o palpite \code{y}, o quociente \code{x/y}, e suas
-médias para as primeiras aproximações para $\sqrt 2$.       
+%% \begin{lstlisting}
+%% 1            2/1 = 2               1.5
+%% 1.5          2/1.5 = 1.3333        1.4167
+%% 1.4167       2/1.4167 = 1.4118     1.4142
+%% 1.4142       ...                   ...
 
-\begin{lstlisting}
-1            2/1 = 2               1.5
-1.5          2/1.5 = 1.3333        1.4167
-1.4167       2/1.4167 = 1.4118     1.4142
-1.4142       ...                   ...
-
-$y$            $x/y$                   $(y + x/y)/2$
-\end{lstlisting}
+%% $y$            $x/y$                   $(y + x/y)/2$
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -989,28 +925,14 @@ $y$            $x/y$                   $(y + x/y)/2$
 %% which each represent one of the elements of the algorithm.  
 
 %% We first define a function for iterating from a guess to the result:
-
-Este algoritmo pode ser implementado em Scala por um conjunto de pequenas funções,
-onde cada uma representa um dos elementos do algoritmo.
-
-Primeiro definimos uma função para iterar do palpite para o resultado:
-%-----------
-
-
-\begin{lstlisting}
-def sqrtIter(guess: Double, x: Double): Double =
-  if (isGoodEnough(guess, x)) guess
-  else sqrtIter(improve(guess, x), x)
-\end{lstlisting}
-
-%-----------
+%% \begin{lstlisting}
+%% def sqrtIter(guess: Double, x: Double): Double =
+%%   if (isGoodEnough(guess, x)) guess
+%%   else sqrtIter(improve(guess, x), x)
+%% \end{lstlisting}
 %% Note that \code{sqrtIter} calls itself recursively.  Loops in
 %% imperative programs can always be modeled by recursion in functional
-%% programs.
- 
-Observe que \code{sqrtIter} chama a si mesmo recursivamente. Laços em 
-programas imperativos podem sempre ser modelados por recursão em 
-programas funcionais. 
+%% programs. 
 %----------
 
 %----------
@@ -1021,38 +943,27 @@ programas funcionais.
 %% compute it from the type of the function's right-hand side. However,
 %% even for non-recursive functions it is often a good idea to include a
 %% return type for better documentation.
-Observe também que a definição de \code{sqrtIter} contém um tipo retorno,
-que segue o seção de parâmetros. Tais tipos de retorno são mandatórios para 
-funções recursivas. Para uma função não recursiva, o tipo de retorno é opcional;
-se estiver faltando o verificador de tipos o computará a partir do tipo do lado
-direito da função. Entretanto, mesmo para funções não recursivas é sempre boa idéia 
-incluir um tipo de retorno para melhor documentação.  
 %----------
 
 %----------
 %% As a second step, we define the two functions called by
 %% \code{sqrtIter}: a function to \code{improve} the guess and a
 %% termination test \code{isGoodEnough}. Here is their definition.
+%% \begin{lstlisting}
+%% def improve(guess: Double, x: Double) =
+%%   (guess + x / guess) / 2
+%----------
 
-Como segundo passo, definimos as duas funções chamadas por:
-\code{sqrtIter}: uma função para melhorar (\code{improve}) o palpite e um
-teste de terminação \code{isGoodEnough}. Aqui estão suas definições.
-\begin{lstlisting}
-def improve(guess: Double, x: Double) =
-  (guess + x / guess) / 2    
-
-def isGoodEnough(guess: Double, x: Double) =
-  abs(square(guess) - x) < 0.001
-\end{lstlisting}
+%----------
+%% def isGoodEnough(guess: Double, x: Double) =
+%%   abs(square(guess) - x) < 0.001
+%% \end{lstlisting}
 
 %% Finally, the \code{sqrt} function itself is defined by an application
 %% of \code{sqrtIter}.
-Finalmente, a própria função \code{sqrt} é definida como uma aplicação de
-\code{sqrtIter}.
-  
-\begin{lstlisting}
-def sqrt(x: Double) = sqrtIter(1.0, x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = sqrtIter(1.0, x)
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1064,13 +975,6 @@ def sqrt(x: Double) = sqrtIter(1.0, x)
 
 %% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
 %% \end{exercise}
-\begin{exercise} O teste \code{isGoodEnough} não é muito preciso para pequenos 
-números e podem levar a não terminação para números muito grandes (por que?).
-Crie uma versão diferente para \code{isGoodEnough} que não tenham esses problemas.
-\end{exercise}
-
-\begin{exercise} Simule a execução da expressão \code{sqrt(4)}.
-\end{exercise}
 %----------
 
 %----------
@@ -1082,33 +986,23 @@ Crie uma versão diferente para \code{isGoodEnough} que não tenham esses proble
 %% \code{improve} and \code{isGoodEnough}. The names of these functions
 %% are relevant only for the implementation of \code{sqrt}. We normally
 %% do not want users of \code{sqrt} to access these functions directly.
-\section{Aninhamento de Funções}
-
-A programação funcional encoraja a construção de muitas pequenas funções
-auxiliares. Nos últimos exemplos, a implementação de \code{sqrt} faz uso da
-funções auxiliares \code{sqrtIter}, \code{improve} e \code{isGoodEnough}.
-Os nomes destas funções são relevantes somente para a implementação de 
-\code{sqrt}. Normalmente não queremos que os usuários de \code{sqrt} acessem
-estas funções diretamente.  
 %----------
 
 %----------
 %% We can enforce this (and avoid name-space pollution) by including
 %% the helper functions within the calling function itself:
-Nós podemos reforçar isto (e evitar poluição de nomes) incluindo
-funções auxiliares dentro das próprias funções: 
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double, x: Double): Double =
-    if (isGoodEnough(guess, x)) guess
-    else sqrtIter(improve(guess, x), x)
-  def improve(guess: Double, x: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double, x: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0, x)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double, x: Double): Double =
+%%     if (isGoodEnough(guess, x)) guess
+%%     else sqrtIter(improve(guess, x), x)
+%%   def improve(guess: Double, x: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double, x: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0, x)
+%% }
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1117,11 +1011,6 @@ def sqrt(x: Double) = {
 %% result expression which defines its value.  The result expression may
 %% be preceded by auxiliary definitions, which are visible only in the
 %% block itself.
-Neste programa, as chaves \code{\{ ... \}} envolvem um {\em bloco}. 
-Blocos em Scala são eles mesmos expressões. Cada bloco termina com um
-expressão resultado o qual define seu valor. A expressão  resultado pode 
-ser precedida por definições auxiliares, as quais são visíveis somente no
-próprio bloco. 
 %----------
 
 %----------
@@ -1130,10 +1019,6 @@ próprio bloco.
 %% expression. However, a semicolon is inserted implicitly at the end of
 %% each line, unless one of the following conditions is
 %% true.
-Cada definição no bloco pode ser seguida para um ponto e vírgula, o qual 
-separa esta definição das definições subsequentes ou a expressão  resultado.
-Entretanto, um ponto e vírgula é inserido implicitamente ao final de cada linha,
-a não ser que uma das condições a seguir seja verdadeira.
 %----------
 
 %----------
@@ -1147,42 +1032,30 @@ a não ser que uma das condições a seguir seja verdadeira.
 %% Or we are inside parentheses \prog{$($...$)$} or brackets \prog{}, 
 %% because these cannot contain multiple statements anyway.
 %% \end{enumerate}
-\begin{enumerate}
-\item 
-Ou a linha em questão termina com uma palavra tal que um ponto ou um 
-operador infixo não são legais ao final da expressão.
-\item 
-Ou a próxima linha inicia com uma palavra que não pode iniciar uma expressão.
-\item
-Ou estamos dentro de parênteses \prog{$($...$)$} ou chaves \prog{}, porque 
-estes não podem conter multiplos comandos de qualquer modo.
-\end{enumerate}
 %----------
 
 %----------
 %% Therefore, the following are all legal:
-Entretanto, os seguintes são legais:
+%% \begin{lstlisting}
+%% def f(x: Int) = x + 1;
+%% f(1) + f(2)
 
-\begin{lstlisting}
-def f(x: Int) = x + 1;
-f(1) + f(2)
+%% def g1(x: Int) = x + 1
+%% g(1) + g(2)
 
-def g1(x: Int) = x + 1
-g(1) + g(2)
+%% def g2(x: Int) = {x + 1};  /* `;' mandatory */ g2(1) + g2(2)
 
-def g2(x: Int) = {x + 1};  /* `;' mandatório */ g2(1) + g2(2)
+%% def h1(x) = 
+%%   x + 
+%%   y
+%% h1(1) * h1(2)
 
-def h1(x) = 
-  x + 
-  y
-h1(1) * h1(2)
-
-def h2(x: Int) = (
-  x     // parênteses mandatório, senão um ponto e vírgula
-  + y   // será inserido após o `x'.
-)
-h2(1) / h2(2)
-\end{lstlisting}
+%% def h2(x: Int) = (
+%%   x     // parentheses mandatory, otherwise a semicolon
+%%   + y   // would be inserted after the `x'.
+%% )
+%% h2(1) / h2(2)
+%% \end{lstlisting}
 %----------
 
 %----------
@@ -1192,100 +1065,76 @@ h2(1) / h2(2)
 %% \code{sqrt} example. We need not pass \code{x} around as an additional parameter of
 %% the nested functions, since it is always visible in them as a
 %% parameter of the outer function \code{sqrt}. Here is the simplified code:
-Scala usa as regras usuais de escopo de bloco estruturado. Um nome definido em
-algum outro bloco é também visível em algum bloco interno, desde que não tenha
-sido redefinido lá. Esta regra nos permite simplificar nosso exemplo \code{sqrt}.
-Não precisamos passar \code{x} como parâmetro adicional de funções aninhadas, dado
-que está sempre visível nelas como um parâmetro da função externa \code{sqrt}.
-Aqui está o código simplificado:
-   
-\begin{lstlisting}
-def sqrt(x: Double) = {
-  def sqrtIter(guess: Double): Double =
-    if (isGoodEnough(guess)) guess
-    else sqrtIter(improve(guess))
-  def improve(guess: Double) =
-    (guess + x / guess) / 2
-  def isGoodEnough(guess: Double) =
-    abs(square(guess) - x) < 0.001
-  sqrtIter(1.0)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = {
+%%   def sqrtIter(guess: Double): Double =
+%%     if (isGoodEnough(guess)) guess
+%%     else sqrtIter(improve(guess))
+%%   def improve(guess: Double) =
+%%     (guess + x / guess) / 2
+%%   def isGoodEnough(guess: Double) =
+%%     abs(square(guess) - x) < 0.001
+%%   sqrtIter(1.0)
+%% }
+%% \end{lstlisting}
 %----------
 
 
-\section{Tail Recursion}
+%% \section{Tail Recursion}
 
-%%Consider the following function to compute the greatest common divisor
-%%of two given numbers.
-Considere a seguinte função para calcular o maior divisor comum entre
-dois números dados.
+%% Consider the following function to compute the greatest common divisor
+%% of two given numbers.
 
-\begin{lstlisting}
-def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def gcd(a: Int, b: Int): Int = if (b == 0) a else gcd(b, a % b)
+%% \end{lstlisting}
 
-%%Using our substitution model of function evaluation, 
-Usando nosso modelo de substituição da função de avaliação,
-\code{gcd(14, 21)} evaluates as follows:
+%% Using our substitution model of function evaluation, 
+%% \code{gcd(14, 21)} evaluates as follows:
 
-\begin{lstlisting}
-$\,\,$      gcd(14, 21)  
-$\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14 % 21)
-$\rightarrow\!$     gcd(21, 14)
-$\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
-$\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
-$\rightarrow\!$     gcd(14, 7)
-$\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
-$\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
-$\rightarrow\!$     gcd(7, 0)
-$\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
-$\rightarrow$ $\rightarrow$  7
-\end{lstlisting}
+%% \begin{lstlisting}
+%% $\,\,$      gcd(14, 21)  
+%% $\rightarrow\!$     if (21 == 0) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     if (false) 14 else gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14 % 21)
+%% $\rightarrow\!$     gcd(21, 14)
+%% $\rightarrow\!$     if (14 == 0) 21 else gcd(14, 21 % 14)
+%% $\rightarrow$ $\rightarrow$  gcd(14, 21 % 14)
+%% $\rightarrow\!$     gcd(14, 7)
+%% $\rightarrow\!$     if (7 == 0) 14 else gcd(7, 14 % 7)
+%% $\rightarrow$ $\rightarrow$  gcd(7, 14 % 7)
+%% $\rightarrow\!$     gcd(7, 0)
+%% $\rightarrow\!$     if (0 == 0) 7 else gcd(0, 7 % 0)
+%% $\rightarrow$ $\rightarrow$  7
+%% \end{lstlisting}
 
-%%Contrast this with the evaluation of another recursive function, 
-Contraste isto com a avaliação de uma outra função recursiva,
-\code{factorial}:
+%% Contrast this with the evaluation of another recursive function, 
+%% \code{factorial}:
 
-\begin{lstlisting}
-def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def factorial(n: Int): Int = if (n == 0) 1 else n * factorial(n - 1)
+%% \end{lstlisting}
 
-%%The application \code{factorial(5)} rewrites as follows:
-A aplicação de \code{factorial(5)} é reescrita como segue: 
-
-\begin{lstlisting}
-$\,\,\,$       factorial(5)
-$\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(5 - 1)
-$\rightarrow$      5 * factorial(4)
-$\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
-$\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
-$\rightarrow\ldots\rightarrow$  120
-\end{lstlisting}
-
-%----------
+%% The application \code{factorial(5)} rewrites as follows:
+%% \begin{lstlisting}
+%% $\,\,\,$       factorial(5)
+%% $\rightarrow$      if (5 == 0) 1 else 5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(5 - 1)
+%% $\rightarrow$      5 * factorial(4)
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * factorial(3))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * factorial(2)))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * factorial(1))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * factorial(0))))
+%% $\rightarrow\ldots\rightarrow$  5 * (4 * (3 * (2 * (1 * 1))))
+%% $\rightarrow\ldots\rightarrow$  120
+%% \end{lstlisting}
 %% There is an important difference between the two rewrite sequences:
 %% The terms in the rewrite sequence of \code{gcd} have again and again
 %% the same form. As evaluation proceeds, their size is bounded by a
 %% constant. By contrast, in the evaluation of factorial we get longer
 %% and longer chains of operands which are then multiplied in the last
 %% part of the evaluation sequence.
-Há uma importante diferença entre as duas sentenças reescritas:
-Os termos na sequência reescrita de \code{gcd} tem repetidamente a
-mesma forma. Conforme a avaliação prossegue, seu tamanho é limitado por
-uma constante. Diferentemente, na avaliação do fatorial obtemos cadeias
-cada vez mais longas de operandos que são então multiplicados na última
-parte da sequência de avaliação. 
-%----------
 
-
-%----------
 %% Even though actual implementations of Scala do not work by rewriting
 %% terms, they nevertheless should have the same space behavior as in the
 %% rewrite sequences. In the implementation of \code{gcd}, one notes that
@@ -1297,34 +1146,14 @@ parte da sequência de avaliação.
 %% instantiation of \code{gcd}, so that no new stack space is needed.
 %% Hence, tail recursive functions are iterative processes, which can be
 %% executed in constant space.
-Ainda que as atuais implementações de Scala não trabalhem reescrevendo
-termos, elas contudo devem ter o mesmo comportamento de espaço que nas
-sequências reescritas. Na implementação de \code{gcd}, nota-se que  a 
-chamada recursiva para \code{gcd} é a última ação realizada na avaliação 
-do seu corpo. Pode-se também dizer que \code{gcd} é uma recursão de cauda
-(tail-recursive). A última chamada numa função recursiva de cauda pode ser
-implementada por um salto ao início da função. Os argumentos dessa chamada 
-pode sobrescrever os parâmetros da atual instanciação de \code{gcd}, portanto 
-nenhum espaço na pilha é necessário. Consequentemente, funções recursivas de 
-cauda são processos iterativos, que podem ser executados em espaço constante.     
-%----------
 
-%----------
 %% By contrast, the recursive call in \code{factorial} is followed by a
 %% multiplication.  Hence, a new stack frame is allocated for the
 %% recursive instance of factorial, and is deallocated after that
 %% instance has finished. The given formulation of the factorial function
 %% is not tail-recursive; it needs space proportional to its input
 %% parameter for its execution.
-Em contraste, a chamada recursiva em \code{factorial} é seguida por uma 
-multiplicação. consequentemente, um novo espaço na pilha é alocado para a 
-instância recursiva de fatorial, e é desalocada após o término daquela 
-instância. A formulação dada para a função fatorial não é recursiva de cauda;
- precisa de espaço proporcional aos seus parâmetros de entrada para sua
-execução. 
-%----------
 
-%----------
 %% More generally, if the last action of a function is a call to another
 %% (possibly the same) function, only a single stack frame is needed for
 %% both functions. Such calls are called ``tail calls''. In principle,
@@ -1335,26 +1164,14 @@ execução.
 %% re-use the stack frame of a directly tail-recursive function whose
 %% last action is a call to itself.  Other tail calls might be optimized
 %% also, but one should not rely on this across implementations.
-Genericamente, se a última ação da função é uma chamada a outra função
-(possivelmente a mesma), apenas um único espaço na pilha é requerido para 
-ambas funções. Tais chamadas são denominadas ``tail call''. Em 
-princípio, tail calls sempre podem reutilizar o espaço da pilha da função 
-de chamada. Entretanto, alguns ambientes de execução (tais como Java VM) 
-carecem das primitivas para fazer um espaço de pilha reutilizável para 
-tail calls eficientes. A produção de uma implementação Scala de qualidade é,
-portanto, requerida somente para reutilizar o espaço de pilha de uma função 
-recursiva de cauda cuja última ação é chamar a si mesma. Outras chamadas de 
-cauda podem ser otimizadas também, mas não deve-se confiar nisso ao longo das
-implementações. 
-%----------
 
-\begin{exercise} Escreva uma implementação recursiva de cauda de 
-\code{factorial}.
-\end{exercise}
+%% \begin{exercise} Design a tail-recursive version of
+%% \code{factorial}.
+%% \end{exercise}
 
-
-%----------
 %% \chapter{\label{chap:first-class-funs}First-Class Functions}
+\chapter{\label{chap:first-class-funs}FunÃ§Ãµes na Primeira Classe}
+
 
 %% A function in Scala is a ``first-class value''. Like any other value,
 %% it may be passed as a parameter or returned as a result.  Functions
@@ -1363,142 +1180,93 @@ implementações.
 %% higher-order functions and shows how they provide a flexible mechanism
 %% for program composition.
 
- \chapter{\label{chap:first-class-funs}Funções de Primeira Classe}
-Uma função em Scala é um valor de primeira classe. Como qualquer outro valor, 
-pode ser passado como um parâmetro ou retornado como um resultado. Funções que 
-recebem outras funções como parâmetros ou as retornam como resultados são 
-denominadas funções de {\em alta ordem}. Este capítulo introduz funções de alta ordem 
-e mostra como elas fornecem um mecanismo flexível para a composição de programas.
-%----------
+Uma funÃ§Ã£o em Scala Ã© um valor ``valor de primeira classe''. Como qualquer
+outro valor, ele pode ser passado por parÃ¢metro ou retornado como um resultado.
+FunÃ§Ãµes que recebem outras funÃ§Ãµes como parÃ¢metros ou os retornem como resultados
+sÃ£o chamadas funÃ§Ãµes de ordem-alta e mostram como podem ser um mecanismo flexÃ­vel para
+a composiÃ§Ã£o de um programa.
+% Vinicius parei aqui
 
-%----------
+
 %% As a motivating example, consider the following three related tasks:
-Como um exemplo de motivação, considere as três tarefas relacionadas a seguir:
-\begin{enumerate}
-\item
-%%Write a function to sum all integers between two given numbers \code{a} and \code{b}:
-Escreva uma função que some todos os inteiros entre dois dados números, \code{a} e \code{b}:  
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int =
-  if (a > b) 0 else a + sumInts(a + 1, b)
-\end{lstlisting}
-%----------
-
-%----------
- \item 
+%% \begin{enumerate}
+%% \item
+%% Write a function to sum all integers between two given numbers \code{a} and \code{b}:
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int =
+%%   if (a > b) 0 else a + sumInts(a + 1, b)
+%% \end{lstlisting}
+%% \item 
 %% Write a function to sum the squares of all integers between two given numbers 
 %% \code{a} and \code{b}:
-Escreva uma função para somar os quadrados de todos os inteiros entre dois dados números, 
- \code{a} e \code{b}:
-
-\begin{lstlisting}
-def square(x: Int): Int = x * x
-def sumSquares(a: Int, b: Int): Int =
-  if (a > b) 0 else square(a) + sumSquares(a + 1, b)
-\end{lstlisting}
-\item
+%% \begin{lstlisting}
+%% def square(x: Int): Int = x * x
+%% def sumSquares(a: Int, b: Int): Int =
+%%   if (a > b) 0 else square(a) + sumSquares(a + 1, b)
+%% \end{lstlisting}
+%% \item
 %% Write a function to sum the powers $2^n$ of all integers $n$ between
 %% two given numbers \code{a} and \code{b}:
-Escreva uma função para somar as potências $2^n$ de todos os $n$ inteiros entre
-dois dados números \code{a} e \code{b}:  
-
-\begin{lstlisting}
-def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-def sumPowersOfTwo(a: Int, b: Int): Int =
-  if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
-\end{lstlisting}
-\end{enumerate}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+%% def sumPowersOfTwo(a: Int, b: Int): Int =
+%%   if (a > b) 0 else powerOfTwo(a) + sumPowersOfTwo(a + 1, b)
+%% \end{lstlisting}
+%% \end{enumerate}
 %% These functions are all instances of
 %% \(\sum^b_a f(n)\) for different values of $f$. 
 %% We can factor out the common pattern by defining a function \code{sum}:
-Estas funções são todas instâncias de \(\sum^b_a f(n)\) para diferentes valores de $x$.
-Podemos obter o padrão comum definindo uma função \code{sum}: 
-\begin{lstlisting}
-def sum(f: Int => Int, a: Int, b: Int): Int =
-  if (a > b) 0 else f(a) + sum(f, a + 1, b)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sum(f: Int => Int, a: Int, b: Int): Int =
+%%   if (a > b) 0 else f(a) + sum(f, a + 1, b)
+%% \end{lstlisting}
 %% The type \code{Int => Int} is the type of functions that
 %% take arguments of type \code{Int} and return results of type
 %% \code{Int}. So \code{sum} is a function which takes another function as
 %% a parameter. In other words, \code{sum} is a {\em higher-order}
 %% function.
-O tipo \code{Int => Int} é o tipo de funções que recebem argumentos do tipo
-\code{Int} e retornam resultados do tipo \code{Int}. Então \code{sum} é uma 
-função que recebe uma outra função como parâmetro. Em outras palavras, \code{sum}
-é uma função de {\em alta ordem}.     
-%----------
 
-%----------
 %% Using \code{sum}, we can formulate the three summing functions as
 %% follows.
-Usando \code{sum}, podemos formular as três funções de soma como segue: 
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum(id, a, b)
-def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
-def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
-\end{lstlisting}
-%%where
-onde 
-\begin{lstlisting}
-def id(x: Int): Int = x
-def square(x: Int): Int = x * x
-def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum(id, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum(square, a, b)
+%% def sumPowersOfTwo(a: Int, b: Int): Int = sum(powerOfTwo, a, b)
+%% \end{lstlisting}
+%% where
+%% \begin{lstlisting}
+%% def id(x: Int): Int = x
+%% def square(x: Int): Int = x * x
+%% def powerOfTwo(x: Int): Int = if (x == 0) 1 else 2 * powerOfTwo(x - 1)
+%% \end{lstlisting}
 
-%----------
 %% \section{Anonymous Functions}
 
 %% Parameterization by functions tends to create many small functions. In
 %% the previous example, we defined \code{id}, \code{square} and
 %% \code{power} as separate functions, so that they could be 
 %% passed as arguments to \code{sum}.
-\section{Funções Anônimas}
-Parametrização por funções tende a criar várias pequenas funções. No exemplo 
-anterior, definimos \code{id}, \code{square} e \code{power} como funções 
-separadas, de tal modo que pudessem ser passadas como argumentos para \code{sum}.    
-%----------
 
-%----------
 %% Instead of using named function definitions for these small argument
 %% functions, we can formulate them in a shorter way as {\em anonymous
 %% functions}. An anonymous function is an expression that evaluates to a
 %% function; the function is defined without giving it a name. As an
 %% example consider the anonymous square function:
-
-Ao invés de usarmos definições de funções nomeadas para estas pequenas funções 
-argumentos, podemos formulá-las de um modo abreviado como {\em funções anônimas}.
-Uma função anônima é uma expressão que é avaliada para uma função; a função é 
-definida sem receber um nome. Como exemplo considere a função anônima quadrado:
-\begin{lstlisting}
-  (x: Int) => x * x
-\end{lstlisting}
-%----------
-  
-%----------
+%% \begin{lstlisting}
+%%   (x: Int) => x * x
+%% \end{lstlisting}
 %% The part before the arrow `\code{=>}' are the parameters of the function,
 %% whereas the part following the `\code{=>}' is its body. 
 %% For instance, here is an anonymous function which multiples its two arguments.
-A parte anterior a flecha `\code{=>}' são os parâmetros da função, ao passo que a parte
-seguinte a `\code{=>}' é o seu corpo.
-Por exemplo, aqui está uma função anônima que multiplica seus dois argumentos.
-\begin{lstlisting}
-  (x: Int, y: Int) => x * y
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   (x: Int, y: Int) => x * y
+%% \end{lstlisting}
 %% Using anonymous functions, we can reformulate the first two summation
 %% functions without named auxiliary functions:
-Usando funções anônimas, podemos reformular as duas funções soma sem
-funções auxiliares nomeadas:
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
-def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum((x: Int) => x, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
+%% \end{lstlisting}
 %% Often, the Scala compiler can deduce the parameter type(s) from the
 %% context of the anonymous function in which case they can be omitted.
 %% For instance, in the case of \code{sumInts} or \code{sumSquares}, one
@@ -1506,20 +1274,11 @@ def sumSquares(a: Int, b: Int): Int = sum((x: Int) => x * x, a, b)
 %% function of type \code{Int => Int}.  Hence, the parameter type
 %% \code{Int} is redundant and may be omitted. If there is a single
 %% parameter without a type, we may also omit the parentheses around it:
-Frequentemente, o compilador Scala pode deduzir o tipo do parâmetro a partir
-do contexto da função anônima nos casos em que foram omitidos.
-Por exemplo, no caso de \code{sumInts} ou \code{sumSquares}, sabe-se a partir do 
-tipo de \code{sum} que o primeiro parâmetro deve ser uma função de tipo \code{Int => Int}.
-Consequentemente, o tipo do parâmetro \code{Int} é redundante e pode ser omitido. Se
-houver um único parâmetro sem um tipo, também podemos omitir os parâmetros a sua volta. 
-   
-\begin{lstlisting}
-def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
-def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def sumInts(a: Int, b: Int): Int = sum(x => x, a, b)
+%% def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
+%% \end{lstlisting}
 
-%----------
 %% Generally, the Scala term
 %% \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
 %% defines a function which maps its parameters
@@ -1528,30 +1287,17 @@ def sumSquares(a: Int, b: Int): Int = sum(x => x * x, a, b)
 %% functions are not essential language elements of Scala, as they can
 %% always be expressed in terms of named functions. Indeed, the 
 %% anonymous function
-Em geral, o termo em Scala 
- \code{(x}$_1$\code{: T}$_1$\code{, ..., x}$_n$\code{: T}$_n$\code{) => E} 
-define uma função que mapeia seus parâmetros \code{x}$_1$\code{, ..., x}$_n$
-ao resultado da expressão \code{E} (onde \code{E} pode referir-se a   
-\code{x}$_1$\code{, ..., x}$_n$). Funções anônimas não são elementos essenciais
-da linguagem Scala, dado que sempre podem ser expressos em termos de funções
-nomeadas. De fato, a função anônima 
-
-\begin{lstlisting}
-(x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
-\end{lstlisting}
+%% \begin{lstlisting}
+%% (x$_1$: T$_1$, ..., x$_n$: T$_n$) => E
+%% \end{lstlisting}
 %% is equivalent to the block
-é equivalente ao bloco
-\begin{lstlisting}
-{ def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
-\end{lstlisting}
+%% \begin{lstlisting}
+%% { def f (x$_1$: T$_1$, ..., x$_n$: T$_n$) = E ; f _ }
+%% \end{lstlisting}
 %% where \code{f} is fresh name which is used nowhere else in the program.
 %% We also say, anonymous functions are ``syntactic sugar''.
-onde \code{f} é um novo nome que não é utilizado em qualquer outro lugar do programa.
-Também dizemos que funções anônimas são ``syntactic sugar''. 
-%----------
 
-%----------
- \section{Currying}
+%% \section{Currying}
 
 %% The latest formulation of the summing functions is already quite
 %% compact. But we can do even better. Note that
@@ -1561,73 +1307,46 @@ Também dizemos que funções anônimas são ``syntactic sugar''.
 
 %% Let's try to rewrite \code{sum} so that it does not take the bounds
 %% \code{a} and \code{b} as parameters:
-
-A última formulação das funções de soma já são bem compactas. Mas 
-podemos fazer ainda melhor. Observe que \code{a} e \code{b} aparecem como 
-parâmetros e argumentos de cada função, mas não parecem tomar parte de 
-combinações interessantes. Há algum modo de nos livrarmos delas?
-
-Vamos tentar reescrever \code{sum} de tal modo que não receba os limites
-\code{a} e \code{b} como parâmetros:     
-
-\begin{lstlisting}
-def sum(f: Int => Int): (Int, Int) => Int = {
-  def sumF(a: Int, b: Int): Int =
-    if (a > b) 0 else f(a) + sumF(a + 1, b)
-  sumF
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def sum(f: Int => Int): (Int, Int) => Int = {
+%%   def sumF(a: Int, b: Int): Int =
+%%     if (a > b) 0 else f(a) + sumF(a + 1, b)
+%%   sumF
+%% }
+%% \end{lstlisting}
 %% In this formulation, \code{sum} is a function which returns another
 %% function, namely the specialized summing function \code{sumF}. This
 %% latter function does all the work; it takes the bounds \code{a} and
 %% \code{b} as parameters, applies \code{sum}'s function parameter \code{f} to all
 %% integers between them, and sums up the results. 
-Nessa formulação, \code{sum} é uma função que retorna uma outra função, especificamente
-a função especializada soma \code{sumF}. Esta última função realiza todo o trabalho; 
-recebe os limites \code{a} e \code{b} como parâmetros, aplica a função \code{f}, parâmetro
-de \code{sum}, a todos os inteiros entre eles, e soma os resultados.
-      
-%% Using this new formulation of \code{sum}, we can now define:
-Usando esta nova formulação de \code{sum}, podemos agora definir:
-\begin{lstlisting}
-def sumInts  =  sum(x => x)
-def sumSquares  =  sum(x => x * x)
-def sumPowersOfTwo  =  sum(powerOfTwo)
-\end{lstlisting}
-%% Or, equivalently, with value definitions:
-Ou, equivalentemente, com definições de valores:
-\begin{lstlisting}
-val sumInts  =  sum(x => x)
-val sumSquares  =  sum(x => x * x)
-val sumPowersOfTwo  =  sum(powerOfTwo)
-\end{lstlisting}
-%----------
 
-%----------
+%% Using this new formulation of \code{sum}, we can now define:
+%% \begin{lstlisting}
+%% def sumInts  =  sum(x => x)
+%% def sumSquares  =  sum(x => x * x)
+%% def sumPowersOfTwo  =  sum(powerOfTwo)
+%% \end{lstlisting}
+%% Or, equivalently, with value definitions:
+%% \begin{lstlisting}
+%% val sumInts  =  sum(x => x)
+%% val sumSquares  =  sum(x => x * x)
+%% val sumPowersOfTwo  =  sum(powerOfTwo)
+%% \end{lstlisting}
+
 %% \code{sumInts}, \code{sumSquares}, and \code{sumPowersOfTwo} can be
 %% applied like any other function. For instance,
- \code{sumInts}, \code{sumSquares}, e \code{sumPowersOfTwo} podem ser
-aplicados como qualquer outra função. Por exemplo,
-\begin{lstlisting}
-scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
-unnamed0: Int = 2096513
-\end{lstlisting}
+%% \begin{lstlisting}
+%% scala> sumSquares(1, 10) + sumPowersOfTwo(10, 20)
+%% unnamed0: Int = 2096513
+%% \end{lstlisting}
 %% How are function-returning functions applied? As an example, in the expression
-Como funções que retornam funções são aplicadas? Como exemplo, na expressão 
-\begin{lstlisting}
-sum(x => x * x)(1, 10) ,
-\end{lstlisting}
+%% \begin{lstlisting}
+%% sum(x => x * x)(1, 10) ,
+%% \end{lstlisting}
 %% the function \code{sum} is applied to the squaring function 
 %% \code{(x => x * x)}. The resulting function is then 
 %% applied to the second argument list, \code{(1, 10)}.
-a função \code{sum} é aplicada a função quadrada \code{(x => x * x)}. 
-O função resultante é então aplicada ao segunda lista de argumentos, \code{(1, 10)}.   
-%----------
 
-%----------
 %% This notation is possible because function application associates to the left.
 %% That is, if $\mbox{args}_1$ and $\mbox{args}_2$ are argument lists, then 
 %% \bda{lcl}
@@ -1636,263 +1355,182 @@ O função resultante é então aplicada ao segunda lista de argumentos, \code{(
 %% In our example, \code{sum(x => x * x)(1, 10)} is equivalent to the
 %% following expression:
 %% \code{(sum(x => x * x))(1, 10)}.
-Essa notação é possível porque aplicações de funções são associativas à esquerda.
-Ou seja, se $\mbox{args}_1$ e $\mbox{args}_2$ são listas de argumentos, então 
-\bda{lcl}
-f(\mbox{args}_1)(\mbox{args}_2) & \ \ \mbox{é equivalente a}\ \ & (f(\mbox{args}_1))(\mbox{args}_2)
-\eda
-Em nosso exemplo, \code{sum(x => x * x)(1, 10)} é equivalente a seguinte expressão:
-\code{(sum(x => x * x))(1, 10)}.
-%----------
 
-%----------
 %% The style of function-returning functions is so useful that Scala has
 %% special syntax for it. For instance, the next definition of \code{sum}
 %% is equivalent to the previous one, but is shorter:
-O estilo ``funções que retornam funções'' é tão útil que Scala tem sintaxe
-especial para ele. Por exemplo, a próxima definição de \code{sum} é equivalente
-a anterior, porém mais curta: 
-\begin{lstlisting}
-def sum(f: Int => Int)(a: Int, b: Int): Int =
-  if (a > b) 0 else f(a) + sum(f)(a + 1, b)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sum(f: Int => Int)(a: Int, b: Int): Int =
+%%   if (a > b) 0 else f(a) + sum(f)(a + 1, b)
+%% \end{lstlisting}
 %% Generally, a curried function definition 
-Genericamente, uma definição de função currificada
-\begin{lstlisting}
-def f (args$_1$) ... (args$_n$) = E
-\end{lstlisting}
-%%where $n > 1$ expands to
-onde $n > 1$ expande para 
-\begin{lstlisting}
-def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
-\end{lstlisting}
-%%where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
-onde \code{g} é um novo identificador. Ou, menor, usando uma função anônima: 
-\begin{lstlisting}
-def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
-\end{lstlisting}
-%%Performing this step $n$ times yields that
-Realizando este passo $n$ vezes dá aquela 
-\begin{lstlisting}
-def f (args$_1$) ... (args$_n$) = E
-\end{lstlisting}
-%%is equivalent to
-é equivalente a 
-\begin{lstlisting}
-def f = (args$_1$) => ... => (args$_n$) => E .
-\end{lstlisting}
-%%Or, equivalently, using a value definition:
-Ou, equivalentemente, usando uma definição valor:
-\begin{lstlisting}
-val f = (args$_1$) => ... => (args$_n$) => E .
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_n$) = E
+%% \end{lstlisting}
+%% where $n > 1$ expands to
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_{n-1}$) = { def g (args$_n$) = E ; g }
+%% \end{lstlisting}
+%% where \code{g} is a fresh identifier. Or, shorter, using an anonymous function:
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_{n-1}$) = ( args$_n$ ) => E .
+%% \end{lstlisting}
+%% Performing this step $n$ times yields that
+%% \begin{lstlisting}
+%% def f (args$_1$) ... (args$_n$) = E
+%% \end{lstlisting}
+%% is equivalent to
+%% \begin{lstlisting}
+%% def f = (args$_1$) => ... => (args$_n$) => E .
+%% \end{lstlisting}
+%% Or, equivalently, using a value definition:
+%% \begin{lstlisting}
+%% val f = (args$_1$) => ... => (args$_n$) => E .
+%% \end{lstlisting}
 %% This style of function definition and application is called {\em
 %% currying} after its promoter, Haskell B.\ Curry, a logician of the
 %% 20th century, even though the idea goes back further to Moses
 %% Sch\"onfinkel and Gottlob Frege.
-Este estilo de definição de função e aplicação é chamado {\em currificado}
-depois que seu divulgador, Haskell B.\ Curry, um lógico do século $20$, mesmo 
-que a idéia nos leve de volta a Moses Sch\"onfinkel e Gottlob Frege.
-%----------
 
-%----------
 %% The type of a function-returning function is expressed analogously to
 %% its parameter list. Taking the last formulation of \code{sum} as an example,
 %% the type of \code{sum} is \code{(Int => Int) => (Int, Int) => Int}.
 %% This is possible because function types associate to the right. I.e.
-O tipo de uma função que retorna função é expresso de modo análogo a sua lista
-de parâmetros. Tomando a última formulação de \code{sum} como exemplo, o tipo 
-para \code{sum} é \code{(Int => Int) => (Int, Int) => Int}.
-Isso é possível porque tipos de funções são associativos à direita. Ou seja, 
-\begin{lstlisting}
-T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% T$_1$ => T$_2$ => T$_3$       $\mbox{is equivalent to}$     T$_1$ => (T$_2$ => T$_3$)
+%% \end{lstlisting}
 
-%----------
-\begin{exercise}
+
+%% \begin{exercise}
 %% 1. The \code{sum} function uses a linear recursion. Can you write a
 %% tail-recursive one by filling in the ??'s?
-1. A função \code{sum} usa uma recursiva linear. Você poderia alterá-la
-para uma função recursiva de cauda, preenchendo as ?? abaixo?  
-\begin{lstlisting}
-def sum(f: Int => Int)(a: Int, b: Int): Int = {
-  def iter(a: Int, result: Int): Int = {
-    if (??) ??
-    else iter(??, ??)
-  }
-  iter(??, ??)
-}
-\end{lstlisting}
-\end{exercise}
-%----------
 
-%----------
-\begin{exercise}
+%% \begin{lstlisting}
+%% def sum(f: Int => Int)(a: Int, b: Int): Int = {
+%%   def iter(a: Int, result: Int): Int = {
+%%     if (??) ??
+%%     else iter(??, ??)
+%%   }
+%%   iter(??, ??)
+%% }
+%% \end{lstlisting}
+%% \end{exercise}
+
+%% \begin{exercise}
 %% Write a function \code{product} that computes the product of the
 %% values of functions at points over a given range.
-Escreva uma função \code{produto} que computa o produto de valores de
-funções em pontos sobre um dado intervalo.  
-\end{exercise}
+%% \end{exercise}
 
-\begin{exercise}
+%% \begin{exercise}
 %% Write \code{factorial} in terms of \code{product}.
-Escreva \code{fatorial} em termos de \code{produto}.  
-\end{exercise}
+%% \end{exercise}
 
-\begin{exercise}
+%% \begin{exercise}
 %% Can you write an even more general function which generalizes both
 %% \code{sum} and \code{product}?
-Escreva uma função ainda mais genérica que generaliza ambos \code{sum} e \code{produto}.  
-\end{exercise}
-%----------
+%% \end{exercise}
 
-%----------
 %% \section{Example: Finding Fixed Points of Functions}
 
 %% A number \code{x} is called a {\em fixed point} of a function \code{f} if
-\section{Exemplo: Encontrando Pontos Fixos de Funções}
-
-Um número \code{x} é chamado um {\em ponto fixo} de uma função \code{f} se  
-\begin{lstlisting}
-f(x) = x .
-\end{lstlisting}
+%% \begin{lstlisting}
+%% f(x) = x .
+%% \end{lstlisting}
 %% For some functions \code{f} we can locate the fixed point by beginning
 %% with an initial guess and then applying \code{f} repeatedly, until the
 %% value does not change anymore (or the change is within a small
 %% tolerance). This is possible if the sequence
-Para algumas funções \code{f} podemos encontrar os pontos fixos iniciando
-com um palpite inicial e então aplicando \code{f} repetidamente, até que o valor 
-não mude mais (ou a mudança seja tolerável). Isso é possível na sequência  
-\begin{lstlisting}
-x, f(x), f(f(x)), f(f(f(x))), ...
-\end{lstlisting}
-%%converges to fixed point of $f$. This idea is captured in
-%%the following ``fixed-point finding function'':
-converge para pontos fixos de $f$. Essa idéia é captada na ``função achadora 
-de pontos fixos'' a seguir:
-\begin{lstlisting}
-val tolerance = 0.0001
-def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
-def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-  def iterate(guess: Double): Double = {
-    val next = f(guess)
-    if (isCloseEnough(guess, next)) next
-    else iterate(next)
-  }
-  iterate(firstGuess)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% x, f(x), f(f(x)), f(f(f(x))), ...
+%% \end{lstlisting}
+%% converges to fixed point of $f$. This idea is captured in
+%% the following ``fixed-point finding function'':
+%% \begin{lstlisting}
+%% val tolerance = 0.0001
+%% def isCloseEnough(x: Double, y: Double) = abs((x - y) / x) < tolerance
+%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+%%   def iterate(guess: Double): Double = {
+%%     val next = f(guess)
+%%     if (isCloseEnough(guess, next)) next
+%%     else iterate(next)
+%%   }
+%%   iterate(firstGuess)
+%% }
+%% \end{lstlisting}
 %% We now apply this idea in a reformulation of the square root function.
 %% Let's start with a specification of \code{sqrt}:
-Agora aplicaremos esta idéia na reformulação da função raiz quadrada.
-Vamos começar pela especificação de \code{sqrt}:  
-\begin{lstlisting}
-sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
-         =  $\mbox{the {\sl y} such that}$  y = x / y
-\end{lstlisting}
-
+%% \begin{lstlisting}
+%% sqrt(x)  =  $\mbox{the {\sl y} such that}$  y * y = x
+%%          =  $\mbox{the {\sl y} such that}$  y = x / y
+%% \end{lstlisting}
 %% Hence, \code{sqrt(x)} is a fixed point of the function \code{y => x / y}.
 %% This suggests that \code{sqrt(x)} can be computed by fixed point iteration:
-Consequentemente, \code{sqrt(x)} é um ponto fixo da função \code{y => x / y}.
-Isso sugere que \code{sqrt(x)} pode ser computado por uma iteração de ponto fixo: 
-\begin{lstlisting}
-def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: double) = fixedPoint(y => x / y)(1.0)
+%% \end{lstlisting}
 %% But if we try this, we find that the computation does not
 %% converge. Let's instrument the fixed point function with a print
 %% statement which keeps track of the current \code{guess} value:
-Mas se tentarmos isso, percebemos que aquela computação não converge. 
-Vamos agregar à função de ponto fixo um comando print que mostra o 
-valor corrente de \code{guess}: 
-\begin{lstlisting}
-def fixedPoint(f: Double => Double)(firstGuess: Double) = {
-  def iterate(guess: Double): Double = {
-    val next = f(guess)
-    println(next)
-    if (isCloseEnough(guess, next)) next
-    else iterate(next)
-  }
-  iterate(firstGuess)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def fixedPoint(f: Double => Double)(firstGuess: Double) = {
+%%   def iterate(guess: Double): Double = {
+%%     val next = f(guess)
+%%     println(next)
+%%     if (isCloseEnough(guess, next)) next
+%%     else iterate(next)
+%%   }
+%%   iterate(firstGuess)
+%% }
+%% \end{lstlisting}
 %% Then, \code{sqrt(2)} yields:
-Então, \code{sqrt(2)} dá: 
-\begin{lstlisting}
-  2.0
-  1.0
-  2.0
-  1.0
-  2.0
-  ...
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%%   2.0
+%%   1.0
+%%   2.0
+%%   1.0
+%%   2.0
+%%   ...
+%% \end{lstlisting}
 %% One way to control such oscillations is to prevent the guess from changing too much. 
 %% This can be achieved by {\em averaging} successive values of the original sequence:
-Um modo de controlar tais oscilações é prevenir guess de mudar muito.
-Isso pode ser obtido pela média (função {\em averaging}) de sucessivos valores da sequência 
-original:
-\begin{lstlisting}
-scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
-sqrt: (Double)Double
+%% \begin{lstlisting}
+%% scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
+%% sqrt: (Double)Double
 
-scala> sqrt(2.0)
-  1.5
-  1.4166666666666665
-  1.4142156862745097
-  1.4142135623746899
-  1.4142135623746899
-\end{lstlisting}
+%% scala> sqrt(2.0)
+%%   1.5
+%%   1.4166666666666665
+%%   1.4142156862745097
+%%   1.4142135623746899
+%%   1.4142135623746899
+%% \end{lstlisting}
 %% In fact, expanding the \code{fixedPoint} function yields exactly our 
 %% previous definition of fixed point from Section~\ref{sec:sqrt}.
-De fato, expandindo a função \code{fixedPoint} dá exatamente nossa prévia
-definição de ponto fixo da Seção~\ref{sec:sqrt}.
+
 %% The previous examples showed that the expressive power of a language
 %% is considerably enhanced if functions can be passed as arguments.  The
 %% next example shows that functions which return functions can also be
 %% very useful.
-Os exemplos anteriores mostraram que o poder de expressividade de uma linguagem 
-é consideravelmente aumentado se funções puderem ser passadas como argumentos.
-O próximo exemplo mostra que funções que retornam funções também podem ser
-muito úteis.
-%----------
 
-%----------
 %% Consider again fixed point iterations. We started with the observation
 %% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
 %% Then we made the iteration converge by averaging successive values.
 %% This technique of {\em average damping} is so general that it
 %% can be wrapped in another function.
-Considere novamente iterações de ponto fixo. Começamos observando que 
-$\sqrt(x)$ é um ponto fixo da função \code{y => x / y}. Então fazemos
-a iteração convergir tirando a média de sucessivos valores. Essa técnica
-de {\em amortecimento da média} é tão genérica que pode ser denotada
-em outra função.
-\begin{lstlisting}
-def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def averageDamp(f: Double => Double)(x: Double) = (x + f(x)) / 2
+%% \end{lstlisting}
 %% Using \code{averageDamp}, we can reformulate the square root function
 %% as follows.
-Usando \code{averageDamp}, podemos reformular a função da raiz quadrada
-como segue. 
-\begin{lstlisting}
-def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sqrt(x: Double) = fixedPoint(averageDamp(y => x/y))(1.0)
+%% \end{lstlisting}
 %% This expresses the elements of the algorithm as clearly as possible.
-Isto expressa os elementos do algoritmo tão claramente quanto possível.
-\begin{exercise} 
-%%Write a function for cube roots using \code{fixedPoint} and 
-%% \code{averageDamp}.
-Escreva uma função para a raiz cúbica usando \code{fixedPoint} e \code{averageDamp}.  
-\end{exercise}
-%----------
 
-%----------
+%% \begin{exercise} Write a function for cube roots using \code{fixedPoint} and 
+%% \code{averageDamp}.
+%% \end{exercise}
+
 %% \section{Summary}
 
 %% We have seen in the previous chapter that functions are essential
@@ -1904,19 +1542,9 @@ Escreva uma função para a raiz cúbica usando \code{fixedPoint} e \code{averag
 %% reuse. The highest possible level of abstraction is not always the
 %% best, but it is important to know abstraction techniques, so that one
 %% can use abstractions where appropriate.
-Vimos no capítulo anterior que funções são abstrações essenciais porque 
-nos permitem introduzir métodos genéricos de computação como explícitos,
-elementos nomeados em nossa linguagem de programação. O presente capítulo
-mostrou que tais abstrações podem ser combinados por funções de alta ordem
-para criar mais abstrações. Como programadores, devemos procurar por oportunidades 
-de reuso e abstração. O mais alto nível possível de abstração nem sempre é 
-o melhor, mas é importante saber técnicas de abstração, de modo que possamos
-usá-las quando apropriado. 
-%----------
 
-%----------
 %% \section{Language Elements Seen So Far}
-\section{Elementos da Linguagem Vistos Até Aqui}
+
 %% Chapters~\ref{chap:simple-funs} and \ref{chap:first-class-funs} have
 %% covered Scala's language elements to express expressions and types
 %% comprising of primitive data and functions.  The context-free syntax
@@ -1924,59 +1552,44 @@ usá-las quando apropriado.
 %% form, where `\code{|}' denotes alternatives, \code{[...]} denotes
 %% option (0 or 1 occurrence), and \lstinline@{...}@ denotes repetition
 %% (0 or more occurrences).
- Os capítulos ~\ref{chap:simple-funs} e \ref{chap:first-class-funs} trataram
-elementos da linguagem Scala para expressar tipos e expressões relacionados a
-tipos primitivos e funções. A sintaxe livre de contexto desses elementos da
-linguagem são dados abaixo em formato Backus-Naur estendido, onde `\code{|}'
-denotam alternativas, \code{[...]} denotam opção  (0 ou 1 ocorrência), e  
-\lstinline@{...}@ denotam (0 ou mais ocorrências). 
+
 %% \subsection*{Characters}
-\subsection*{Caracteres}
+
 %% Scala programs are sequences of (Unicode) characters. We distinguish the
 %% following character sets:
-Programas em Scala são sequência de caracteres (Unicode). Distinguimos os
-seguintes conjuntos de caracteres.
- \begin{itemize}
- \item
+%% \begin{itemize}
+%% \item
 %% whitespace, such as `\code{ }', tabulator, or newline characters,
-espaço em branco, tal como `\code{ }', tabulação, ou caracter de mudança de linha (newline), 
- \item
+%% \item
 %% letters `\code{a}' to `\code{z}', `\code{A}' to `\code{Z}',
-letras `\code{a}' a `\code{z}', `\code{A}' a `\code{Z}',    
- \item
+%% \item
 %% digits \code{`0'} to `\code{9}',
-digitos `\code{0}' a `\code{9}',   
- \item
+%% \item
 %% the delimiter characters
-caracteres delimitadores
- \begin{lstlisting}
- .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
- \end{lstlisting}
- \item
+
+%% \begin{lstlisting}
+%% .    ,    ;    (    )    {    }    [    ]    \    $\mbox{\tt "}$    '
+%% \end{lstlisting}
+
+%% \item
 %% operator characters, such as `\code{#}' `\code{+}',
 %% `\code{:}'. Essentially, these are printable characters which are
 %% in none of the character sets above.
-caracteres operadores, tal como `\code{#}', `\code{+}' e `\code{:}'.
-Essencialmente, há caracteres imprimíveis que não estão em nenhum dos 
-conjuntos de caracteres acima.   
- \end{itemize}
+%% \end{itemize}
 
 %% \subsection*{Lexemes:}
-\subsection*{Lexemas:}
 
-\begin{lstlisting}
-ident    =  letter {letter | digit}
-         |  operator { operator }
-         |  ident '_' ident
-literal  =  $\mbox{``como em Java''}$
-\end{lstlisting}
+%% \begin{lstlisting}
+%% ident    =  letter {letter | digit}
+%%          |  operator { operator }
+%%          |  ident '_' ident
+%% literal  =  $\mbox{``as in Java''}$
+%% \end{lstlisting}
 
 %% Literals are as in Java. They define numbers, characters, strings, or
 %% boolean values.  Examples of literals as \code{0}, \code{1.0e10}, \code{'x'},
 %% \code{"he said \"hi!\""}, or \code{true}.
-Literais são como em Java. Eles definem números, caracteres, cadeias de caracteres, ou 
-valores boleanos. Exemplos de literais tais como \code{0}, \code{1.0e10}, \code{'x'},
-\code{"ele disse \"oi!\""}, ou \code{true}.
+
 %% Identifiers can be of two forms. They either start with a letter,
 %% which is followed by a (possibly empty) sequence of letters or
 %% symbols, or they start with an operator character, which is followed
@@ -1984,120 +1597,87 @@ valores boleanos. Exemplos de literais tais como \code{0}, \code{1.0e10}, \code{
 %% identifiers may contain underscore characters `\code{_}'. Furthermore,
 %% an underscore character may be followed by either sort of
 %% identifier. Hence, the following are all legal identifiers:
-Identificadores podem ter duas formas. Eles ou iniciam por uma letra, que é 
-seguida por uma sequência (possivelmente vazia) de letras ou símbolos, ou podem 
-iniciar com um caracter operador, seguido por uma sequência (possivelmente vazia) de
-caracteres operadores. Ambas as formas podem conter caracteres ``underscore'' `\code{_}'.
-Além disso, um caracter underscore pode ser seguido por quaisquer identificadores.
-Consequentemente, todos a seguir são identificadores legais:  
- \begin{lstlisting}
- x     Room10a     +     --     foldl_:     +_vector
- \end{lstlisting}
+%% \begin{lstlisting}
+%% x     Room10a     +     --     foldl_:     +_vector
+%% \end{lstlisting}
 %% It follows from this rule that subsequent operator-identifiers need to
 %% be separated by whitespace. For instance, the input
 %% \code{x+-y} is parsed as the three token sequence \code{x}, \code{+-},
 %% \code{y}. If we want to express the sum of \code{x} with the
 %% negated value of \code{y}, we need to add at least one space,
 %% e.g. \code{x+ -y}.
-Segue desta regra que identificadores operadores subsequentes precisam ser
-separados por espaço em branco. Por exemplo, a entrada \code{x+-y} é entendida 
-como a sequência de três ``tokens'' \code{x}, \code{+-} e \code{y}. Se
-desejamos expressar a soma de \code{x} com o valor negativo de \code{y}, 
-precisamos acrescentar no mínimo um espaço, ou seja, \code{x+ -y}.      
-%----------
 
-%----------
 %% The \verb@$@ character is reserved for compiler-generated
 %% identifiers; it should not be used in source programs. %$
-O caracter \verb@$@ é reservado para identificadores gerados
-pelo compilador; não devem ser usados em programas fontes. %$ 
 
 %% The following are reserved words, they may not be used as identifiers:
-Os seguintes são palavras reservadas, e não devem ser usadas como identificadores:
-\begin{lstlisting}
-abstract    case        catch       class       def    
-do          else        extends     false       final    
-finally     for         if          implicit    import      
-match       new         null        object      override    
-package     private     protected   requires    return      
-sealed      super       this        throw       trait
-try         true        type        val         var         
-while       with        yield
-_    :    =    =>    <-    <:    <%     >:    #    @
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% abstract    case        catch       class       def    
+%% do          else        extends     false       final    
+%% finally     for         if          implicit    import      
+%% match       new         null        object      override    
+%% package     private     protected   requires    return      
+%% sealed      super       this        throw       trait
+%% try         true        type        val         var         
+%% while       with        yield
+%% _    :    =    =>    <-    <:    <%     >:    #    @
+%% \end{lstlisting}
 
-%----------
 %% \subsection*{Types:}
-\subsection*{Types:}
 
-\begin{lstlisting}
-Type          =  SimpleType | FunctionType
-FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
-SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
-                 Boolean | Unit | String
-Types         =  Type {`,' Type}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% Type          =  SimpleType | FunctionType
+%% FunctionType  =  SimpleType '=>' Type | '(' [Types] ')' '=>' Type
+%% SimpleType    =  Byte | Short | Char | Int | Long | Float | Double |
+%%                  Boolean | Unit | String
+%% Types         =  Type {`,' Type}
+%% \end{lstlisting}
 
 %% Types can be:
-Tipos podem ser:
- \begin{itemize}
- \item tipos numéricos \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (com em Java),
- \item o tipo \code{Boolean} com valores  \code{true} e \code{false},
- \item o tipo \code{Unit} com o único valor  \lstinline@()@,
- \item o tipo \code{String},
- \item tipos função, tal como  \code{(Int, Int) => Int} ou \code{String => Int => String}.
- \end{itemize}
-%----------
+%% \begin{itemize}
+%% \item number types \code{Byte}, \code{Short}, \code{Char}, \code{Int}, \code{Long}, \code{Float} and \code{Double} (these are as in Java),
+%% \item the type \code{Boolean} with values \code{true} and \code{false},
+%% \item the type \code{Unit} with the only value \lstinline@()@,
+%% \item the type \code{String},
+%% \item function types such as \code{(Int, Int) => Int} or \code{String => Int => String}.
+%% \end{itemize}
 
-%----------
 %% \subsection*{Expressions:}
- \subsection*{Expressões:}
-\begin{lstlisting}
-Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
-InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
-Operator     = ident
-PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
-SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
-FunctionExpr = (Bindings | Id) '=>' Expr
-Bindings     = `(' Binding {`,' Binding} `)'
-Binding      = ident [':' Type]
-Block        = '{' {Def ';'} Expr '}'
-\end{lstlisting}
+
+%% \begin{lstlisting}
+%% Expr         = InfixExpr | FunctionExpr | if '(' Expr ')' Expr else Expr
+%% InfixExpr    = PrefixExpr | InfixExpr Operator InfixExpr
+%% Operator     = ident
+%% PrefixExpr   = ['+' | '-' | '!' | '~' ] SimpleExpr
+%% SimpleExpr   = ident | literal | SimpleExpr '.' ident | Block
+%% FunctionExpr = (Bindings | Id) '=>' Expr
+%% Bindings     = `(' Binding {`,' Binding} `)'
+%% Binding      = ident [':' Type]
+%% Block        = '{' {Def ';'} Expr '}'
+%% \end{lstlisting}
 
 %% Expressions can be:
-Expressões podem ser:
- \begin{itemize}
- \item
+%% \begin{itemize}
+%% \item
 %% identifiers such as \code{x}, \code{isGoodEnough}, \code{*}, or \code{+-},
-identificadores tais como \code{x}, \code{isGoodEnough}, \code{*}, ou \code{+-},
- \item
+%% \item
 %% literals, such as \code{0}, \code{1.0}, or \code{"abc"},
-literais, tais como \code{0}, \code{1.0}, ou \code{"abc"},
- \item
+%% \item
 %% field and method selections, such as \code{System.out.println},
-Seleções de campo e método, tal como \code{System.out.println},
- \item
-%% function applications, such as \code{sqrt(x)},
-aplicações de função, tal como \code{sqrt(x)},
- \item
+%% \item
+%% function applications, such as \code{sqrt(x)}, 
+%% \item
 %% operator applications, such as \code{-x} or \code{y + x},
-aplicações de operador, tais como \code{-x} ou \code{y + x},
- \item
+%% \item
 %% conditionals, such as \code{if (x < 0) -x else x},
-condicionais, tal como \code{if (x < 0) -x else x},
- \item
+%% \item
 %% blocks, such as \lstinline@{ val x = abs(y) ; x * 2 }@,
-blocos, tal como \lstinline@{ val x = abs(y) ; x * 2 }@,
- \item
+%% \item
 %% anonymous functions, such as \code{x => x + 1} or \code{(x: Int, y: Int) => x + y}.
-funções anônimas, tais como \code{x => x + 1} ou \code{(x: Int, y: Int) => x + y}.
- \end{itemize}
-%----------
+%% \end{itemize}
 
-%----------
-%% \subsection*{Definitions}:
-\subsection*{Definições:}
+%% \subsection*{Definitions:}
+
 \begin{lstlisting}
 Def          =  FunDef  |  ValDef
 FunDef       =  'def' ident {'(' [Parameters] ')'} [':' Type] '=' Expr
@@ -2105,26 +1685,19 @@ ValDef       =  'val' ident [':' Type] '=' Expr
 Parameters   =  Parameter {',' Parameter}
 Parameter    =  ident ':' ['=>'] Type
 \end{lstlisting}
-%%Definitions can be:
-Definições podem ser:
+Definitions can be:
 \begin{itemize}
 \item
-%%function definitions such as \code{def square(x: Int): Int = x * x},
-definições de função tal como \code{def square(x: Int): Int = x * x},
+function definitions such as \code{def square(x: Int): Int = x * x},
 \item
-%%value definitions such as \code{val y = square(2)}.
-definições de valor tal como \code{val y = square(2)}.
+value definitions such as \code{val y = square(2)}.
 \end{itemize}
-%----------
 
-%----------
 \chapter{Classes and Objects}
 \label{chap:classes}
 
 %% Scala does not have a built-in type of rational numbers, but it is
 %% easy to define one, using a class. Here's a possible implementation.
-Scala não tem um tipo primitivo para números racionais, mas é fácil 
-definir um, usando uma classe. Aqui está uma possível implementação.
 
 \begin{lstlisting}
 class Rational(n: Int, d: Int) {
@@ -2158,15 +1731,6 @@ class Rational(n: Int, d: Int) {
 %% operation. The left operand of the operation is always the rational
 %% number of which the method is a member.
 
-Isso define \code{Rational} como uma classe que recebe dois argumentos 
-construtores \code{n} e \code{d}, contendo as partes numéricas do numerador
-e denominador. A classe provê campos que retornam estas partes, bem como
-métodos para a aritmética sobre números racionais. Cada método aritmético 
-recebe como parâmetro o operando direito da operação. O operando esquerdo
-da operação sempre é o número racional do método cujo é membro.   
-%----------
-
-%----------
 %% \paragraph{Private members}
 %% The implementation of rational numbers defines a private method
 %% \code{gcd} which computes the greatest common denominator of two
@@ -2176,41 +1740,23 @@ da operação sempre é o número racional do método cujo é membro.
 %% the class to eliminate common factors in the constructor arguments in
 %% order to ensure that numerator and denominator are always in
 %% normalized form.
-\paragraph{Membros Privados}
-A implementação dos números racionais define um método privado \code{gcd} que 
-computa o maior denominador comum de dois inteiros, bem como um campo
-privado \code{g} que contém o \code{gcd} dos argumentos construtores. Esses
-membros são inacessíveis de fora da classe \code{Rational}. São usados na 
-implementação da classe para eliminar fatores comuns nos argumentos construtores
-para garantir que o numerador e o denominador estejam sempre em forma normalizada.    
-%----------
 
-%----------
 %% \paragraph{Creating and Accessing Objects}
 %% As an example of how rational numbers can be used, here's a program
 %% that prints the sum of all numbers $1/i$ where $i$ ranges from 1 to 10.
-\paragraph{Criando e Acessando Objetos}
-Como um exemplo de como os números racionais podem ser usados, aqui está um programa 
-que imprime a soma de todos os números $1/i$ onde $i$ está no intervalo de 1 a 10. 
-\begin{lstlisting}
-var i = 1
-var x = new Rational(0, 1)
-while (i <= 10) {
-  x += new Rational(1, i)
-  i += 1
-}
-println("" + x.numer + "/" + x.denom)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% var i = 1
+%% var x = new Rational(0, 1)
+%% while (i <= 10) {
+%%   x += new Rational(1, i)
+%%   i += 1
+%% }
+%% println("" + x.numer + "/" + x.denom)
+%% \end{lstlisting}
 %% The \code{+} takes as left operand a string and as right operand a
 %% value of arbitrary type. It returns the result of converting its right
 %% operand to a string and appending it to its left operand. 
-O \code{+} recebe como operando esquerdo uma cadeia de caracteres e como 
-operando direito um valor de tipo arbitrário. Retorna o resultado de 
-converter seu operando direito em uma cadeia de caracteres e concatená-la 
-a seu operando esquerdo.   
-%----------
-
-%----------
+  
 %% \paragraph{Inheritance and Overriding}
 %% Every class in Scala has a superclass which it extends.  
 %% \comment{Excepted is
@@ -2221,104 +1767,63 @@ a seu operando esquerdo.
 %% \code{scala.AnyRef} is implicitly assumed (for Java implementations,
 %% this type is an alias for \code{java.lang.Object}. For instance, class
 %% \code{Rational} could equivalently be defined as
-\paragraph{Herança e Sobrecarga}
-Cada classe em Scala tem uma superclasse que ela estende.
-\comment{A exceção é a classe \code{Object}, que não possui superclasse, e
-que é indiretamente estendida para cada outra classe.}
-Se uma classe não menciona sua superclasse em sua definição, o tipo básico 
-\code{scala.AnyRef} é implicitamente assumido (para implementações Java, este
-tipo é um apelido (alias) para \code{java.lang.Object}. Por exemplo, a classe 
-\code{Rational} pode ser equivalentemente definida como      
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // como antes
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%% }
+%% \end{lstlisting}
 %% A class inherits all members from its superclass. It may also redefine
 %% (or: {\em override}) some inherited members. For instance, class
 %% \code{java.lang.Object} defines
 %% a method
 %% \code{toString} which returns a representation of the object as a string:
-Uma classe herda todos os membros de sua superclasse. Pode também redefinir
-(ou: {\em sobrescrever}) alguns membros herdados. Por exemplo, a classe 
-\code{java.lang.Object} define um método \code{toString} que retorna uma 
-representação do objeto como cadeia de caracteres (string): 
-\begin{lstlisting}
-class Object {
-  ...
-  def toString: String = ...
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Object {
+%%   ...
+%%   def toString: String = ...
+%% }
+%% \end{lstlisting}
 %% The implementation of \code{toString} in \code{Object}
 %% forms a string consisting of the object's class name and a number. It
 %% makes sense to redefine this method for objects that are rational
 %% numbers:
-A implementação de \code{toString} em \code{Object} forma uma string que 
-consiste do nome da classe do objeto e um número. Faz sentido redefinir este
-método para objetos que são números racionais:  
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // como antes
-  override def toString = "" + numer + "/" + denom
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%%   override def toString = "" + numer + "/" + denom
+%% }
+%% \end{lstlisting}
 %% Note that, unlike in Java, redefining definitions need to be preceded
 %% by an \code{override} modifier.
-Observe que, diferentemente de Java, definições que redefinem precisam
-ser precedidas por um modificador \code{override}.  
-%----------
 
-%----------
 %% If class $A$ extends class $B$, then objects of type $A$ may be used
 %% wherever objects of type $B$ are expected. We say in this case that
 %% type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
 %% conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
 %% value to a variable of type \code{AnyRef}:
-Se a classe $A$ estende a classe $B$, então objetos do tipo $A$ podem ser
-usados sempre que objetos do tipo $B$ são esperados. Nesse caso dizemos que o 
-tipo $A$ está em {\em conformidade} com o tipo $B$. Por exemplo, \code{Rational}
-está em conformidade com \code{AnyRef}, logo é legal atribuir um valor \code{Rational}
-à variável do tipo \code{AnyRef}:
- 
- \begin{lstlisting}
- var x: AnyRef = new Rational(1, 2)
- \end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% var x: AnyRef = new Rational(1, 2)
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Parameterless Methods}
 %% %Also unlike in Java, methods in Scala do not necessarily take a
 %% %parameter list. An example is \code{toString}; the method is invoked
 %% %by simply mentioning its name. For instance:
-\paragraph{Métodos sem Parâmetros}
-
-\begin{lstlisting}
-val r = new Rational(1,2)
-System.out.println(r.toString);      // prints``1/2''
-\end{lstlisting}
+%% %\begin{lstlisting}
+%% %val r = new Rational(1,2)
+%% %System.out.println(r.toString);      // prints``1/2''
+%% %\end{lstlisting}
 %% Unlike in Java, methods in Scala do not necessarily take a
 %% parameter list. An example is the \code{square} method below. This
 %% method is invoked by simply mentioning its name. 
-Distintamente de Java, métodos em Scala não necessariamente precisam 
-receber uma lista de parâmetros. Um exemplo é o método abaixo \code{square}.
-Este método é invocado simplesmente mencionando seu nome. 
-\begin{lstlisting}
-class Rational(n: Int, d: Int) extends AnyRef {
-  ... // como antes
-  def square = new Rational(numer*numer, denom*denom)
-}
-val r = new Rational(3, 4)
-println(r.square)           // prints``9/16''*
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Rational(n: Int, d: Int) extends AnyRef {
+%%   ... // as before
+%%   def square = new Rational(numer*numer, denom*denom)
+%% }
+%% val r = new Rational(3, 4)
+%% println(r.square)           // prints``9/16''*
+%% \end{lstlisting}
 %% That is, parameterless methods are accessed just as value fields such
 %% as \code{numer} are. The difference between values and parameterless
 %% methods lies in their definition. The right-hand side of a value is
@@ -2329,21 +1834,8 @@ println(r.square)           // prints``9/16''*
 %% the implementer of a class. Often, a field in one version of a class
 %% becomes a computed value in the next version. Uniform access ensures
 %% that clients do not have to be rewritten because of that change.
-Ou seja, métodos sem parâmetros são acessados como campos valor, tais como 
-\code{numer} são. A diferença entre valores e métodos sem parâmetros 
-reside em suas definições. O lado direito de um valor é avaliado quando o 
-objeto é criado, e o valor não muda depois. Um lado direito de um método sem
-parâmetros, por outro lado, é avaliado cada vez que o método é chamado. O 
-acesso uniforme dos campos de métodos sem parâmetros resulta em crescente
-flexibilidade para o implementador de uma classe. Frequentemente, um campo
-em uma versão da classe torna-se um valor computado na próxima versão. 
-O acesso uniforme garante que clientes não tenham de ser reescritos 
-por conta desta mudança.
-%----------
 
-%----------
 %% \paragraph{Abstract Classes}
-\paragraph{Classes Abstratas}
 
 %% Consider the task of writing a class for sets of integer numbers with
 %% two operations, \code{incl} and \code{contains}. \code{(s incl x)}
@@ -2351,22 +1843,13 @@ por conta desta mudança.
 %% with all the elements of set \code{s}. \code{(s contains x)} should
 %% return true if the set \code{s} contains the element \code{x}, and
 %% should return \code{false} otherwise. The interface of such sets is
-%% given by:
-Considere a tarefa de escrever uma classe para conjuntos de números inteiros com 
-duas operações, \code{incl} e \code{contains}. \code{(s incl x)} deve retornar
-um novo conjunto que contém o elemento \code{x} juntamente com todos os elementos 
-do conjunto \code{s}. \code{(s contains x)} deve retornar \code{true} se o conjunto 
-\code{s} contiver o elemento \code{x}, e deve retornar \code{false}, caso contrário.
-A interface para tais conjuntos é dada por:
-\begin{lstlisting}
-abstract class IntSet {
-  def incl(x: Int): IntSet
-  def contains(x: Int): Boolean
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% given by:  
+%% \begin{lstlisting}
+%% abstract class IntSet {
+%%   def incl(x: Int): IntSet
+%%   def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
 %% \code{IntSet} is labeled as an \emph{abstract class}. This has two
 %% consequences.  First, abstract classes may have {\em deferred} members
 %% which are declared but which do not have an implementation. In our
@@ -2375,17 +1858,8 @@ abstract class IntSet {
 %% of that class may be created using \code{new}. By contrast, an
 %% abstract class may be used as a base class of some other class, which
 %% implements the deferred members.
-\code{IntSet} é tido como uma {\em classe abstrata}. Isso tem duas consequências. 
-Primeiro, classes abstratas podem ter membros {\em protelados (deferred)} que são 
-declarados, mas que não tem uma implementação. No nosso caso, ambos \code{incl} e 
-\code{contains} são tais membros. Segundo, porque uma classe abstrata pode ter 
-membros não implementados, nenhum objeto daquela classe pode ser criado usando \code{new}.
-Em contraste, uma classe abstrata pode ser usada como uma classe base de alguma outra
-classe, que implementa os membros que foram postergados. 
-%----------
 
-%----------
- \paragraph{Traits}
+%% \paragraph{Traits}
 
 %% Instead of \code{abstract class} one also often uses the keyword
 %% \code{trait} in Scala. Traits are abstract classes that are meant to
@@ -2395,93 +1869,64 @@ classe, que implementa os membros que foram postergados.
 %% components. Another usage scenario is where the trait collects
 %% signatures of some functionality provided by different classes, much
 %% in the way a Java interface would work.
-Ao invés de \code{classe abstrata} frequentemente usa-se a palavra chave
-\code{trait} em Scala. Traits são classes abstratas que desejamos adicionar
-a alguma outra classe. Isso pode ser porque um trait adiciona alguns métodos
-ou campos para uma classe pai desconhecida. Por exemplo, um trait \code{Bordered} 
-pode ser usado para adicionar uma borda a vários componentes gráficos. Um outro
-cenário de uso ocorre quando o trait coleta assinaturas de alguma funcionalidade 
-provida por diferentes classes, do mesmo modo que uma interface Java faria.
 
 %% Since \code{IntSet} falls in this category, one can alternatively
 %% define it as a trait:
-Como \code{IntSet} pertence a esta categoria, pode-se alternativamente 
-definí-la como um trait:
-\begin{lstlisting}
-trait IntSet {
-  def incl(x: Int): IntSet
-  def contains(x: Int): Boolean
-}
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% trait IntSet {
+%%   def incl(x: Int): IntSet
+%%   def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Implementing Abstract Classes}
-\paragraph{Implementando Classes Abstratas}
+
 %% Let's say, we plan to implement sets as binary trees.  There are two
 %% possible forms of trees. A tree for the empty set, and a tree
 %% consisting of an integer and two subtrees. Here are their
 %% implementations.
 
-Vamos dizer que planejamos implementar conjuntos como árvores binárias. Há 
-duas possíveis formas de árvores. Uma árvore para o conjunto vazio, e uma 
-árvore consistindo de um inteiro e duas subárvores. Aqui estão suas implementações:
- 
-\begin{lstlisting}
-class EmptySet extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class EmptySet extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = new NonEmptySet(x, new EmptySet, new EmptySet)
+%% }
+%% \end{lstlisting}
 
-\begin{lstlisting}
-class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: Int): IntSet =
-    if (x < elem) new NonEmptySet(elem, left incl x, right)
-    else if (x > elem) new NonEmptySet(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class NonEmptySet(elem: Int, left: IntSet, right: IntSet) extends IntSet {
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: Int): IntSet =
+%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
+%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
 %% Both \code{EmptySet} and \code{NonEmptySet} extend class
 %% \code{IntSet}.  This implies that types \code{EmptySet} and
 %% \code{NonEmptySet} conform to type \code{IntSet} -- a value of type \code{EmptySet} or \code{NonEmptySet} may be used wherever a value of type \code{IntSet} is required.
-Ambos \code{EmptySet} e \code{NonEmptySet} estendem a classe \code{IntSet}. Isso implica
-que tipos \code{EmptySet} e \code{NonEmptySet} estão em conformidade com o tipo \code{IntSet} -- 
-um valor do tipo \code{EmptySet} ou \code{NonEmptySet} pode ser usado sempre que um valor 
- do tipo \code{IntSet} é requerido.
-%----------
 
-%----------
 %% \begin{exercise} Write methods \code{union} and \code{intersection} to form
 %% the union and intersection between two sets.
 %% \end{exercise}
-\begin{exercise}
-Escreva os métodos \code{uniao} e \code{intersecao} para formar a união e interseção entre
-dois conjuntos.
-\end{exercise}
- \begin{exercise} Adicione um método  
- \begin{lstlisting}
- def excl(x: Int)
- \end{lstlisting}
+
+%% \begin{exercise} Add a method 
+%% \begin{lstlisting}
+%% def excl(x: Int)
+%% \end{lstlisting}
 %% to return the given set without the element \code{x}. To accomplish this,
 %% it is useful to also implement a test method
-para retornar um dado conjunto sem o elemento \code{x}. Para isso, é interessante também 
-implementar um método teste
- \begin{lstlisting}
- def isEmpty: Boolean
- \end{lstlisting}
+%% \begin{lstlisting}
+%% def isEmpty: Boolean
+%% \end{lstlisting}
 %% for sets.
-para conjuntos.
- \end{exercise}
-%----------
+%% \end{exercise}
 
-%----------
 %% \paragraph{Dynamic Binding}
-\paragraph{Ligação Dinâmica}
+
 %% Object-oriented languages (Scala included) use \emph{dynamic dispatch}
 %% for method invocations.  That is, the code invoked for a method call
 %% depends on the run-time type of the object which contains the method.
@@ -2490,74 +1935,50 @@ para conjuntos.
 %% \code{contains} is executed depends on the type of value of \code{s} at run-time.
 %% If it is an \code{EmptySet} value, it is the implementation of \code{contains} in class \code{EmptySet} that is executed, and analogously for \code{NonEmptySet} values. 
 %% This behavior is a direct consequence of our substitution model of evaluation.
-Linguagens orientadas a objetos (inclusive Scala) usam \emph{despacho dinâmico} para 
-invocações de métodos. Ou seja, o código invocado por uma chamada de método depende
-do tipo em tempo de execução do objeto que contém o método. Por exemplo, considere
-a expressão \code{s contains 7} onde \code{s} é um valor do tipo declarado \code{s: IntSet}. 
-Qual código para \code{contains} é executado depende do tipo do valor de \code{s} em 
-tempo de execução. Se for um valor \code{EmptySet}, é a implementação de \code{contains} na 
-classe \code{EmptySet} que é executada, e analogamente para valores \code{NonEmptySet}.
-Este comportamento é consequência direta do nosso modelo de substituição da avaliação.
-%----------
-
-%----------
 %% For instance,
-Por exemplo, 
-\begin{lstlisting}
-    (new EmptySet).contains(7) 
+%% \begin{lstlisting}
+%%     (new EmptySet).contains(7) 
 
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-    false
-\end{lstlisting}
-Ou,
-\begin{lstlisting}
-    new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
+%%     false
+%% \end{lstlisting}
+%% Or,
+%% \begin{lstlisting}
+%%     new NonEmptySet(7, new EmptySet, new EmptySet).contains(1)
 
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl NonEmptySet}}$
 
-    if (1 < 7) new EmptySet contains 1
-    else if (1 > 7) new EmptySet contains 1
-    else true
+%%     if (1 < 7) new EmptySet contains 1
+%%     else if (1 > 7) new EmptySet contains 1
+%%     else true
 
-->  $\rewriteby{by rewriting the conditional}$
+%% ->  $\rewriteby{by rewriting the conditional}$
 
-    new EmptySet contains 1
+%%     new EmptySet contains 1
 
-->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
+%% ->  $\rewriteby{by replacing {\sl contains} by its body in class {\sl EmptySet}}$
 
-    false .
-\end{lstlisting}
-%----------
+%%     false .
+%% \end{lstlisting}
 
-%----------
 %% Dynamic method dispatch is analogous to higher-order function
 %% calls. In both cases, the identity of code to be executed is known
 %% only at run-time. This similarity is not just superficial. Indeed,
 %% Scala represents every function value as an object (see
 %% Section~\ref{sec:functions}).
-Envio dinâmico de métodos é análogo a chamadas para funções de alta ordem. 
-Em ambos os casos, a identidade do código  a ser executado é conhecida somente
-em tempo de execução. Essa similaridade não é apenas superficial. Na verdade, 
-Scala representa cada valor de função como um objeto (veja Seção~\ref{sec:functions}).
-%----------
 
-%----------
+
 %% \paragraph{Objects}
-\paragraph{Objetos}
+
 %% In the previous implementation of integer sets, empty sets were
 %% expressed with \code{new EmptySet}; so a new object was created every time
 %% an empty set value was required. We could have avoided unnecessary
 %% object creations by defining a value \code{empty} once and then using
 %% this value instead of every occurrence of \code{new EmptySet}. For example:
-Na implementação prévia de conjuntos de inteiros, conjuntos vazios eram expressos
-com \code{new EmptySet}; então um novo objeto era criado a cada vez que um valor
-conjunto vazio era requerido. Podemos evitar criações desnecessárias de objetos 
-definindo um valor \code{empty} uma vez e então, usando este valor ao invés de cada 
-ocorrência de \code{new EmptySet}. Por exemplo:
- \begin{lstlisting}
- val EmptySetVal = new EmptySet
- \end{lstlisting}
+%% \begin{lstlisting}
+%% val EmptySetVal = new EmptySet
+%% \end{lstlisting}
 %% One problem with this approach is that a value definition such as the
 %% one above is not a legal top-level definition in Scala; it has to be
 %% part of another class or object. Also, the definition of class
@@ -2565,21 +1986,12 @@ ocorrência de \code{new EmptySet}. Por exemplo:
 %% if we are only interested in a single object of this class? A more
 %% direct approach is to use an {\em object definition}. Here is
 %% a more streamlined alternative definition of the empty set:
-Um problema com esse tratamento é que uma definição de valor tal como a anterior
-não é uma definição top-level legal em Scala; tem de ser parte de uma outra classe 
-ou objeto. Ainda, a definição de classe \code{EmptySet} agora parece um pouco exagerada -- 
-por que definir uma classe de objetos, se somente estamos interessados em um único objeto 
-dessa classe? Um tratamento mais direto é usar uma {\em definição de objeto}. Aqui está 
-uma alternativa mais adequada para a definição de conjunto vazio:
-\begin{lstlisting}
-object EmptySet extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% object EmptySet extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = new NonEmptySet(x, EmptySet, EmptySet)
+%% }
+%% \end{lstlisting}
 %% The syntax of an object definition follows the syntax of a class
 %% definition; it has an optional extends clause as well as an optional
 %% body. As is the case for classes, the extends clause defines inherited
@@ -2588,53 +2000,28 @@ object EmptySet extends IntSet {
 %% it is not possible to create other objects with the same structure
 %% using \code{new}.  Therefore, object definitions also lack constructor
 %% parameters, which might be present in class definitions.
-A sintaxe de uma definição de objeto segue a sintaxe da definição de uma 
-classe; tem uma cláusula opcional extends, bem como um corpo opcional. 
-Assim como em classes, a cláusula extends define membros herdados do objeto 
-considerando que o corpo define novos membros ou sobrecarga. Entretanto, uma 
-definição de objeto denota um único objeto somente se não for possível criar
-outros objetos com a mesma estrutura usando \code{new}. Então, definições de
-objeto também carecem de parâmetros construtores, que podem estar presentes
-nas definições das classes.
-%----------
 
-%----------
 %% Object definitions can appear anywhere in a Scala program; including
 %% at top-level.  Since there is no fixed execution order of top-level
 %% entities in Scala, one might ask exactly when the object defined by an
 %% object definition is created and initialized. The answer is that the
 %% object is created the first time one of its members is accessed. This
 %% strategy is called {\em lazy evaluation}.
-Definições de objetos podem aparecer em qualquer lugar em um programa Scala;
-incluindo o top-level. Como não há ordem fixa de execução de entidades
-top-level em Scala, pode-se questionar quando exatamente o objeto definido 
-pela definição de objeto é criado e inicializado. A resposta é que o objeto 
-é criado assim que seus membros são acessados. Esta estratégia é chamada 
-{\em avaliação preguiçosa}.
-%----------
 
-%----------
 %% \paragraph{Standard Classes}
-\paragraph{Classes Padrão}
+
 %% \todo{include picture}
 
 %% Scala is a pure object-oriented language. This means that every value
 %% in Scala can be regarded as an object.  In fact, even primitive types
 %% such as \code{int} or \code{boolean} are not treated specially. They
 %% are defined as type aliases of Scala classes in module \code{Predef}:
-Scala é uma linguagem orientada a objetos pura. Isso significa que cada valor 
-em Scala pode ser visto como um objeto. De fato, mesmo tipos primitivos tais como 
-\code{int} ou \code{boolean} não são tratados de modo especial. São definidos
-como apelidos de tipos de classes Scala no módulo \code{Predef}.  
-\begin{lstlisting}
-type boolean = scala.Boolean
-type int = scala.Int
-type long = scala.Long
-...
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% type boolean = scala.Boolean
+%% type int = scala.Int
+%% type long = scala.Long
+%% ...
+%% \end{lstlisting}
 %% For efficiency, the compiler usually represents values of type
 %% \code{scala.Int} by 32 bit integers, values of type
 %% \code{scala.Boolean} by Java's booleans, etc.  But it converts these
@@ -2643,208 +2030,143 @@ type long = scala.Long
 %% parameter of type \code{AnyRef}.  Hence, the special representation of
 %% primitive values is just an optimization, it does not change the
 %% meaning of a program.
-Por eficiência, o compilador geralmente representa valor de tipo
-\code{scala.Int} por inteiros de 32 bits, valores de tipo \code{scala.Boolean}
-por boleanos Java etc. Mas converte essas representações especializadas para 
-objetos quando requeridos, por exemplo, quando um valor primitivo \code{Int} é 
-passada a uma função com um parâmetro de tipo \code{AnyRef}. Consequentemente, a
-representação de valores primitivos é apenas uma otimização, não muda o significado
-de um programa.
-%----------
 
-%----------
 %% Here is a specification of class \code{Boolean}.
-Aqui está a especificação da classe \code{Boolean}.
-\begin{lstlisting}
-package scala
-abstract class Boolean {
-  def && (x: => Boolean): Boolean
-  def || (x: => Boolean): Boolean
-  def !                 : Boolean
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Boolean {
+%%   def && (x: => Boolean): Boolean
+%%   def || (x: => Boolean): Boolean
+%%   def !                 : Boolean
 
-  def == (x: Boolean)   : Boolean
-  def != (x: Boolean)   : Boolean
-  def <  (x: Boolean)   : Boolean
-  def >  (x: Boolean)   : Boolean
-  def <= (x: Boolean)   : Boolean
-  def >= (x: Boolean)   : Boolean
-}
-\end{lstlisting}
-%----------
-
-%----------
+%%   def == (x: Boolean)   : Boolean
+%%   def != (x: Boolean)   : Boolean
+%%   def <  (x: Boolean)   : Boolean
+%%   def >  (x: Boolean)   : Boolean
+%%   def <= (x: Boolean)   : Boolean
+%%   def >= (x: Boolean)   : Boolean
+%% }
+%% \end{lstlisting}
 %% Booleans can be defined using only classes and objects, without
 %% reference to a built-in type of booleans or numbers. A possible
 %% implementation of class \code{Boolean} is given below.  This is not
 %% the actual implementation in the standard Scala library. For
 %% efficiency reasons the standard implementation uses built-in
 %% booleans.
-Boleanos podem ser definidos usando somente classes e objetos, sem
-referência ao tipos básicos para boleanos ou números. Uma possível 
-implementação da claro \code{Boolean} é dada abaixo. Esta não é 
-a implementação atual na biblioteca padrão Scala. Por razões de 
-eficiência a implementação padrão usa boleanos primitivos.
-\begin{lstlisting}
-package scala
-abstract class Boolean {
-  def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Boolean {
+%%   def ifThenElse(thenpart: => Boolean, elsepart: => Boolean)
 
-  def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
-  def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
-  def !                 : Boolean  =  ifThenElse(false, true)
+%%   def && (x: => Boolean): Boolean  =  ifThenElse(x, false)
+%%   def || (x: => Boolean): Boolean  =  ifThenElse(true, x)
+%%   def !                 : Boolean  =  ifThenElse(false, true)
 
-  def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
-  def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
-  def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
-  def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
-  def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
-  def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
-}
-case object True extends Boolean {
-  def ifThenElse(t: => Boolean, e: => Boolean) = t
-}
-case object False extends Boolean {
-  def ifThenElse(t: => Boolean, e: => Boolean) = e
-}
-\end{lstlisting}
-%----------
-
-%----------
+%%   def == (x: Boolean)   : Boolean  =  ifThenElse(x, x.!)
+%%   def != (x: Boolean)   : Boolean  =  ifThenElse(x.!, x)
+%%   def <  (x: Boolean)   : Boolean  =  ifThenElse(false, x)
+%%   def >  (x: Boolean)   : Boolean  =  ifThenElse(x.!, false)
+%%   def <= (x: Boolean)   : Boolean  =  ifThenElse(x, true)
+%%   def >= (x: Boolean)   : Boolean  =  ifThenElse(true, x.!)
+%% }
+%% case object True extends Boolean {
+%%   def ifThenElse(t: => Boolean, e: => Boolean) = t
+%% }
+%% case object False extends Boolean {
+%%   def ifThenElse(t: => Boolean, e: => Boolean) = e
+%% }
+%% \end{lstlisting}
 %% Here is a partial specification of class \code{Int}.
-Aqui está uma especificação parcial da classe \code{Int}.
-\begin{lstlisting}
-package scala
-abstract class Int extends AnyVal {
-  def toLong: Long
-  def toFloat: Float
-  def toDouble: Double
 
-  def + (that: Double): Double
-  def + (that: Float): Float
-  def + (that: Long): Long
-  def + (that: Int): Int         // análogo para -, *, /, %
+%% \begin{lstlisting}
+%% package scala
+%% abstract class Int extends AnyVal {
+%%   def toLong: Long
+%%   def toFloat: Float
+%%   def toDouble: Double
 
-  def << (cnt: Int): Int         // análogo para  >>, >>>
+%%   def + (that: Double): Double
+%%   def + (that: Float): Float
+%%   def + (that: Long): Long
+%%   def + (that: Int): Int         // analogous for -, *, /, %
 
-  def & (that: Long): Long
-  def & (that: Int): Int         // análogo para |, ^
+%%   def << (cnt: Int): Int         // analogous for >>, >>>
 
-  def == (that: Double): Boolean
-  def == (that: Float): Boolean
-  def == (that: Long): Boolean   // análogo para !=, <, >, <=, >=
-}
-\end{lstlisting}
-%----------
+%%   def & (that: Long): Long
+%%   def & (that: Int): Int         // analogous for |, ^
 
-%----------
+%%   def == (that: Double): Boolean
+%%   def == (that: Float): Boolean
+%%   def == (that: Long): Boolean   // analogous for !=, <, >, <=, >=
+%% }
+%% \end{lstlisting}
+
 %% Class \code{Int} can in principle also be implemented using just
 %% objects and classes, without reference to a built in type of
 %% integers. To see how, we consider a slightly simpler problem, namely
 %% how to implement a type \code{Nat} of natural (i.e. non-negative)
 %% numbers. Here is the definition of an abstract class \code{Nat}:
-A classe \code{Int} pode em princípio também ser implementada usando
-apenas objetos e classes, sem referência a um tipo construído para 
-inteiros. Para ver como, vamos considerar um problema um pouco mais 
-simples, especificamente como implementar um tipo \code{Nat} de 
-números naturais, ou seja, inteiros não negativo. Aqui está uma definição 
-para uma classe abstrata \code{Nat}:
-\begin{lstlisting}
-abstract class Nat {
-  def isZero: Boolean
-  def predecessor: Nat
-  def successor: Nat
-  def + (that: Nat): Nat
-  def - (that: Nat): Nat
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% abstract class Nat {
+%%   def isZero: Boolean
+%%   def predecessor: Nat
+%%   def successor: Nat
+%%   def + (that: Nat): Nat
+%%   def - (that: Nat): Nat
+%% }
+%% \end{lstlisting}
 %% To implement the operations of class \code{Nat}, we define a sub-object
 %% \code{Zero} and a subclass \code{Succ} (for successor). Each number
 %% \code{N} is represented as \code{N} applications of the \code{Succ}
 %% constructor to \code{Zero}:
-Para implementar as operações da classe \code{Nat}, nós definimos um
-sub-objeto \code{Zero} e uma subclasse \code{Succ} (para sucessor). Cada 
-número \code{N} é representado como \code{N} aplicações do construtor \code{Succ}
-até zero: 
- \[
- \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
- \]
+%% \[
+%% \underbrace{\mbox{\sl new Succ( ... new Succ}}_{\mbox{$N$ times}}\mbox{\sl (Zero) ... )}
+%% \]
 %% The implementation of the \code{Zero} object is straightforward:
-A implementação do objeto \code{Zero} é direta:
-\begin{lstlisting}
-object Zero extends Nat {
-  def isZero: Boolean = true
-  def predecessor: Nat = error("negative number")
-  def successor: Nat = new Succ(Zero)
-  def + (that: Nat): Nat = that
-  def - (that: Nat): Nat = if (that.isZero) Zero
-                           else error("negative number")
-}
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% object Zero extends Nat {
+%%   def isZero: Boolean = true
+%%   def predecessor: Nat = error("negative number")
+%%   def successor: Nat = new Succ(Zero)
+%%   def + (that: Nat): Nat = that
+%%   def - (that: Nat): Nat = if (that.isZero) Zero
+%%                            else error("negative number")
+%% }
+%% \end{lstlisting}
 
-%----------
 %% The implementation of the predecessor and subtraction functions on
 %% \code{Zero} throws an \code{Error} exception, which aborts the program
 %% with the given error message.
 
 %% Here is the implementation of the successor class:
-
-A implementação das funções  predecessor e subtração sobre \code{Zero} leva a 
-um \code{Erro}, que aborta o programa com uma mensagem de erro.
-
-Aqui está uma implementação da classe sucessor: 
-
-\begin{lstlisting}
-class Succ(x: Nat) extends Nat  {
-  def isZero: Boolean = false
-  def predecessor: Nat = x
-  def successor: Nat = new Succ(this)
-  def + (that: Nat): Nat = x + that.successor
-  def - (that: Nat): Nat = if (that.isZero) this 
-                           else x - that.predecessor
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Succ(x: Nat) extends Nat  {
+%%   def isZero: Boolean = false
+%%   def predecessor: Nat = x
+%%   def successor: Nat = new Succ(this)
+%%   def + (that: Nat): Nat = x + that.successor
+%%   def - (that: Nat): Nat = if (that.isZero) this 
+%%                            else x - that.predecessor
+%% }
+%% \end{lstlisting}
 %% Note the implementation of method \code{successor}. To create the
 %% successor of a number, we need to pass the object itself as an
 %% argument to the \code{Succ} constructor.  The object itself is
-%% referenced by the reserved name \code{this}.
-Observe a implementação do método \code{successor}. Para criar o 
-sucessor de um número, precisamos passar o próprio objeto como um 
-argumento para o construtor \code{Succ}. O próprio objeto é referenciado
-por uma palavra reservada \code{this}.   
-%----------
+%% referenced by the reserved name \code{this}.   
 
-%----------
 %% The implementations of \code{+} and \code{-} each contain a recursive
 %% call with the constructor argument as receiver. The recursion will
 %% terminate once the receiver is the \code{Zero} object (which is
 %% guaranteed to happen eventually because of the way numbers are formed).
-As implementações de \code{+} e \code{-}, cada uma contém uma chamada 
-recursiva com o argumento do costrutor como destinatário. A recursão 
-terminará assim que o destinatário for o objeto \code{Zero} (o que é 
-garantido de acontecer eventualmente dado o modo com que os números são formados).
-%----------
 
-%----------
 %% \begin{exercise} Write an implementation \code{Integer} of integer numbers
 %% The implementation should support all operations of class \code{Nat}
 %% while adding two methods
-\begin{exercise}
-Escreva uma implementação \code{Integer} dos números inteiros. A implementação deve
-suportar todas as operações da classe \code{Nat} e mais dois métodos.
-
-\begin{lstlisting}
-def isPositive: Boolean
-def negate: Integer
-\end{lstlisting}
-%% The first method should return \code{true} if the number is positive.
-%% The second method should negate the number.
+%% \begin{lstlisting}
+%% def isPositive: Boolean
+%% def negate: Integer
+%% \end{lstlisting}
+%% The first method should return \code{true} if the number is positive. The second method should negate the number.
 %% Do not use any of Scala's standard numeric classes in your
 %% implementation. (Hint: There are two possible ways to implement
 %% \code{Integer}. One can either make use the existing implementation of
@@ -2853,142 +2175,100 @@ def negate: Integer
 %% \code{Integer}, using the three subclasses \code{Zero} for 0, 
 %% \code{Succ} for positive numbers and \code{Pred} for negative numbers.)
 %% \end{exercise}
-O primeiro método deve retornar \code{true} se o número for positivo. O segundo 
-método deve negativar o número. Não utilize qualquer classe numérica padrão Scala
-em sua implementação. (Dica: Há duas formas para implementar \code{Integer}. Uma
-pode ou fazer uso da implementação existente de \code{Nat}, representando um inteiro 
-como um número natural e um sinal. Ou pode-se generalizar a implementação dada de 
-\code{Nat} para \code{Integer}, usando as três subclasses \code{Zero} para 0, 
-\code{Succ} para números positivos e \code{Pred} para números negativos. 
-\end{exercise}
-%----------
 
-%----------
+
+
 %% \subsection*{Language Elements Introduced In This Chapter}
-\subsection*{Elementos da Linguagem Introduzidos Neste Capítulo}
- \textbf{Types:}
- \begin{lstlisting}
- Type         = ...  |  ident
- \end{lstlisting}
+
+%% \textbf{Types:}
+%% \begin{lstlisting}
+%% Type         = ...  |  ident
+%% \end{lstlisting}
 
 %% Types can now be arbitrary identifiers which represent classes.
-Tipos podem agora ser identificadores arbitrários que representam classes.
 
 %% \textbf{Expressions:}
-\textbf{Expressões:}
- \begin{lstlisting}
- Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
- \end{lstlisting}
+%% \begin{lstlisting}
+%% Expr         = ...  |  Expr '.' ident  |  'new' Expr  |  'this'
+%% \end{lstlisting}
 
 %% An expression can now be an object creation, or
 %% a selection \code{E.m} of a member \code{m}
 %% from an object-valued expression \code{E}, or it can be the reserved name \code{this}.
-Uma expressão pode agora ser uma criação de objeto, ou uma seleção
-\code{E.m} de um membro \code{m} a partir de uma expressão valorada objeto \code{E},
-ou pode ser a palavra reservada \code{this}.
-%----------
 
-%----------
 %% \textbf{Definitions and Declarations:}
- \textbf{Definições e Declarações}
-\begin{lstlisting}
-Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
-ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
-               ['extends' Expr] [`{' {TemplateDef} `}']
-TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
-ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
-TemplateDef  = [Modifier] (Def | Dcl)
-ObjectDef    = [Modifier] Def
-Modifier     = 'private'  |  'override'
-Dcl          = FunDcl  |  ValDcl
-FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
-ValDcl       = 'val' ident ':' Type
-\end{lstlisting}
+%% \begin{lstlisting}
+%% Def          = FunDef  |  ValDef  |  ClassDef  |  TraitDef  |  ObjectDef
+%% ClassDef     = ['abstract'] 'class' ident ['(' [Parameters] ')'] 
+%%                ['extends' Expr] [`{' {TemplateDef} `}']
+%% TraitDef     = 'trait' ident ['extends' Expr] ['{' {TemplateDef} '}']
+%% ObjectDef    = 'object' ident ['extends' Expr] ['{' {ObjectDef} '}']
+%% TemplateDef  = [Modifier] (Def | Dcl)
+%% ObjectDef    = [Modifier] Def
+%% Modifier     = 'private'  |  'override'
+%% Dcl          = FunDcl  |  ValDcl
+%% FunDcl       = 'def' ident {'(' [Parameters] ')'} ':' Type
+%% ValDcl       = 'val' ident ':' Type
+%% \end{lstlisting}
 
-%%A definition can now be a class, trait or object definition such as
-Uma definição pode agora ser uma definição de classe, trait ou objeto, tal como  
-\begin{lstlisting}
-class C(params) extends B { defs }
-trait T extends B { defs }
-object O extends B { defs }
-\end{lstlisting}
+%% A definition can now be a class, trait or object definition such as
+%% \begin{lstlisting}
+%% class C(params) extends B { defs }
+%% trait T extends B { defs }
+%% object O extends B { defs }
+%% \end{lstlisting}
 %% The definitions \code{defs} in a class, trait or object may be
 %% preceded by modifiers \code{private} or \code{override}.
-As definições \code{defs} na classe, trait ou objeto podem ser 
-precedidas pelos modificadores \code{private} ou \code{override}.
 
 %% Abstract classes and traits may also contain declarations. These
 %% introduce {\em deferred} functions or values with their types, but do
 %% not give an implementation. Deferred members have to be implemented in
 %% subclasses before objects of an abstract class or trait can be created.
-Classes abstratas e traits podem também conter declarações. Isso introduz
-funções {\em deferred} (postergadas) ou valores com seus tipos, mas não 
-dão uma implementação. Membros deferred devem ser implementados nas subclasses 
-antes que objetos de uma classe abstrata ou trait sejam criados. 
-%----------
 
-
-%----------
 %% \chapter{Case Classes and Pattern Matching}
-\chapter{Classes Case e Casamento de Padrões}
+
 %% Say, we want to write an interpreter for arithmetic expressions.  To
 %% keep things simple initially, we restrict ourselves to just numbers
 %% and \code{+} operations. Such expressions can be represented as a class hierarchy, with an abstract base class \code{Expr} as the root, and two subclasses \code{Number} and
 %% \code{Sum}. Then, an expression \code{1 + (3 + 7)} would be represented as
-Digamos, queremos escrever um interpretador para expressões aritméticas. Para 
-deixar as coisas simples inicialmente, vamos nos restringir somente a números e operações \code{+}.
-Tais expressões podem ser representadas como hierarquia de classes, 
-com uma classe abstrata base \code{Expr} como raiz, e duas subclasses \code{Number} e \code{Sum}.
-Então, uma expressão \code{1 + (3 + 7)} é representada como 
- \begin{lstlisting}
- new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
- \end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% new Sum(new Number(1), new Sum(new Number(3), new Number(7)))
+%% \end{lstlisting}
 %% Now, an evaluator of an expression like this needs to know of what
 %% form it is (either \code{Sum} or \code{Number}) and also needs to
 %% access the components of the expression.  The following
 %% implementation provides all necessary methods.
-Agora, um avaliador de uma expressão como esta precisa saber de 
-qual forma ela é (ou \code{Sum} ou \code{Number}) e também precisa
-acessar os componentes da expressão. A implementação a seguir provê
-todos os métodos necessários.
-\begin{lstlisting}
-abstract class Expr {
-  def isNumber: Boolean
-  def isSum: Boolean
-  def numValue: Int
-  def leftOp: Expr
-  def rightOp: Expr
-}
-class Number(n: Int) extends Expr {
-  def isNumber: Boolean = true
-  def isSum: Boolean = false
-  def numValue: Int = n
-  def leftOp: Expr = error("Number.leftOp")
-  def rightOp: Expr = error("Number.rightOp")
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def isNumber: Boolean = false
-  def isSum: Boolean = true
-  def numValue: Int = error("Sum.numValue")
-  def leftOp: Expr = e1
-  def rightOp: Expr = e2
-}
-\end{lstlisting}
-%----------
-
-%----------
-%%With these classification and access methods, writing an evaluator function is simple:
-Com esta classificação e métodos de acesso, escrever uma função avaliador é simples:
-\begin{lstlisting}
-def eval(e: Expr): Int = {
-  if (e.isNumber) e.numValue
-  else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
-  else error("unrecognized expression kind")
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def isNumber: Boolean
+%%   def isSum: Boolean
+%%   def numValue: Int
+%%   def leftOp: Expr
+%%   def rightOp: Expr
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def isNumber: Boolean = true
+%%   def isSum: Boolean = false
+%%   def numValue: Int = n
+%%   def leftOp: Expr = error("Number.leftOp")
+%%   def rightOp: Expr = error("Number.rightOp")
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def isNumber: Boolean = false
+%%   def isSum: Boolean = true
+%%   def numValue: Int = error("Sum.numValue")
+%%   def leftOp: Expr = e1
+%%   def rightOp: Expr = e2
+%% }
+%% \end{lstlisting}
+%% With these classification and access methods, writing an evaluator function is simple:
+%% \begin{lstlisting}
+%% def eval(e: Expr): Int = {
+%%   if (e.isNumber) e.numValue
+%%   else if (e.isSum) eval(e.leftOp) + eval(e.rightOp)
+%%   else error("unrecognized expression kind")
+%% }
+%% \end{lstlisting}
 %% However, defining all these methods in classes \code{Sum} and
 %% \code{Number} is rather tedious. Furthermore, the problem becomes worse 
 %% when we want to add new forms of expressions. For instance, consider
@@ -2997,18 +2277,7 @@ def eval(e: Expr): Int = {
 %% new abstract method \code{isProduct} in class \code{Expr} and
 %% implement that method in subclasses \code{Number}, \code{Sum}, and
 %% \code{Prod}. Having to modify existing code when a system grows is always problematic, since it introduces versioning and maintenance problems. 
-Entretanto, definir todos esses métodos dentro das classes \code{Sum} e \code{Number}
-é um tanto quanto tedioso. Além do mais, o problema fica ainda pior se desejarmos 
-adicionar novas formas de expressões. Por exemplo, considere adicionar uma nova 
-forma de expressão \code{Prod} para produtos. Não apenas teremos de implementar uma nova classe 
-\code{Prod}, com todos os métodos de acesso e classificação prévios; também teremos de 
-introduzir um novo método abstrato \code{isProduct} dentro da classe \code{Expr} e 
-implementar aquele método na subclasse \code{Number}, \code{Sum}, e \code{Prod}.
-Ter de  modificar código existente quando um sistema cresce é sempre problemático, pois
-introduz problemas de versão e manutenção.  
-%----------
 
-%----------
 %% The promise of object-oriented programming is that such modifications
 %% should be unnecessary, because they can be avoided by re-using
 %% existing, unmodified code through inheritance. Indeed, a more
@@ -3018,36 +2287,23 @@ introduz problemas de versão e manutenção.
 %% outside the expression class hierarchy, as we have done
 %% before. Because \code{eval} is now a member of all expression nodes,
 %% all classification and access methods become superfluous, and the implementation is simplified considerably:
-A promessa da programação orientada a objetos é que tais modificações 
-são desnecessárias, dado que podem ser evitadas pela reutilização de código 
-existente e não modificado, através da herança. De fato, uma decomposição 
-mais orientada a objetos para nosso problema resolve a questão. A idéia é tornar
-a operação de alto nível \code{eval} um método para cada classe expressão, ao 
-invés de implementá-lo como uma função fora da hierarquia de classes expressões, como 
-fizemos anteriormente. Como \code{eval} é agora um membro de todos os nós de expressão, 
-quaisquer métodos de classificação e acesso tornam-se supérfluos, e a implementação 
-é simplificada consideravelmente:  
-\begin{lstlisting}
-abstract class Expr {
-  def eval: Int
-}
-class Number(n: Int) extends Expr {
-  def eval: Int = n
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval + e2.eval
-}
-\end{lstlisting}
-%----------
-
-%----------
-%%Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
-Além disso, adicionar uma nova classe \code{Prod} não leva a qualquer mudança ao código existente:
-\begin{lstlisting}
-class Prod(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval * e2.eval
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def eval: Int
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def eval: Int = n
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval + e2.eval
+%% }
+%% \end{lstlisting}
+%% Furthermore, adding a new \code{Prod} class does not entail any changes to existing code:
+%% \begin{lstlisting}
+%% class Prod(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval * e2.eval
+%% }
+%% \end{lstlisting}
 
 %% The conclusion we can draw from this example is that object-oriented
 %% decomposition is the technique of choice for constructing systems that
@@ -3055,66 +2311,47 @@ class Prod(e1: Expr, e2: Expr) extends Expr {
 %% possible way we might want to extend the expression example. We might
 %% want to add new {\em operations} on expressions.  For instance, we might
 %% want to add an operation that pretty-prints an expression tree to standard output.
-A conclusão que tiramos deste exemplo é que a decomposição orientada a objetos
-é a técnica de escolha para a construção de sistemas que devem ser estensíveis
-com novos tipos de dados. Mas há também um outro possível modo para estender a 
-expressão exemplo. Podemos querer adicionar novas {\em operações} sobre expressões.
-Por exemplo, podemos querer adicionar uma operação que imprime uma árvore-expressão
-para a saída padrão.  
-%----------
 
-%----------
 %% If we have defined all classification and access methods, such an
 %% operation can easily be written as an external function. Here is an
 %% example:
-Se definimos todos os métodos de classificação e acesso, tal operação pode ser 
-facilmente escrita como uma função externa. Aqui está um exemplo: 
-\begin{lstlisting}
-def print(e: Expr) {
-  if (e.isNumber) Console.print(e.numValue)
-  else if (e.isSum) {
-    Console.print("(")
-    print(e.leftOp)
-    Console.print("+")
-    print(e.rightOp)
-    Console.print(")")
-  } else error("unrecognized expression kind")
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def print(e: Expr) {
+%%   if (e.isNumber) Console.print(e.numValue)
+%%   else if (e.isSum) {
+%%     Console.print("(")
+%%     print(e.leftOp)
+%%     Console.print("+")
+%%     print(e.rightOp)
+%%     Console.print(")")
+%%   } else error("unrecognized expression kind")
+%% }
+%% \end{lstlisting}
 %% However, if we had opted for an object-oriented decomposition of
 %% expressions, we would need to add a new \code{print} procedure
 %% to each class:
-Entretanto, se optamos por uma decomposição orientada a objetos das 
-expressões, precisaremos adicionar um novo procedimento \code{print} 
-para cada classe: 
-\begin{lstlisting}
-abstract class Expr {
-  def eval: Int
-  def print
-}
-class Number(n: Int) extends Expr {
-  def eval: Int = n
-  def print { Console.print(n) }
-}
-class Sum(e1: Expr, e2: Expr) extends Expr {
-  def eval: Int = e1.eval + e2.eval
-  def print {
-    Console.print("(")
-    print(e1)
-    Console.print("+")
-    print(e2)
-    Console.print(")")
-  }
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% abstract class Expr {
+%%   def eval: Int
+%%   def print
+%% }
+%% class Number(n: Int) extends Expr {
+%%   def eval: Int = n
+%%   def print { Console.print(n) }
+%% }
+%% class Sum(e1: Expr, e2: Expr) extends Expr {
+%%   def eval: Int = e1.eval + e2.eval
+%%   def print {
+%%     Console.print("(")
+%%     print(e1)
+%%     Console.print("+")
+%%     print(e2)
+%%     Console.print(")")
+%%   }
+%% }
+%% \end{lstlisting}
 %% Hence, classical object-oriented decomposition requires modification
 %% of all existing classes when a system is extended with new operations.
-Consequentemente, decomposição orientada a objetos clássica requer modificação 
-de todas as classes existentes quando um sistema for estendido com novas
-operações.
 
 %% As yet another way we might want to extend the interpreter, consider
 %% expression simplification. For instance, we might want to write a
@@ -3127,72 +2364,36 @@ operações.
 %% seems to bring us back to square one, with all the problems of
 %% verbosity and extensibility.
 
-Ainda como uma outra forma, podemos querer estender o interpretador. 
-Considere a simplificação de expressões. Por exemplo, podemos querer criar 
-uma função que reescreve expressões da forma \code{a * b + a * c} para 
-\code{a * (b + c)}. Esta operação requer inspeção de mais de um nó para a 
-árvore de expressões ao mesmo tempo. Consequentemente, não pode ser implementada
-por um método dentro de cada tipo de expressão, a não ser que tal método também 
-possa inspecionar outros nós. Portanto somos forçados a ter métodos de acesso e 
-classificação neste caso. Isto parece nos levar para a casa inicial, com todos os 
-problemas de estensibilidade e expressividade.
-%----------
-
-%----------
 %% Taking a closer look, one observes that the only purpose of the
 %% classification and access functions is to {\em reverse} the data
 %% construction process.  They let us determine, first, which sub-class
 %% of an abstract base class was used and, second, what were the
 %% constructor arguments. Since this situation is quite common, Scala has
 %% a way to automate it with case classes. 
-Olhando mais de perto, observa-se que o único propósito das funções de acesso
-e classificação  é {\em reverter} o processo de construção de dados. Elas nos 
-permitem determinar, primeiro, qual subclasse de uma classe base abstrata foi 
-usada e, segundo, quais foram os argumentos construtores. Como essa situação é 
-bem comum, Scala tem um modo de automatizá-lo para classes case.
-%----------
 
-%----------
 %% \section{Case Classes and Case Objects}
-\section{Classes Case e Objetos Case}
 
 %% {\em Case classes} and {\em case objects} are defined like a normal
 %% classes or objects, except that the definition is prefixed with the modifier
 %% \code{case}.  For instance, the definitions
-{\em Classes Case} e {\em objetos case} são definidos como classes e objetos 
-normais, exceto que a definição é prefixada com um modificador \code{case}. 
-Por exemplo, as definições:
-
-\begin{lstlisting}
-abstract class Expr
-case class Number(n: Int) extends Expr
-case class Sum(e1: Expr, e2: Expr) extends Expr
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class Expr
+%% case class Number(n: Int) extends Expr
+%% case class Sum(e1: Expr, e2: Expr) extends Expr
+%% \end{lstlisting}
 %% introduce \code{Number} and \code{Sum} as case classes.
 %% The \code{case} modifier in front of a class or object 
 %% definition has the following effects.
 %% \begin{enumerate}
-%% \item Case classes implicitly come with a constructor function, with the same name as the class. 
-%%In our example, the two functions
-intruduzem \code{Number} e \code{Sum} como classes case.
-O modificador \code{case} em frente a uma definição de classe ou objeto tem 
-os seguintes efeitos.
-\begin{enumerate}
-\item Classes case implicitamente vem com uma função construtora, com o mesmo nome da classe.
-No nosso exemplo, as duas funções
-\begin{lstlisting}
-def Number(n: Int) = new Number(n)
-def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
-\end{lstlisting}
-%----------
-
-%----------
-%%would be added. Hence, one can now construct expression trees a bit more concisely, as in
-serão adicionadas. Consequentemente, pode-se agora construir árvores-expressões de modo um 
-pouco mais conciso, como em
-\begin{lstlisting}
-Sum(Sum(Number(1), Number(2)), Number(3))
-\end{lstlisting} 
+%% \item Case classes implicitly come with a constructor function, with the same name as the class. In our example, the two functions
+%% \begin{lstlisting}
+%% def Number(n: Int) = new Number(n)
+%% def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
+%% \end{lstlisting}
+%% would be added. Hence, one can now construct expression trees a bit more concisely, as in
+%% \begin{lstlisting}
+%% Sum(Sum(Number(1), Number(2)), Number(3))
+%% \end{lstlisting} 
 %% \item Case classes and case objects 
 %% implicitly come with implementations of methods
 %% \code{toString}, \code{equals} and \code{hashCode}, which override the
@@ -3200,18 +2401,9 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% of these methods takes in each case the structure of a member of a
 %% case class into account. The \code{toString} method represents an
 %% expression tree the way it was constructed. So,
-\item Classes case e objetos case implicitamente vem com implementações dos métodos 
-\code{toString}, \code{equals} e \code{hashCode}, que sobrescrevem os
-métodos com o mesmo nome na classe \code{AnyRef}. A implementação desses 
-métodos leva em consideração em cada caso a estrutura de um membro de uma classe 
-case. O método \code{toString} representa uma árvore expressão do modo como foi
-construída. Então,  
-\begin{lstlisting}
-Sum(Sum(Number(1), Number(2)), Number(3))
-\end{lstlisting} 
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% Sum(Sum(Number(1), Number(2)), Number(3))
+%% \end{lstlisting} 
 %% would be converted to exactly that string, whereas the default
 %% implementation in class \code{AnyRef} would return a string consisting
 %% of the outermost constructor name \code{Sum} and a number.  The
@@ -3220,19 +2412,9 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% arguments which are themselves pairwise equal. This also affects the
 %% implementation of \code{==} and \code{!=}, which are implemented in
 %% terms of \code{equals} in Scala. So,
-será convertida exatamente naquela cadeia de caracteres, onde a implementação 
-default dentro da classe \code{AnyRef} retornará uma cadeia de caracteres 
-consistindo construtor \code{Sum} mais externo e um número. O método 
-\code{equals} trata dois membros case da classe case do mesmo modo, caso
-eles tenham sido construídos com o mesmo construtor e com argumentos que 
-são par a par iguais. Isso também afeta a implementação de \code{==} e 
-\code{!=}, que são implementados em termos de \code{equals} em Scala. Então,  
- \begin{lstlisting}
- Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
- \end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
+%% \end{lstlisting}
 %% will yield \code{true}. If \code{Sum} or \code{Number} were not case
 %% classes, the same expression would be \code{false}, since the standard
 %% implementation of \code{equals} in class \code{AnyRef} always treats
@@ -3245,27 +2427,13 @@ são par a par iguais. Isso também afeta a implementação de \code{==} e
 %% Case classes implicitly come with nullary accessor methods which
 %% retrieve the constructor arguments.
 %% In our example, \code{Number} would obtain an accessor method
-dará \code{true}. Se \code{Sum} ou \code{Number} não fossem classes case, a 
-mesma expressão seria \code{false}, pois a implementação padrão de \code{equals} na 
-classe \code{AnyRef} sempre trata objetos criados por diferentes chamadas de construtores 
-como sendo diferentes. O método \code{hashCode} segue a mesmo princípio dos 
-outros dois métodos. Computa um código hash a partir do nome do construtor da classe case
-e os códigos hash dos argumentos do construtor, ao invés de o fazer a partir do endereço 
-do objeto, que é o que a implementação default de \code{hashCode} faz.
-\item
-Classes case implicitamente vem com métodos de acesso nulos que recuperam os argumentos 
-do construtor. Em nosso exemplo, \code{Number} obteria um método de acesso  
- \begin{lstlisting}
- def n: Int
- \end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def n: Int
+%% \end{lstlisting}
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
-que retorna o parâmetro \code{n} do construtor, onde \code{Sum} obterá dois métodos de acesso
- \begin{lstlisting}
- def e1: Expr, e2: Expr
- \end{lstlisting}
+%% \begin{lstlisting}
+%% def e1: Expr, e2: Expr
+%% \end{lstlisting}
 %% Hence, if for a value \code{s} of type \code{Sum}, say, one can now
 %% write \code{s.e1}, to access the left operand. However, for a value
 %% \code{e} of type \code{Expr}, the term \code{e.e1} would be illegal
@@ -3277,21 +2445,8 @@ que retorna o parâmetro \code{n} do construtor, onde \code{Sum} obterá dois m
 %% \item 
 %% Case classes allow the constructions of {\em patterns} which refer to
 %% the case class constructor.
- \end{enumerate}
-Consequentemente, para um valor \code{s} de tipo \code{Sum}, digamos, 
-podemos escrever \code{s.e1} para acessar o operando esquerdo. Entretanto, 
-para um valor \code{e} de tipo \code{Expr}, o termo \code{e.e1} será ilegal,
-pois \code{e1} é definido em \code{Sum}; não é um membro da classe base
-\code{Expr}.
-Então, como determinar o construtor e os argumentos do construtor de acesso
-para valores cujo tipo estático é a classe base \code{Expr}? Isso é resolvido
-pela quarta e última particularidade das classes case.
-\item
-Classes case permitem construções de {\em padrões} que se referem ao construtor 
-da classe case.
-%----------
+%% \end{enumerate}
 
-%----------
 %% \section{Pattern Matching}
 
 %% Pattern matching is a generalization of C or Java's \code{switch}
@@ -3301,24 +2456,12 @@ da classe case.
 %% The \code{match} method takes as argument a number of cases. 
 %% For instance, here is an implementation of \code{eval} using 
 %% pattern matching.
-
-\section{Casamento de Padrões}
-O casamento de padrões é uma generalização do comando \code{switch} do C ou
-Java para hierarquias de classes. Ao invés de um comando \code{switch}, há um 
-método padrão \code{match}, que é definido na classe raíz Scala \code{Any}, e 
-portanto está disponível para todos os objetos. O método \code{match} recebe como 
-argumento um número de cases. Por exemplo, aqui está uma implementação de \code{eval}
-usando casamento de padrões.
-
-\begin{lstlisting}
-def eval(e: Expr): Int = e match {
-  case Number(n) => n 
-  case Sum(l, r) => eval(l) + eval(r) 
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def eval(e: Expr): Int = e match {
+%%   case Number(n) => n 
+%%   case Sum(l, r) => eval(l) + eval(r) 
+%% }
+%% \end{lstlisting}
 %% In this example, there are two cases. Each case associates a pattern
 %% with an expression. Patterns are matched against the selector
 %% values \code{e}.  The first pattern in our example,
@@ -3329,16 +2472,7 @@ def eval(e: Expr): Int = e match {
 %% \code{Sum(v}$_1$\code{, v}$_2$\code{)} and binds the pattern variables
 %% \code{l} and \code{r} 
 %% to \code{v}$_1$ and \code{v}$_2$, respectively. 
-Neste exemplo, há dois cases. Cada case associa um padrão a uma expressão. 
-Padrões são casados contra o valor do seletor \code{e}. O primeiro padrão do
-nosso exemplo, \code{Number(n)}, casa todos os valores da forma \code{Number(v)},
-onde \code{v} é um valor arbitrário. Naquele caso, a {\em variável padrão} \code{n}
-é ligada ao valor \code{v}. Similarmente, o padrão \code{Sum(l, r)} casa com todos 
-os valores do seletor da forma \code{Sum(v}$_1$\code{, v}$_2$\code{)} e liga as 
-variáveis padrão \code{l} e \code{r} a \code{v}$_1$ e \code{v}$_2$, respectivamente. 
-%----------
 
-%----------
 %% In general, patterns are built from
 %% \begin{itemize}
 %% \item Case class constructors, e.g. \code{Number}, \code{Sum}, whose arguments
@@ -3353,42 +2487,14 @@ variáveis padrão \code{l} e \code{r} a \code{v}$_1$ e \code{v}$_2$, respectiva
 %% upper case letter.  Each variable name may occur only once in a
 %% pattern. For instance, \code{Sum(x, x)} would be illegal as a pattern,
 %% since the pattern variable \code{x} occurs twice in it.
-Em geral, padrões são construídos a partir
 
-\begin{itemize}
-\item Construtores de classes case, por exemplo \code{Number}, \code{Sum}, cujos
-argumentos são, novamente, padrões, 
-\item variáveis padrão, por exemplo \code{n}, \code{e1}, \code{e2}, 
-\item o padrão ``coringa'' \code{_},
-\item literais, tal como \code{1}, \code{true},  "abc", 
-\item identificadores constantes, tais como \code{MAXINT}, \code{EmptySet}.  
-\end{itemize}
-Variáveis padrão sempre iniciam com uma letra minúscula, para que possamos
-distinguí-las de identificadores constantes, que iniciam com uma letra 
-maiúscula. Cada nome de variável pode ocorrer somente uma vez em um padrão. 
-Por exemplo, \code{Sum(x, x)} seria ilegal como padrão, pois a variável padrão 
-\code{x} ocorre duas vezes dentro dele.  
-
-%----------
-
-%----------
 %% \paragraph{Meaning of Pattern Matching}
 %% A pattern matching expression 
-\begin{lstlisting}
-e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
-\end{lstlisting}
+%% \begin{lstlisting}
+%% e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
+%% \end{lstlisting}
 %% matches the patterns $p_1 \commadots p_n$ in the order they
 %% are written against the selector value \code{e}.
-\paragraph{Significado do Casamento de Padrões}
-Uma expressão de casamento de padrões
-\begin{lstlisting}
-e match { case p$_1$ => e$_1$ ... case p$_n$ => e$_n$ }
-\end{lstlisting}
-casa os padrões $p_1 \commadots p_n$ na ordem em que eles são 
-escritos contra o valor seletor \code{e}.
-%----------
-
-%----------xpto
 %% \begin{itemize}
 %% \item
 %% A constructor pattern $C(p_1 \commadots p_n)$ matches all values that
@@ -3407,40 +2513,36 @@ escritos contra o valor seletor \code{e}.
 %% pattern variables are replaced by corresponding constructor arguments.
 %% If none of the patterns matches, the pattern matching expression is
 %% aborted with a \code{MatchError} exception.
-%----------
 
-%----------
 %% \example Our substitution model of program evaluation extends quite naturally to pattern matching, For instance, here is how \code{eval} applied to a simple expression is re-written:
-\begin{lstlisting}
-     eval(Sum(Number(1), Number(2)))
+%% \begin{lstlisting}
+%%      eval(Sum(Number(1), Number(2)))
 
-->   $\mbox{\tab\tab\rm(by rewriting the application)}$
+%% ->   $\mbox{\tab\tab\rm(by rewriting the application)}$
 
-     Sum(Number(1), Number(2)) match {
-         case Number(n) => n
-         case Sum(e1, e2) => eval(e1) + eval(e2)
-     }
+%%      Sum(Number(1), Number(2)) match {
+%%          case Number(n) => n
+%%          case Sum(e1, e2) => eval(e1) + eval(e2)
+%%      }
 
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
 
-     eval(Number(1)) + eval(Number(2))
+%%      eval(Number(1)) + eval(Number(2))
 
-->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
+%% ->   $\mbox{\tab\tab\rm(by rewriting the first application)}$
 
-     Number(1) match {
-         case Number(n) => n
-         case Sum(e1, e2) => eval(e1) + eval(e2)
-     } + eval(Number(2))
+%%      Number(1) match {
+%%          case Number(n) => n
+%%          case Sum(e1, e2) => eval(e1) + eval(e2)
+%%      } + eval(Number(2))
 
-->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
+%% ->   $\mbox{\tab\tab\rm(by rewriting the pattern match)}$
 
-     1 + eval(Number(2))
+%%      1 + eval(Number(2))
 
-->$^*$ 1 + 2 -> 3
-\end{lstlisting}
-%----------
+%% ->$^*$ 1 + 2 -> 3
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Pattern Matching and Methods}
 %% In the previous example, we have used pattern
 %% matching in a function which was defined outside the class hierarchy
@@ -3448,62 +2550,54 @@ escritos contra o valor seletor \code{e}.
 %% pattern matching function in that class hierarchy itself. For
 %% instance, we could have defined
 %% \code{eval} is a method of the base class \code{Expr}, and still have used pattern matching in its implementation:
-\begin{lstlisting}
-abstract class Expr { 
-  def eval: Int = this match {
-    case Number(n) => n
-    case Sum(e1, e2) => e1.eval + e2.eval 
-  } 
-}
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% abstract class Expr { 
+%%   def eval: Int = this match {
+%%     case Number(n) => n
+%%     case Sum(e1, e2) => e1.eval + e2.eval 
+%%   } 
+%% }
+%% \end{lstlisting}
 
-
-%----------
 %% \begin{exercise} Consider the following definitions representing trees
 %% of integers.  These definitions can be seen as an alternative
 %% representation of \code{IntSet}:
-\begin{lstlisting}
-abstract class IntTree
-case object EmptyTree extends IntTree
-case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class IntTree
+%% case object EmptyTree extends IntTree
+%% case class  Node(elem: Int, left: IntTree, right: IntTree) extends IntTree
+%% \end{lstlisting}
 %% Complete the following implementations of function \code{contains} and \code{insert} for 
 %% \code{IntTree}'s.
-\begin{lstlisting}
-def contains(t: IntTree, v: Int): Boolean = t match { ...
-  ...
-}
-def insert(t: IntTree, v: Int): IntTree = t match { ...
-  ...
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def contains(t: IntTree, v: Int): Boolean = t match { ...
+%%   ...
+%% }
+%% def insert(t: IntTree, v: Int): IntTree = t match { ...
+%%   ...
+%% }
+%% \end{lstlisting}
 %% \end{exercise}
-%----------
 
-
-%----------
 %% \paragraph{Pattern Matching Anonymous Functions}
 
 %% So far, case-expressions always appeared in conjunction with a
 %% \verb@match@ operation. But it is also possible to use
 %% case-expressions by themselves. A block of case-expressions such as
-\begin{lstlisting}
-{ case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
-\end{lstlisting}
+%% \begin{lstlisting}
+%% { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ }
+%% \end{lstlisting}
 %% is seen by itself as a function which matches its arguments
 %% against the patterns $P_1 \commadots P_n$, and produces the result of
 %% one of $E_1 \commadots E_n$. (If no pattern matches, the function
 %% would throw a \code{MatchError} exception instead).
 %% In other words, the expression above is seen as a shorthand for the anonymous function
-\begin{lstlisting}
-(x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
-\end{lstlisting}
+%% \begin{lstlisting}
+%% (x => x match { case $P_1$ => $E_1$ ... case $P_n$ => $E_n$ })
+%% \end{lstlisting}
 %% where \code{x} is a fresh variable which is not used 
 %% otherwise in the expression.
-%----------
 
-%----------
 %% \chapter{Generic Types and Methods}
 
 %% Classes in Scala can have type parameters. We demonstrate the use of
@@ -3511,34 +2605,29 @@ def insert(t: IntTree, v: Int): IntTree = t match { ...
 %% write a data type of stacks of integers, with methods \code{push},
 %% \code{top}, \code{pop}, and \code{isEmpty}. This is achieved by the
 %% following class hierarchy:
-\begin{lstlisting}
-abstract class IntStack {
-  def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
-  def isEmpty: Boolean
-  def top: Int
-  def pop: IntStack
-}
-class IntEmptyStack extends IntStack {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% abstract class IntStack {
+%%   def push(x: Int): IntStack = new IntNonEmptyStack(x, this)
+%%   def isEmpty: Boolean
+%%   def top: Int
+%%   def pop: IntStack
+%% }
+%% class IntEmptyStack extends IntStack {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
 %% Of course, it would also make sense to define an abstraction for a
 %% stack of Strings. To do that, one could take the existing abstraction
 %% for \code{IntStack}, rename it to \code{StringStack} and at the same
 %% time rename all occurrences of type \code{Int} to \code{String}.
-%----------
 
-%----------
 %% A better way, which does not entail code duplication, is to
 %% parameterize the stack definitions with the element type.
 %% Parameterization lets us generalize from a specific instance of a
@@ -3546,40 +2635,34 @@ class IntNonEmptyStack(elem: Int, rest: IntStack) extends IntStack {
 %% only for values, but it is available also for types. To arrive at a
 %% {\em generic} version of \code{Stack}, we equip it with a type
 %% parameter.
-\begin{lstlisting}
-abstract class Stack[A] {
-  def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
-  def isEmpty: Boolean
-  def top: A
-  def pop: Stack[A]
-}
-class EmptyStack[A] extends Stack[A] {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% abstract class Stack[A] {
+%%   def push(x: A): Stack[A] = new NonEmptyStack[A](x, this)
+%%   def isEmpty: Boolean
+%%   def top: A
+%%   def pop: Stack[A]
+%% }
+%% class EmptyStack[A] extends Stack[A] {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class NonEmptyStack[A](elem: A, rest: Stack[A]) extends Stack[A] {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
 %% In the definitions above, `\code{A}' is a {\em type parameter} of
 %% class \code{Stack} and its subclasses.  Type parameters are arbitrary
 %% names; they are enclosed in brackets instead of parentheses, so that
 %% they can be easily distinguished from value parameters.  Here is an
 %% example how the generic classes are used:
-\begin{lstlisting}
-val x = new EmptyStack[Int]
-val y = x.push(1).push(2)
-println(y.pop.top)
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% val x = new EmptyStack[Int]
+%% val y = x.push(1).push(2)
+%% println(y.pop.top)
+%% \end{lstlisting}
 %% The first line creates a new empty stack of \code{Int}'s. Note the
 %% actual type argument \code{[Int]} which replaces the formal type
 %% parameter \code{A}.
@@ -3587,28 +2670,23 @@ println(y.pop.top)
 %% It is also possible to parameterize methods with types. As an example,
 %% here is a generic method which determines whether one stack is a
 %% prefix of another.
-\begin{lstlisting}
-def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
-  p.isEmpty ||
-  p.top == s.top && isPrefix[A](p.pop, s.pop)
-}
-\end{lstlisting}
-%----------
-
-%----------  
+%% \begin{lstlisting}
+%% def isPrefix[A](p: Stack[A], s: Stack[A]): Boolean = {
+%%   p.isEmpty ||
+%%   p.top == s.top && isPrefix[A](p.pop, s.pop)
+%% }
+%% \end{lstlisting}  
 %% The method parameters are called {\em polymorphic}.  Generic methods are
 %% also called {\em polymorphic}.  The term comes from the Greek, where it
 %% means ``having many forms''.  To apply a polymorphic method such as
 %% \code{isPrefix}, we pass type parameters as well as value parameters
 %% to it. For instance,
-\begin{lstlisting}
-val s1 = new EmptyStack[String].push("abc")
-val s2 = new EmptyStack[String].push("abx").push(s1.top)
-println(isPrefix[String](s1, s2))
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% val s1 = new EmptyStack[String].push("abc")
+%% val s2 = new EmptyStack[String].push("abx").push(s1.top)
+%% println(isPrefix[String](s1, s2))
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Local Type Inference}
 %% Passing type parameters such as \code{[Int]} or \code{[String]} all
 %% the time can become tedious in applications where generic functions
@@ -3623,9 +2701,7 @@ println(isPrefix[String](s1, s2))
 %% constructors in situations like these.  In the example above, one
 %% could have written \code{isPrefix(s1, s2)} and the missing type argument
 %% \code{[String]} would have been inserted by the type inferencer. 
-%----------
 
-%----------
 %% \section{Type Parameter Bounds}
 
 %% Now that we know how to make classes generic it is natural to
@@ -3633,15 +2709,12 @@ println(isPrefix[String](s1, s2))
 %% class \code{IntSet} could be generalized to sets with arbitrary
 %% element types. Let's try. The abstract class for generic sets is easily
 %% written.
-\begin{lstlisting}
-abstract class Set[A] {
-  def incl(x: A): Set[A]
-  def contains(x: A): Boolean
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% abstract class Set[A] {
+%%   def incl(x: A): Set[A]
+%%   def contains(x: A): Boolean
+%% }
+%% \end{lstlisting}
 %% However, if we still want to implement sets as binary search trees, we
 %% encounter a problem. The \code{contains} and \code{incl} methods both
 %% compare elements using methods \code{<} and \code{>}. For
@@ -3649,115 +2722,99 @@ abstract class Set[A] {
 %% methods. But for an arbitrary type parameter \code{a}, we cannot
 %% guarantee this. Therefore, the previous implementation of, say,
 %% \code{contains} would generate a compiler error.
-\begin{lstlisting}
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-          ^ < $\mbox{\sl not a member of type}$ A.
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%           ^ < $\mbox{\sl not a member of type}$ A.
+%% \end{lstlisting}
 %% One way to solve the problem is to restrict the legal types that can
 %% be substituted for type \code{A} to only those types that contain methods
 %% \code{<} and \code{>} of the correct types. There is a trait
 %% \code{Ordered[A]} in the standard class library Scala which represents
 %% values which are comparable (via \code{<} and \code{>}) to values of
 %% type \code{A}. This trait is defined as follows:
-\begin{lstlisting}
-/** A class for totally ordered data. */
-trait Ordered[A] {
+%% \begin{lstlisting}
+%% /** A class for totally ordered data. */
+%% trait Ordered[A] {
 
-  /** Result of comparing `this' with operand `that'.
-   *  returns `x' where
-   *  x < 0    iff    this < that
-   *  x == 0   iff    this == that
-   *  x > 0    iff    this > that
-   */
-  def compare(that: A): Int
+%%   /** Result of comparing `this' with operand `that'.
+%%    *  returns `x' where
+%%    *  x < 0    iff    this < that
+%%    *  x == 0   iff    this == that
+%%    *  x > 0    iff    this > that
+%%    */
+%%   def compare(that: A): Int
 
-  def <  (that: A): Boolean = (this compare that) <  0
-  def >  (that: A): Boolean = (this compare that) >  0
-  def <= (that: A): Boolean = (this compare that) <= 0
-  def >= (that: A): Boolean = (this compare that) >= 0
-  def compareTo(that: A): Int = compare(that)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%%   def <  (that: A): Boolean = (this compare that) <  0
+%%   def >  (that: A): Boolean = (this compare that) >  0
+%%   def <= (that: A): Boolean = (this compare that) <= 0
+%%   def >= (that: A): Boolean = (this compare that) >= 0
+%%   def compareTo(that: A): Int = compare(that)
+%% }
+%% \end{lstlisting}
 %% We can enforce the comparability of a type by demanding
 %% that the type is a subtype of \code{Ordered}. This is done by giving an
 %% upper bound to the type parameter of \code{Set}:
-\begin{lstlisting}
-trait Set[A <: Ordered[A]] {
-  def incl(x: A): Set[A]
-  def contains(x: A): Boolean
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% trait Set[A <: Ordered[A]] {
+%%   def incl(x: A): Set[A]
+%%   def contains(x: A): Boolean
+%% }
+%% \end{lstlisting}
 %% The parameter declaration \code{A <: Ordered[A]} introduces \code{A} as a
 %% type parameter which must be a subtype of \code{Ordered[A]}, i.e.\ its values
 %% must be comparable to values of the same type.
-%----------
 
-%----------
 %% With this restriction, we can now implement the rest of the generic
 %% set abstraction as we did in the case of \code{IntSet}s before.
 
-\begin{lstlisting}
-class EmptySet[A <: Ordered[A]] extends Set[A] {
-  def contains(x: A): Boolean = false
-  def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class EmptySet[A <: Ordered[A]] extends Set[A] {
+%%   def contains(x: A): Boolean = false
+%%   def incl(x: A): Set[A] = new NonEmptySet(x, new EmptySet[A], new EmptySet[A])
+%% }
+%% \end{lstlisting}
 
-\begin{lstlisting}
-class NonEmptySet[A <: Ordered[A]]
-        (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
-  def contains(x: A): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: A): Set[A] =
-    if (x < elem) new NonEmptySet(elem, left incl x, right)
-    else if (x > elem) new NonEmptySet(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class NonEmptySet[A <: Ordered[A]]
+%%         (elem: A, left: Set[A], right: Set[A]) extends Set[A] {
+%%   def contains(x: A): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: A): Set[A] =
+%%     if (x < elem) new NonEmptySet(elem, left incl x, right)
+%%     else if (x > elem) new NonEmptySet(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
 %% Note that we have left out the type argument in the object creations
 %% \code{new NonEmptySet(...)}. In the same way as for polymorphic methods,
 %% missing type arguments in constructor calls are inferred from value
 %% arguments and/or the expected result type.
-%----------
 
-%----------
 %% Here is an example that uses the generic set abstraction. Let's first
 %% create a subclass of \lstinline@Ordered@, like this:
-\begin{lstlisting}
-case class Num(value: Double) extends Ordered[Num] {
-  def compare(that: Num): Int =
-    if (this.value < that.value) -1
-    else if (this.value > that.value) 1
-    else 0
-}
-\end{lstlisting}
-%%Then:
-\begin{lstlisting}
-val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
-s.contains(Num(1.5))
-\end{lstlisting}
-%%This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
-%%However, the following example is in error.
-\begin{lstlisting}
-val s = new EmptySet[java.io.File]
-                    ^ java.io.File $\mbox{\sl does not conform to type}$
-                      $\mbox{\sl parameter bound}$ Ordered[java.io.File].
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% case class Num(value: Double) extends Ordered[Num] {
+%%   def compare(that: Num): Int =
+%%     if (this.value < that.value) -1
+%%     else if (this.value > that.value) 1
+%%     else 0
+%% }
+%% \end{lstlisting}
+%% Then:
+%% \begin{lstlisting}
+%% val s = new EmptySet[Num].incl(Num(1.0)).incl(Num(2.0))
+%% s.contains(Num(1.5))
+%% \end{lstlisting}
+%% This is OK, as type \code{Num} implements the trait \code{Ordered[Num]}.
+%% However, the following example is in error.
+%% \begin{lstlisting}
+%% val s = new EmptySet[java.io.File]
+%%                     ^ java.io.File $\mbox{\sl does not conform to type}$
+%%                       $\mbox{\sl parameter bound}$ Ordered[java.io.File].
+%% \end{lstlisting}
 %% One probem with type parameter bounds is that they require
 %% forethought: if we had not declared \lstinline@Num@ a subclass of
 %% \lstinline@Ordered@, we would not have been able to use \lstinline@Num@
@@ -3765,36 +2822,27 @@ val s = new EmptySet[java.io.File]
 %% such as \lstinline@Int@, \lstinline@Double@, or
 %% \lstinline@String@ are not subclasses of \lstinline@Ordered@, so
 %% values of these types cannot be used as set elements.
-%----------
 
-%----------
 %% A more flexible design, which admits elements of these types, uses
 %% {\em view bounds} instead of the plain type bounds we have seen so
 %% far. The only change this entails in the example above is in the type
 %% parameters:
-\begin{lstlisting}
-trait Set[A <% Ordered[A]] ...
-class EmptySet[A <% Ordered[A]] ...
-class NonEmptySet[A <% Ordered[A]] ...
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% trait Set[A <% Ordered[A]] ...
+%% class EmptySet[A <% Ordered[A]] ...
+%% class NonEmptySet[A <% Ordered[A]] ...
+%% \end{lstlisting}
 %% View bounds \lstinline@<%@ are weaker than plain bounds \verb@<:@:
 %% A view bounded type parameter clause \lstinline@[A <% T]@ only
 %% specifies that the bounded type \lstinline@A@ must be {\em convertible} to
 %% the bound type \lstinline@T@, using an implicit conversion.
-%----------
 
-%----------
 %% The Scala library predefines implicit conversions for a number of
 %% types, including the primitive types and \lstinline@String@.
 %% Therefore, the redesign set abstraction can be instantiated with these
 %% types as well. More explanations on implicit conversions and view
 %% bounds are given in Section~\ref{sec:implicits}.
-%----------
 
-%----------
 %% \section{Variance Annotations}\label{sec:first-arrays}
 
 %% The combination of type parameters and subtyping poses some
@@ -3804,20 +2852,15 @@ class NonEmptySet[A <% Ordered[A]] ...
 %% \code{AnyRef}s.  More generally, if \code{T} is a subtype of type \code{S}
 %% then \code{Stack[T]} should be a subtype of \code{Stack[S]}. 
 %% This property is called {\em co-variant} subtyping.
-%----------
 
-%----------
 %% In Scala, generic types have by default non-variant subtyping. That
 %% is, with \code{Stack} defined as above, stacks with different element
 %% types would never be in a subtype relation. However, we can enforce
 %% co-variant subtyping of stacks by changing the first line of the
 %% definition of class \code{Stack} as follows.
-\begin{lstlisting}
-class Stack[+A] {
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%% \end{lstlisting}
 %% Prefixing a formal type parameter with a \code{+} indicates that
 %% subtyping is covariant in that parameter. 
 %% Besides \code{+}, there is also a prefix \code{-} which indicates
@@ -3825,44 +2868,34 @@ class Stack[+A] {
 %% Stack[-A] ...}, then \code{T} a subtype of type \code{S} would imply
 %% that \code{Stack[S]} is a subtype of \code{Stack[T]} (which in the
 %% case of stacks would be rather surprising!).
-%----------
 
-%----------
 %% In a purely functional world, all types could be co-variant. However,
 %% the situation changes once we introduce mutable data. Consider the
 %% case of arrays in Java or .NET. Such arrays are represented in Scala
 %% by a generic class \code{Array}. Here is a partial definition of this
 %% class.
-\begin{lstlisting}
-class Array[A] {
-  def apply(index: Int): A
-  def update(index: Int, elem: A)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Array[A] {
+%%   def apply(index: Int): A
+%%   def update(index: Int, elem: A)
+%% }
+%% \end{lstlisting}
 %% The class above defines the way Scala arrays are seen from Scala user
 %% programs. The Scala compiler will map this abstraction to the
 %% underlying arrays of the host system in most cases where this
 %% possible.
-%----------
 
-%----------
 %% In Java, arrays are indeed covariant; that is, for reference types
 %% \code{T} and \code{S}, if \code{T} is a subtype of \code{S}, then also
 %% \code{Array[T]} is a subtype of \code{Array[S]}. This might seem
 %% natural but leads to safety problems that require special runtime
 %% checks. Here is an example:
-\begin{lstlisting}
-val x = new Array[String](1)
-val y: Array[Any] = x
-y(0) = new Rational(1, 2)  // this is syntactic sugar for
-                           // y.update(0, new Rational(1, 2))
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% val x = new Array[String](1)
+%% val y: Array[Any] = x
+%% y(0) = new Rational(1, 2)  // this is syntactic sugar for
+%%                            // y.update(0, new Rational(1, 2))
+%% \end{lstlisting}
 %% In the first line, a new array of strings is created. In the second
 %% line, this array is bound to a variable \code{y}, of type
 %% \code{Array[Any]}.  Assuming arrays are covariant, this is OK, since
@@ -3871,26 +2904,20 @@ y(0) = new Rational(1, 2)  // this is syntactic sugar for
 %% OK, since type \code{Rational} is a subtype of the element type
 %% \code{Any} of the array \code{y}. We thus end up storing a rational
 %% number in an array of strings, which clearly violates type soundness. 
-%----------
 
-%----------
 %% Java solves this problem by introducing a run-time check in the third
 %% line which tests whether the stored element is compatible with the
 %% element type with which the array was created. We have seen in the
 %% example that this element type is not necessarily the static element
 %% type of the array being updated. If the test fails, an
 %% \code{ArrayStoreException} is raised.
-%----------
 
-%----------
 %% Scala solves this problem instead statically, by disallowing the
 %% second line at compile-time, because arrays in Scala have non-variant
 %% subtyping. This raises the question how a Scala compiler verifies that
 %% variance annotations are correct. If we had simply declared arrays
 %% co-variant, how would the potential problem have been detected?
-%----------
 
-%----------
 %% Scala uses a conservative approximation to verify soundness of
 %% variance annotations.  A covariant type parameter of a class may only
 %% appear in co-variant positions inside the class.  Among the co-variant
@@ -3898,44 +2925,34 @@ y(0) = new Rational(1, 2)  // this is syntactic sugar for
 %% methods in the class, and type arguments to other covariant types. Not
 %% co-variant are types of formal method parameters. Hence, the following
 %% class definition would have been rejected
-\begin{lstlisting}
-class Array[+A] {
-  def apply(index: Int): A
-  def update(index: Int, elem: A)
-                               ^ $\mbox{\sl covariant type parameter}$ A
-                                 $\mbox{\sl appears in contravariant position.}$
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Array[+A] {
+%%   def apply(index: Int): A
+%%   def update(index: Int, elem: A)
+%%                                ^ $\mbox{\sl covariant type parameter}$ A
+%%                                  $\mbox{\sl appears in contravariant position.}$
+%% }
+%% \end{lstlisting}
 %% So far, so good. Intuitively, the compiler was correct in rejecting
 %% the \code{update} procedure in a co-variant class because \code{update}
 %% potentially changes state, and therefore undermines the soundness of
 %% co-variant subtyping. 
-%----------
 
-%----------
 %% However, there are also methods which do not mutate state, but where a
 %% type parameter still appears contra-variantly. An example is
 %% \code{push} in type \code{Stack}. Again the Scala compiler will reject
 %% the definition of this method for co-variant stacks.
-\begin{lstlisting}
-class Stack[+A] {
-  def push(x: A): Stack[A] =
-              ^ $\mbox{\sl covariant type parameter}$ A
-                $\mbox{\sl appears in contravariant position.}$
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%%   def push(x: A): Stack[A] =
+%%               ^ $\mbox{\sl covariant type parameter}$ A
+%%                 $\mbox{\sl appears in contravariant position.}$
+%% \end{lstlisting}
 %% This is a pity, because, unlike arrays, stacks are purely functional data
 %% structures and therefore should enable co-variant subtyping. However,
 %% there is a a way to solve the problem by using a polymorphic method
 %% with a lower type parameter bound.
-%----------
 
-%----------
 %% \section{Lower Bounds}
 
 %% We have seen upper bounds for type parameters. In a type parameter
@@ -3945,23 +2962,19 @@ class Stack[+A] {
 %% \code{T >: S}, the type parameter \code{T} is restricted to range only
 %% over {\em supertypes} of type \code{S}. (One can also combine lower and
 %% upper bounds, as in \code{T >: S <: U}.)
-%----------
 
-%----------
 %% Using lower bounds, we can generalize the \code{push} method in
 %% \code{Stack} as follows.
-\begin{lstlisting}
-class Stack[+A] {
-  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class Stack[+A] {
+%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+%% \end{lstlisting}
 %% Technically, this solves our variance problem since now the type
 %% parameter \code{A} appears no longer as a parameter type of method
 %% \code{push}. Instead, it appears as lower bound for another type
 %% parameter of a method, which is classified as a co-variant position.
 %% Hence, the Scala compiler accepts the new definition of \code{push}.
-%----------
 
-%----------
 %% In fact, we have not only solved the technical variance problem but
 %% also have generalized the definition of \code{push}.  Before, we were
 %% required to push only elements with types that conform to the declared
@@ -3970,30 +2983,23 @@ class Stack[+A] {
 %% accordingly. For instance, we can now push an \code{AnyRef} onto a
 %% stack of \code{String}s, but the resulting stack will be a stack of
 %% \code{AnyRef}s instead of a stack of \code{String}s!
-%----------
 
-%----------
 %% In summary, one should not hesitate to add variance annotations to
 %% your data structures, as this yields rich natural subtyping
 %% relationships. The compiler will detect potential soundness
 %% problems. Even if the compiler's approximation is too conservative, as
 %% in the case of method \code{push} of class \code{Stack}, this will
 %% often suggest a useful generalization of the contested method.
-%----------
 
-%----------
 %% \section{Least Types}
 
 %% Scala does not allow one to parameterize objects with types. That's
 %% why we originally defined a generic class \code{EmptyStack[A]}, even
 %% though a single value denoting empty stacks of arbitrary type would
 %% do. For co-variant stacks, however, one can use the following idiom:
-\begin{lstlisting}
-object EmptyStack extends Stack[Nothing] { ... }
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% object EmptyStack extends Stack[Nothing] { ... }
+%% \end{lstlisting}
 %% The bottom type \code{Nothing} contains no value, so the type
 %% \code{Stack[Nothing]} expresses the fact that an \code{EmptyStack}
 %% contains no elements. Furthermore, \code{Nothing} is a subtype of all
@@ -4001,136 +3007,110 @@ object EmptyStack extends Stack[Nothing] { ... }
 %% subtype of \code{Stack[T]}, for any other type \code{T}. This makes it
 %% possible to use a single empty stack object in user code. For
 %% instance:
-\begin{lstlisting}
-val s = EmptyStack.push("abc").push(new AnyRef())
-\end{lstlisting}
-%----------
-
-%----------
-%%Let's analyze the type assignment for this expression in detail.  The
-%%\code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
-%%method
-\begin{lstlisting}
-push[B >: Nothing](elem: B): Stack[B] .
-\end{lstlisting}
+%% \begin{lstlisting}
+%% val s = EmptyStack.push("abc").push(new AnyRef())
+%% \end{lstlisting}
+%% Let's analyze the type assignment for this expression in detail.  The
+%% \code{EmptyStack} object is of type \code{Stack[Nothing]}, which has a
+%% method
+%% \begin{lstlisting}
+%% push[B >: Nothing](elem: B): Stack[B] .
+%% \end{lstlisting}
 %% Local type inference will determine that the type parameter \code{B}
 %% should be instantiated to \code{String} in the application 
 %% \code{EmptyStack.push("abc")}. The result type of that application is hence
 %% \code{Stack[String]}, which in turn has a method
-\begin{lstlisting}
-push[B >: String](elem: B): Stack[B] .
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% push[B >: String](elem: B): Stack[B] .
+%% \end{lstlisting}
 %% The final part of the value definition above is the application of
 %% this method to \code{new AnyRef()}. Local type inference will
 %% determine that the type parameter \code{b} should this time be
 %% instantiated to \code{AnyRef}, with result type \code{Stack[AnyRef]}.
 %% Hence, the type assigned to value \code{s} is \code{Stack[AnyRef]}.
-%----------
 
-%----------
 %% Besides \code{Nothing}, which is a subtype of every other type, there
 %% is also the type \code{Null}, which is a subtype of
 %% \code{scala.AnyRef}, and every class derived from it. The \code{null}
 %% literal in Scala is the only value of that type. This makes
 %% \code{null} compatible with every reference type, but not with a value
 %% type such as \code{Int}.
-%----------
 
-%----------
 %% We conclude this section with the complete improved definition of
 %% stacks. Stacks have now co-variant subtyping, the \code{push} method
 %% has been generalized, and the empty stack is represented by a single
 %% object.
-\begin{lstlisting}
-abstract class Stack[+A] {
-  def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
-  def isEmpty: Boolean
-  def top: A
-  def pop: Stack[A]
-}
-object EmptyStack extends Stack[Nothing] {
-  def isEmpty = true
-  def top = error("EmptyStack.top")
-  def pop = error("EmptyStack.pop")
-}
-class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
-  def isEmpty = false
-  def top = elem
-  def pop = rest
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class Stack[+A] {
+%%   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)
+%%   def isEmpty: Boolean
+%%   def top: A
+%%   def pop: Stack[A]
+%% }
+%% object EmptyStack extends Stack[Nothing] {
+%%   def isEmpty = true
+%%   def top = error("EmptyStack.top")
+%%   def pop = error("EmptyStack.pop")
+%% }
+%% class NonEmptyStack[+A](elem: A, rest: Stack[A]) extends Stack[A] {
+%%   def isEmpty = false
+%%   def top = elem
+%%   def pop = rest
+%% }
+%% \end{lstlisting}
 %% Many classes in the Scala library are generic. We now present two
 %% commonly used families of generic classes, tuples and functions. The
 %% discussion of another common class, lists, is deferred to the next
 %% chapter.
-%----------
 
-%----------
 %% \section{Tuples}
 
 %% Sometimes, a function needs to return more than one result. For
 %% instance, take the function \code{divmod} which returns the integer quotient
 %% and rest of two given integer arguments.  Of course, one can define a
 %% class to hold the two results of \code{divmod}, as in:
-\begin{lstlisting}
-case class TwoInts(first: Int, second: Int)
-def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% case class TwoInts(first: Int, second: Int)
+%% def divmod(x: Int, y: Int): TwoInts = new TwoInts(x / y, x % y)
+%% \end{lstlisting}
 %% However, having to define a new class for every possible pair of
 %% result types is very tedious. In Scala one can use instead a
 %% generic class \lstinline@Tuple$2$@, which is defined as follows:
-\begin{lstlisting}
-package scala
-case class Tuple2[A, B](_1: A, _2: B)
-\end{lstlisting}
-%%With \code{Tuple2}, the \code{divmod} method can be written as follows.
-\begin{lstlisting}
-def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% package scala
+%% case class Tuple2[A, B](_1: A, _2: B)
+%% \end{lstlisting}
+%% With \code{Tuple2}, the \code{divmod} method can be written as follows.
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int) = new Tuple2[Int, Int](x / y, x % y)
+%% \end{lstlisting}
 %% As usual, type parameters to constructors can be omitted if they are
 %% deducible from value arguments. There exist also tuple classes for
 %% every other number of elements (the current Scala implementation
 %% limits this to tuples of some reasonable number of elements).  
-%----------
 
-%----------
 %% \comment{
 %% Also, Scala defines an alias \code{Pair} for \code{Tuple2} (as well as
 %% \code{Triple} for \code{Tuple3}).  With these conventions,
 %% \code{divmod} can equivalently be written as follows.
-\begin{lstlisting}
-def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int): Pair(Int, Int) = Pair(x / y, x % y)
+%% \end{lstlisting}
 %% }
-%----------
-
-%----------
 %% How are elements of tuples accessed? Since tuples are case classes,
 %% there are two possibilities. One can either access a tuple's fields
 %% using the names of the constructor parameters \lstinline@_$i$@, as in the following example:
-\begin{lstlisting}
-val xy = divmod(x, y)
-println("quotient: " + xy._1 + ", rest: " + xy._2)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% val xy = divmod(x, y)
+%% println("quotient: " + xy._1 + ", rest: " + xy._2)
+%% \end{lstlisting}
 %% Or one uses pattern matching on tuples, as in the following example:
-\begin{lstlisting}
-divmod(x, y) match {
-  case Tuple2(n, d) =>
-    println("quotient: " + n + ", rest: " + d)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% divmod(x, y) match {
+%%   case Tuple2(n, d) =>
+%%     println("quotient: " + n + ", rest: " + d)
+%% }
+%% \end{lstlisting}
 %% Note that type parameters are never used in patterns; it would have
 %% been illegal to write case \code{Tuple2[Int, Int](n, d)}.
 
@@ -4140,15 +3120,12 @@ divmod(x, y) match {
 %% \lstinline@Tuple$n$($x_1 \commadots x_n$)@. The $(...)$ syntax works
 %% equivalently for types and for patterns. With that tuple syntax, the
 %% \lstinline@divmod@ example is written as follows:
-\begin{lstlisting}
-def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
-divmod(x, y) match {
-  case (n, d) => println("quotient: " + n + ", rest: " + d)
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def divmod(x: Int, y: Int): (Int, Int) = (x / y, x % y)
+%% divmod(x, y) match {
+%%   case (n, d) => println("quotient: " + n + ", rest: " + d)
+%% }
+%% \end{lstlisting}
 %% \section{Functions}\label{sec:functions}
 
 %% Scala is a functional language in that functions are first-class
@@ -4157,15 +3134,12 @@ divmod(x, y) match {
 %% instance, a function from type \code{String} to type \code{Int} is
 %% represented as an instance of the trait \code{Function1[String, Int]}.
 %% The \code{Function1} trait is defined as follows.
-\begin{lstlisting}
-package scala
-trait Function1[-A, +B] {
-  def apply(x: A): B
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% package scala
+%% trait Function1[-A, +B] {
+%%   def apply(x: A): B
+%% }
+%% \end{lstlisting}
 %% Besides \code{Function1}, there are also definitions of for functions
 %% of all other arities (the current implementation implements this only
 %% up to a reasonable limit).  That is, there is one definition for each
@@ -4173,18 +3147,14 @@ trait Function1[-A, +B] {
 %% ~\lstinline@$(T_1 \commadots T_n)$ => $S$@~ is simply an abbreviation
 %% for the parameterized type ~\lstinline@Function$n$[$T_1 \commadots
 %% T_n, S$]@~.
-%----------
 
-%----------
 %% Scala uses the same syntax $f(x)$ for function application, no matter
 %% whether $f$ is a method or a function object. This is made possible by
 %% the following convention: A function application $f(x)$ where $f$ is
 %% an object (as opposed to a method) is taken to be a shorthand for
 %% \lstinline@$f$.apply($x$)@. Hence, the \code{apply} method of a
 %% function type is inserted automatically where this is necessary.
-%----------
 
-%----------
 %% That's also why we defined array subscripting in
 %% Section~\ref{sec:first-arrays} by an \code{apply} method.  For any
 %% array \code{a}, the subscript operation \code{a(i)} is taken to be a
@@ -4192,14 +3162,11 @@ trait Function1[-A, +B] {
 
 %% Functions are an example where a contra-variant type parameter
 %% declaration is useful. For example, consider the following code:
-\begin{lstlisting}
-val f: (AnyRef => Int)  =  x => x.hashCode()
-val g: (String => Int)  =  f
-g("abc")
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% val f: (AnyRef => Int)  =  x => x.hashCode()
+%% val g: (String => Int)  =  f
+%% g("abc")
+%% \end{lstlisting}
 %% It's sound to bind the value \code{g} of type \code{String => Int} to
 %% \code{f}, which is of type \code{AnyRef => Int}. Indeed, all one can
 %% do with function of type \code{String => Int} is pass it a string in
@@ -4209,72 +3176,64 @@ g("abc")
 %% in its argument type whereas it is covariant in its result type.
 %% In short, $S \Rightarrow T$ is a subtype of $S' \Rightarrow T'$, provided
 %% $S'$ is a subtype of $S$ and $T$ is a subtype of $T'$.
-%----------
 
-%----------
 %% \example Consider the Scala code
-\begin{lstlisting}
-val plus1: (Int => Int)  =  (x: Int) => x + 1
-plus1(2)
-\end{lstlisting}
-%%This is expanded into the following object code.
-\begin{lstlisting}
-val plus1: Function1[Int, Int] = new Function1[Int, Int] {
-  def apply(x: Int): Int = x + 1
-}
-plus1.apply(2)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% val plus1: (Int => Int)  =  (x: Int) => x + 1
+%% plus1(2)
+%% \end{lstlisting}
+%% This is expanded into the following object code.
+%% \begin{lstlisting}
+%% val plus1: Function1[Int, Int] = new Function1[Int, Int] {
+%%   def apply(x: Int): Int = x + 1
+%% }
+%% plus1.apply(2)
+%% \end{lstlisting}
 %% Here, the object creation \lstinline@new Function1[Int, Int]{ ... }@
 %% represents an instance of an {\em anonymous class}. It combines the
 %% creation of a new \code{Function1} object with an implementation of 
 %% the \code{apply} method (which is abstract in \code{Function1}).
 %% Equivalently, but more verbosely, one could have used a local class:
-\begin{lstlisting}
-val plus1: Function1[Int, Int] = {
-  class Local extends Function1[Int, Int] {
-    def apply(x: Int): Int = x + 1
-  }
-  new Local: Function1[Int, Int]
-}
-plus1.apply(2)
-\end{lstlisting}
-%----------
-
-%---------- 
+%% \begin{lstlisting}
+%% val plus1: Function1[Int, Int] = {
+%%   class Local extends Function1[Int, Int] {
+%%     def apply(x: Int): Int = x + 1
+%%   }
+%%   new Local: Function1[Int, Int]
+%% }
+%% plus1.apply(2)
+%% \end{lstlisting}
+ 
 %% \chapter{Lists}
 
 %% Lists are an important data structure in many Scala programs.  
 %% A list containing the elements \code{x}$_1$, \ldots, \code{x}$_n$ is written
 %% \code{List(x}$_1$\code{, ..., x}$_n$\code{)}. Examples are:
-\begin{lstlisting}
-val fruit = List("apples", "oranges", "pears")
-val nums  = List(1, 2, 3, 4)
-val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-val empty = List()
-\end{lstlisting}
+%% \begin{lstlisting}
+%% val fruit = List("apples", "oranges", "pears")
+%% val nums  = List(1, 2, 3, 4)
+%% val diag3 = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+%% val empty = List()
+%% \end{lstlisting}
 %% Lists are similar to arrays in languages such as C or Java, but there
 %% are also three important differences. First, lists are immutable. That
 %% is, elements of a list cannot be changed by assignment. Second, 
 %% lists have a recursive structure, whereas arrays are flat. Third,
 %% lists support a much richer set of operations than arrays usually do.
-%----------
 
-%----------
 %% \section{Using Lists}
 
 %% \paragraph{The List type}
 %% Like arrays, lists are {\em homogeneous}. That is, the elements of a
 %% list all have the same type.  The type of a list with elements of type
 %% \code{T} is written \code{List[T]} (compare to \code{T[]} in Java).
-\begin{lstlisting}
-val fruit: List[String]    = List("apples", "oranges", "pears")
-val nums : List[Int]       = List(1, 2, 3, 4)
-val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
-val empty: List[Int]       = List()
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% val fruit: List[String]    = List("apples", "oranges", "pears")
+%% val nums : List[Int]       = List(1, 2, 3, 4)
+%% val diag3: List[List[Int]] = List(List(1, 0, 0), List(0, 1, 0), List(0, 0, 1))
+%% val empty: List[Int]       = List()
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{List constructors}
 %% All lists are built from two more fundamental constructors, \code{Nil}
 %% and \code{::} (pronounced ``cons''). \code{Nil} represents an empty
@@ -4283,27 +3242,22 @@ val empty: List[Int]       = List()
 %% which is followed by (the elements of) list \code{xs}.  Hence, the
 %% list values above could also have been defined as follows (in fact
 %% their previous definition is simply syntactic sugar for the definitions below).
-\begin{lstlisting}
-val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
-val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
-val diag3  = (1 :: (0 :: (0 :: Nil))) ::
-             (0 :: (1 :: (0 :: Nil))) ::
-             (0 :: (0 :: (1 :: Nil))) :: Nil
-val empty  = Nil
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% val fruit  = "apples" :: ("oranges" :: ("pears" :: Nil))
+%% val nums   = 1 :: (2 :: (3 :: (4 :: Nil)))
+%% val diag3  = (1 :: (0 :: (0 :: Nil))) ::
+%%              (0 :: (1 :: (0 :: Nil))) ::
+%%              (0 :: (0 :: (1 :: Nil))) :: Nil
+%% val empty  = Nil
+%% \end{lstlisting}
 %% The `\code{::}' operation associates to the right: \code{A :: B :: C} is
 %% interpreted as \code{A :: (B :: C)}.  Therefore, we can drop the
 %% parentheses in the definitions above. For instance, we can write
 %% shorter
-\begin{lstlisting}
-val nums  =  1 :: 2 :: 3 :: 4 :: Nil
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% val nums  =  1 :: 2 :: 3 :: 4 :: Nil
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Basic operations on lists}
 %% All operations on lists can be expressed in terms of the following three:
 
@@ -4313,23 +3267,19 @@ val nums  =  1 :: 2 :: 3 :: 4 :: Nil
 %% & first element,\\
 %% \code{isEmpty} & returns \code{true} iff the list is empty
 %% \end{tabular}
-%----------
 
-%----------
 %% These operations are defined as methods of list objects. So we invoke
 %% them by selecting from the list that's operated on. Examples:
-\begin{lstlisting}
-empty.isEmpty   = true
-fruit.isEmpty   = false
-fruit.head      = "apples"
-fruit.tail.head = "oranges"
-diag3.head      = List(1, 0, 0)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% empty.isEmpty   = true
+%% fruit.isEmpty   = false
+%% fruit.head      = "apples"
+%% fruit.tail.head = "oranges"
+%% diag3.head      = List(1, 0, 0)
+%% \end{lstlisting}
 %% The \code{head} and \code{tail} methods are defined only for non-empty
 %% lists.  When selected from an empty list, they throw an exception.
-%----------
 
-%----------
 %% As an example of how lists can be processed, consider sorting the
 %% elements of a list of numbers into ascending order. One simple way to
 %% do so is {\em insertion sort}, which works as follows: To sort a
@@ -4337,54 +3287,45 @@ diag3.head      = List(1, 0, 0)
 %% the remainder \code{xs} and insert the element \code{x} at the right
 %% position in the result. Sorting an empty list will yield the
 %% empty list. Expressed as Scala code:
-\begin{lstlisting}
-def isort(xs: List[Int]): List[Int] =
-  if (xs.isEmpty) Nil
-  else insert(xs.head, isort(xs.tail))
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def isort(xs: List[Int]): List[Int] =
+%%   if (xs.isEmpty) Nil
+%%   else insert(xs.head, isort(xs.tail))
+%% \end{lstlisting}
 
-%----------
 %% \begin{exercise} Provide an implementation of the missing function
 %% \code{insert}.
 %% \end{exercise}
-%----------
 
-%----------
 %% \paragraph{List patterns} In fact, \code{::} is defined as a case
 %% class in Scala's standard library. Hence, it is possible to decompose
 %% lists by pattern matching, using patterns composed from the \code{Nil}
 %% and \code{::} constructors. For instance, \code{isort} can be written
 %% alternatively as follows.
-\begin{lstlisting}
-def isort(xs: List[Int]): List[Int] = xs match {
-  case List() => List()
-  case x :: xs1 => insert(x, isort(xs1))
-}
-\end{lstlisting}
-onde
-\begin{lstlisting}
-def insert(x: Int, xs: List[Int]): List[Int] = xs match {
-  case List() => List(x)
-  case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
-}
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def isort(xs: List[Int]): List[Int] = xs match {
+%%   case List() => List()
+%%   case x :: xs1 => insert(x, isort(xs1))
+%% }
+%% \end{lstlisting}
+%% where
+%% \begin{lstlisting}
+%% def insert(x: Int, xs: List[Int]): List[Int] = xs match {
+%%   case List() => List(x)
+%%   case y :: ys => if (x <= y) x :: xs else y :: insert(x, ys)
+%% }
+%% \end{lstlisting}
 
-%----------
 %% \section{Definition of class List I: First Order Methods}
 %% \label{sec:list-first-order}
 
 %% Lists are not built in in Scala; they are defined by an abstract class
 %% \code{List}, which comes with two subclasses for \code{::} and \code{Nil}.
 %% In the following we present a tour through class \code{List}.
-\begin{lstlisting}
-package scala
-abstract class List[+A] {
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% package scala
+%% abstract class List[+A] {
+%% \end{lstlisting}
 %% \code{List} is an abstract class, so one cannot define elements by
 %% calling the empty \code{List} constructor (e.g. by
 %% \code{new List}).  The class has a type parameter \code{a}. It is
@@ -4395,214 +3336,179 @@ abstract class List[+A] {
 %% classes of Scala.
 %%  \code{List} defines a number of methods, which are
 %% explained in the following.
-%----------
 
-%----------
 %% \paragraph{Decomposing lists}
 %% First, there are the three basic methods \code{isEmpty},
 %% \code{head}, \code{tail}. Their implementation in terms of pattern
 %% matching is straightforward:
-\begin{lstlisting}
-def isEmpty: Boolean = this match {
-  case Nil => true
-  case x :: xs => false
-}
-def head: A = this match {
-  case Nil => error("Nil.head")
-  case x :: xs => x
-}
-def tail: List[A] = this match {
-  case Nil => error("Nil.tail")
-  case x :: xs => xs
-}
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def isEmpty: Boolean = this match {
+%%   case Nil => true
+%%   case x :: xs => false
+%% }
+%% def head: A = this match {
+%%   case Nil => error("Nil.head")
+%%   case x :: xs => x
+%% }
+%% def tail: List[A] = this match {
+%%   case Nil => error("Nil.tail")
+%%   case x :: xs => xs
+%% }
+%% \end{lstlisting}
 
-%----------
-%%The next function computes the length of a list.
-\begin{lstlisting}
-def length: Int = this match {
-  case Nil => 0
-  case x :: xs => 1 + xs.length
-}
-\end{lstlisting}
+%% The next function computes the length of a list.
+%% \begin{lstlisting}
+%% def length: Int = this match {
+%%   case Nil => 0
+%%   case x :: xs => 1 + xs.length
+%% }
+%% \end{lstlisting}
 %% \begin{exercise} Design a tail-recursive version of \code{length}.
 %% \end{exercise}
-%----------
 
-%----------
 %% The next two functions are the complements of \code{head} and
 %% \code{tail}.
-\begin{lstlisting}
-def last: A
-def init: List[A]
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def last: A
+%% def init: List[A]
+%% \end{lstlisting}
 %% \code{xs.last} returns the last element of list \code{xs}, whereas
 %% \code{xs.init} returns all elements of \code{xs} except the last.
 %% Both functions have to traverse the entire list, and are thus less
 %% efficient than their \code{head} and \code{tail} analogues.
 %% Here is the implementation of \code{last}.
-\begin{lstlisting}
-def last: A = this match {
-  case Nil      => error("Nil.last")
-  case x :: Nil => x
-  case x :: xs  => xs.last
-}
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%% def last: A = this match {
+%%   case Nil      => error("Nil.last")
+%%   case x :: Nil => x
+%%   case x :: xs  => xs.last
+%% }
+%% \end{lstlisting}
 %% The implementation of \code{init} is analogous.
 
 %% The next three functions return a prefix of the list, or a suffix, or
 %% both.
-\begin{lstlisting}
-def take(n: Int): List[A] =
-  if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
+%% \begin{lstlisting}
+%% def take(n: Int): List[A] =
+%%   if (n == 0 || isEmpty) Nil else head :: tail.take(n-1)
 
-def drop(n: Int): List[A] =
-  if (n == 0 || isEmpty) this else tail.drop(n-1)
+%% def drop(n: Int): List[A] =
+%%   if (n == 0 || isEmpty) this else tail.drop(n-1)
 
-def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
-\end{lstlisting}
-%----------
-
-%----------
+%% def split(n: Int): (List[A], List[A]) = (take(n), drop(n))
+%% \end{lstlisting}
 %% \code{(xs take n)} returns the first \code{n} elements of list
 %% \code{xs}, or the whole list, if its length is smaller than \code{n}.
 %% \code{(xs drop n)} returns all elements of \code{xs} except the
 %% \code{n} first ones. Finally, \code{(xs split n)} returns a pair
 %% consisting of the lists resulting from \code{xs take n} and
 %% \code{xs drop n}.
-%----------
 
-%----------
 %% The next function returns an element at a given index in a list.
 %% It is thus analogous to array subscripting. Indices start at 0.
-\begin{lstlisting}
-def apply(n: Int): A = drop(n).head
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def apply(n: Int): A = drop(n).head
+%% \end{lstlisting}
 %% The \code{apply} method has a special meaning in Scala. An object with
 %% an \code{apply} method can be applied to arguments as if it was a
 %% function. For instance, to pick the 3'rd element of a list \code{xs},
 %% one can write either \code{xs.apply(3)} or \code{xs(3)} -- the latter
 %% expression expands into the first.
-%----------
 
-%----------
 %% With \code{take} and \code{drop}, we can extract sublists consisting
 %% of consecutive elements of the original list.  To extract the sublist
 %% $xs_m \commadots xs_{n-1}$ of a list \code{xs}, use:
 
-\begin{lstlisting}
-xs.drop(m).take(n - m)
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% xs.drop(m).take(n - m)
+%% \end{lstlisting}
 
-%----------
-%%\paragraph{Zipping lists} The next function combines two lists into a list of pairs.
-%%Given two lists
-\begin{lstlisting}
-xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
-ys = List(y$_1$, ..., y$_n$)   ,
-\end{lstlisting}
+%% \paragraph{Zipping lists} The next function combines two lists into a list of pairs.
+%% Given two lists
+%% \begin{lstlisting}
+%% xs = List(x$_1$, ..., x$_n$)   $\mbox{\rm, and}$
+%% ys = List(y$_1$, ..., y$_n$)   ,
+%% \end{lstlisting}
 %% \code{xs zip ys} constructs the list
 %% \lstinline@List((x$_1$, y$_1$), ..., (x$_n$, y$_n$))@.
 %% If the two lists have different lengths, the longer one of the two is
 %% truncated. Here is the definition of \code{zip} -- note that it is a
 %% polymorphic method.
-\begin{lstlisting}
-def zip[B](that: List[B]): List[(a,b)] =
-  if (this.isEmpty || that.isEmpty) Nil
-  else (this.head, that.head) :: (this.tail zip that.tail)
-\end{lstlisting}
-%----------
+%% \begin{lstlisting}
+%% def zip[B](that: List[B]): List[(a,b)] =
+%%   if (this.isEmpty || that.isEmpty) Nil
+%%   else (this.head, that.head) :: (this.tail zip that.tail)
+%% \end{lstlisting}
 
-%----------
 %% \paragraph{Consing lists.}
 %% Like any infix operator, \code{::}
 %% is also implemented as a method of an object. In this case, the object
 %% is the list that is extended. This is possible, because operators
 %% ending with a `\code{:}' character are treated specially in Scala.  
 %% All such operators are treated as methods of their right operand. E.g.,
-\begin{lstlisting}
-    x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
-\end{lstlisting}
-%----------
-
-%----------
+%% \begin{lstlisting}
+%%     x :: y = y.::(x)       $\mbox{\rm whereas}$       x + y = x.+(y)                  
+%% \end{lstlisting}
 %% Note, however, that operands of a binary operation are in each case
 %% evaluated from left to right.  So, if \code{D} and \code{E} are
 %% expressions with possible side-effects, \code{D :: E} is translated to
 %% \lstinline@{val x = D; E.::(x)}@ in order to maintain the left-to-right
 %% order of operand evaluation.
-%----------
 
-%----------
 %% Another difference between operators ending in a `\code{:}' and other
 %% operators concerns their associativity.  Operators ending in
 %% `\code{:}' are right-associative, whereas other operators are
 %% left-associative.  E.g.,
-\begin{lstlisting}
-    x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
-\end{lstlisting}
-%----------
-
-%----------
-%%The definition of \code{::} as a method in
-%%class \code{List} is as follows:
-\begin{lstlisting}
-def ::[B >: A](x: B): List[B] = new scala.::(x, this)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     x :: y :: z = x :: (y :: z)   $\mbox{\rm whereas}$    x + y + z = (x + y) + z
+%% \end{lstlisting}
+%% The definition of \code{::} as a method in
+%% class \code{List} is as follows:
+%% \begin{lstlisting}
+%% def ::[B >: A](x: B): List[B] = new scala.::(x, this)
+%% \end{lstlisting}
 %% Note that \code{::} is defined for all elements \code{x} of type
 %% \code{B} and lists of type \code{List[A]} such that the type \code{B}
 %% of \code{x} is a supertype of the list's element type \code{A}. The result
 %% is in this case a list of \code{B}'s. This
 %% is expressed by the type parameter \code{B} with lower bound \code{A}
 %% in the signature of \code{::}. 
-%----------
 
-%----------
 %% \paragraph{Concatenating lists}
 %% An operation similar to \code{::} is list concatenation, written
 %% `\code{:::}'. The result of \code{(xs ::: ys)} is a list consisting of
 %% all elements of \code{xs}, followed by all elements of \code{ys}.
 %% Because it ends in a colon, \code{:::} is right-associative and is
 %% considered as a method of its right-hand operand. Therefore,
-\begin{lstlisting}
-xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
-                  =   zs.:::(ys).:::(xs)
-\end{lstlisting}
-%----------
-
-%----------
-%%Here is the implementation of the \code{:::} method:
-\begin{lstlisting}
-  def :::[B >: A](prefix: List[B]): List[B] = prefix match {
-    case Nil => this
-    case p :: ps => this.:::(ps).::(p)
-  }
-\end{lstlisting}
-%----------
-
+%% \begin{lstlisting}
+%% xs ::: ys ::: zs  =   xs ::: (ys ::: zs)
+%%                   =   zs.:::(ys).:::(xs)
+%% \end{lstlisting}
+%% Here is the implementation of the \code{:::} method:
+%% \begin{lstlisting}
+%%   def :::[B >: A](prefix: List[B]): List[B] = prefix match {
+%%     case Nil => this
+%%     case p :: ps => this.:::(ps).::(p)
+%%   }
+%% \end{lstlisting}
 
 %% \paragraph{Reversing lists} Another useful operation
 %% is list reversal. There is a method \code{reverse} in \code{List} to
 %% that effect. Let's try to give its implementation:
-\begin{lstlisting}
-def reverse[A](xs: List[A]): List[A] = xs match {
-  case Nil => Nil
-  case x :: xs => reverse(xs) ::: List(x)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def reverse[A](xs: List[A]): List[A] = xs match {
+%%   case Nil => Nil
+%%   case x :: xs => reverse(xs) ::: List(x)
+%% }
+%% \end{lstlisting}
 %% This implementation has the advantage of being simple, but it is not
 %% very efficient.  Indeed, one concatenation is executed for every
 %% element in the list. List concatenation takes time proportional to the
 %% length of its first operand. Therefore, the complexity of
 %% \code{reverse(xs)} is
-\[
-n + (n - 1) + ... + 1 = n(n+1)/2
-\]
+%% \[
+%% n + (n - 1) + ... + 1 = n(n+1)/2
+%% \]
 %% where $n$ is the length of \code{xs}. Can \code{reverse} be
 %% implemented more efficiently? We will see later that there exists
 %% another implementation which has only linear complexity.
@@ -4628,18 +3534,18 @@ n + (n - 1) + ... + 1 = n(n+1)/2
 %% used for the comparison of elements. We obtain a function of maximal
 %% generality by passing these two items as parameters. This leads to the
 %% following implementation.
-\begin{lstlisting}
-def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
-  def merge(xs1: List[A], xs2: List[A]): List[A] =
-    if (xs1.isEmpty) xs2
-    else if (xs2.isEmpty) xs1
-    else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
-    else xs2.head :: merge(xs1, xs2.tail)
-  val n = xs.length/2
-  if (n == 0) xs
-  else merge(msort(less)(xs take n), msort(less)(xs drop n))
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
+%%   def merge(xs1: List[A], xs2: List[A]): List[A] =
+%%     if (xs1.isEmpty) xs2
+%%     else if (xs2.isEmpty) xs1
+%%     else if (less(xs1.head, xs2.head)) xs1.head :: merge(xs1.tail, xs2)
+%%     else xs2.head :: merge(xs1, xs2.tail)
+%%   val n = xs.length/2
+%%   if (n == 0) xs
+%%   else merge(msort(less)(xs take n), msort(less)(xs drop n))
+%% }
+%% \end{lstlisting}
 %% The complexity of \code{msort} is $O(N;log(N))$, where $N$ is the
 %% length of the input list. To see why, note that splitting a list in
 %% two and merging two sorted lists each take time proportional to the
@@ -4658,16 +3564,16 @@ def msort[A](less: (A, A) => Boolean)(xs: List[A]): List[A] = {
 %% sorting lists.
 
 %% Here is an example how \code{msort} is used.
-\begin{lstlisting}
-msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
-\end{lstlisting}
-%%The definition of \code{msort} is curried, to make it easy to specialize it with particular
-%%comparison functions. For instance,
-\begin{lstlisting}
+%% \begin{lstlisting}
+%% msort((x: Int, y: Int) => x < y)(List(5, 7, 1, 3))
+%% \end{lstlisting}
+%% The definition of \code{msort} is curried, to make it easy to specialize it with particular
+%% comparison functions. For instance,
+%% \begin{lstlisting}
 
-val intSort = msort((x: Int, y: Int) => x < y)
-val reverseSort = msort((x: Int, y: Int) => x > y)
-\end{lstlisting}
+%% val intSort = msort((x: Int, y: Int) => x < y)
+%% val reverseSort = msort((x: Int, y: Int) => x > y)
+%% \end{lstlisting}
 
 %% \section{Definition of class List II: Higher-Order Methods}
 
@@ -4688,90 +3594,89 @@ val reverseSort = msort((x: Int, y: Int) => x > y)
 %% A common operation is to transform each element of a list and then
 %% return the lists of results.  For instance, to scale each element of a
 %% list by a given factor.
-\begin{lstlisting}
-def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
-  case Nil => xs
-  case x :: xs1 => x * factor :: scaleList(xs1, factor)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def scaleList(xs: List[Double], factor: Double): List[Double] = xs match {
+%%   case Nil => xs
+%%   case x :: xs1 => x * factor :: scaleList(xs1, factor)
+%% }
+%% \end{lstlisting}
 %% This pattern can be generalized to the \code{map} method of class \code{List}:
-\begin{lstlisting}
-abstract class List[A] { ...
-  def map[B](f: A => B): List[B] = this match {
-    case Nil => this
-    case x :: xs => f(x) :: xs.map(f)
-  }
-\end{lstlisting}
-%%Using \code{map}, \code{scaleList} can be more concisely written as follows.
-\begin{lstlisting}
-def scaleList(xs: List[Double], factor: Double) =
-  xs map (x => x * factor)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class List[A] { ...
+%%   def map[B](f: A => B): List[B] = this match {
+%%     case Nil => this
+%%     case x :: xs => f(x) :: xs.map(f)
+%%   }
+%% \end{lstlisting}
+%% Using \code{map}, \code{scaleList} can be more concisely written as follows.
+%% \begin{lstlisting}
+%% def scaleList(xs: List[Double], factor: Double) =
+%%   xs map (x => x * factor)
+%% \end{lstlisting}
 
 %% As another example, consider the problem of returning a given column
 %% of a matrix which is represented as a list of rows, where each row is
 %% again a list. This is done by the following function \code{column}.
 
-\begin{lstlisting}
-def column[A](xs: List[List[A]], index: Int): List[A] =
-  xs map (row => row(index))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def column[A](xs: List[List[A]], index: Int): List[A] =
+%%   xs map (row => row(index))
+%% \end{lstlisting}
 
 %% Closely related to \code{map} is the \code{foreach} method, which
 %% applies a given function to all elements of a list, but does not
 %% construct a list of results. The function is thus applied only for its
 %% side effect. \code{foreach} is defined as follows.
-\begin{lstlisting}
-  def foreach(f: A => Unit) {
-    this match {
-      case Nil => ()
-      case x :: xs => f(x); xs.foreach(f)
-    }
-  }
-\end{lstlisting}
-%%This function can be used for printing all elements of a list, for instance:
-\begin{lstlisting}
-  xs foreach (x => println(x))
-\end{lstlisting} 
+%% \begin{lstlisting}
+%%   def foreach(f: A => Unit) {
+%%     this match {
+%%       case Nil => ()
+%%       case x :: xs => f(x); xs.foreach(f)
+%%     }
+%%   }
+%% \end{lstlisting}
+%% This function can be used for printing all elements of a list, for instance:
+%% \begin{lstlisting}
+%%   xs foreach (x => println(x))
+%% \end{lstlisting} 
 
- \begin{exercise} 
-%%Consider a function which squares all elements of a list and
+%% \begin{exercise} Consider a function which squares all elements of a list and
 %% returns a list with the results. Complete the following two equivalent
 %% definitions of \code{squareList}.
 
-\begin{lstlisting}
-def squareList(xs: List[Int]): List[Int] = xs match {
-  case List() => ??
-  case y :: ys => ??
-}
-def squareList(xs: List[Int]): List[Int] =
-  xs map ??
-\end{lstlisting}
-\end{exercise}
+%% \begin{lstlisting}
+%% def squareList(xs: List[Int]): List[Int] = xs match {
+%%   case List() => ??
+%%   case y :: ys => ??
+%% }
+%% def squareList(xs: List[Int]): List[Int] =
+%%   xs map ??
+%% \end{lstlisting}
+%% \end{exercise}
 
 %% \paragraph{Filtering Lists}
 %% Another common operation selects from a list all elements fulfilling a
 %% given criterion. For instance, to return a list of all positive
 %% elements in some given lists of integers:
-\begin{lstlisting}
-def posElems(xs: List[Int]): List[Int] = xs match {
-  case Nil => xs
-  case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
-}
-\end{lstlisting}
-%%This pattern is generalized to the \code{filter} method of class \code{List}:
-\begin{lstlisting}
-  def filter(p: A => Boolean): List[A] = this match {
-    case Nil => this
-    case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
-  }
-\end{lstlisting}
-%%Using \code{filter}, \code{posElems} can be more concisely written as
-%%follows.
-\begin{lstlisting}
-def posElems(xs: List[Int]): List[Int] =
-  xs filter (x => x > 0)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def posElems(xs: List[Int]): List[Int] = xs match {
+%%   case Nil => xs
+%%   case x :: xs1 => if (x > 0) x :: posElems(xs1) else posElems(xs1)
+%% }
+%% \end{lstlisting}
+%% This pattern is generalized to the \code{filter} method of class \code{List}:
+%% \begin{lstlisting}
+%%   def filter(p: A => Boolean): List[A] = this match {
+%%     case Nil => this
+%%     case x :: xs => if (p(x)) x :: xs.filter(p) else xs.filter(p)
+%%   }
+%% \end{lstlisting}
+%% Using \code{filter}, \code{posElems} can be more concisely written as
+%% follows.
+%% \begin{lstlisting}
+%% def posElems(xs: List[Int]): List[Int] =
+%%   xs filter (x => x > 0)
+%% \end{lstlisting}
 
 %% An operation related to filtering is testing whether all elements of a
 %% list satisfy a certain condition. Dually, one might also be interested
@@ -4779,12 +3684,12 @@ def posElems(xs: List[Int]): List[Int] =
 %% satisfies a certain condition. These operations are embodied in the
 %% higher-order functions \code{forall} and \code{exists} of class
 %% \code{List}.
-\begin{lstlisting}
-def forall(p: A => Boolean): Boolean =
-  isEmpty || (p(head) && (tail forall p))
-def exists(p: A => Boolean): Boolean =
-  !isEmpty && (p(head) || (tail exists p))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def forall(p: A => Boolean): Boolean =
+%%   isEmpty || (p(head) && (tail forall p))
+%% def exists(p: A => Boolean): Boolean =
+%%   !isEmpty && (p(head) || (tail exists p))
+%% \end{lstlisting}
 %% To illustrate the use of \code{forall}, consider the question of whether
 %% a number if prime. Remember that a number $n$ is prime of it can be
 %% divided without remainder only by one and itself. The most direct
@@ -4792,19 +3697,19 @@ def exists(p: A => Boolean): Boolean =
 %% numbers from 2 up to and excluding itself gives a non-zero
 %% remainder. This list of numbers can be generated using a function
 %% \code{List.range} which is defined in object \code{List} as follows.
-\begin{lstlisting}
-package scala
-object List { ...
-  def range(from: Int, end: Int): List[Int] =
-    if (from >= end) Nil else from :: range(from + 1, end)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% package scala
+%% object List { ...
+%%   def range(from: Int, end: Int): List[Int] =
+%%     if (from >= end) Nil else from :: range(from + 1, end)
+%% \end{lstlisting}
 %% For example, \code{List.range(2, n)}
 %% generates the list of all integers from 2 up to and excluding $n$.
 %% The function \code{isPrime} can now simply be defined as follows.
-\begin{lstlisting}
-def isPrime(n: Int) =
-  List.range(2, n) forall (x => n % x != 0)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def isPrime(n: Int) =
+%%   List.range(2, n) forall (x => n % x != 0)
+%% \end{lstlisting}
 %% We see that the mathematical definition of prime-ness has been
 %% translated directly into Scala code. 
 
@@ -4814,98 +3719,98 @@ def isPrime(n: Int) =
 %% \paragraph{Folding and Reducing Lists}
 %% Another common operation is to combine the elements of a list with
 %% some operator.  For instance:
-\begin{lstlisting}
-sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
-product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
-\end{lstlisting}
+%% \begin{lstlisting}
+%% sum(List(x$_1$, ..., x$_n$))       =  0 + x$_1$ + ... + x$_n$
+%% product(List(x$_1$, ..., x$_n$))   =  1 * x$_1$ * ... * x$_n$
+%% \end{lstlisting}
 %% Of course, we can implement both functions with a
 %% recursive scheme:
-\begin{lstlisting}
-def sum(xs: List[Int]): Int = xs match {
-  case Nil => 0
-  case y :: ys => y + sum(ys)
-}
-def product(xs: List[Int]): Int = xs match {
-  case Nil => 1
-  case y :: ys => y * product(ys)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def sum(xs: List[Int]): Int = xs match {
+%%   case Nil => 0
+%%   case y :: ys => y + sum(ys)
+%% }
+%% def product(xs: List[Int]): Int = xs match {
+%%   case Nil => 1
+%%   case y :: ys => y * product(ys)
+%% }
+%% \end{lstlisting}
 %% But we can also use the generalization of this program scheme embodied
 %% in the \code{reduceLeft} method of class \code{List}.  This method
 %% inserts a given binary operator between adjacent elements of a given list.
 %% E.g.\ 
-\begin{lstlisting}
-List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
-\end{lstlisting}
-%%Using \code{reduceLeft}, we can make the common pattern
-%%in \code{sum} and \code{product} apparent:
-\begin{lstlisting}
-def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
-def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
-\end{lstlisting}
-%%Here is the implementation of \code{reduceLeft}.
-\begin{lstlisting}
-  def reduceLeft(op: (A, A) => A): A = this match {
-    case Nil     => error("Nil.reduceLeft")
-    case x :: xs => (xs foldLeft x)(op)
-  }
-  def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
-    case Nil => z
-    case x :: xs => (xs foldLeft op(z, x))(op)
-  }
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% List(x$_1$, ..., x$_n$).reduceLeft(op) = (...(x$_1$ op x$_2$) op ... ) op x$_n$
+%% \end{lstlisting}
+%% Using \code{reduceLeft}, we can make the common pattern
+%% in \code{sum} and \code{product} apparent:
+%% \begin{lstlisting}
+%% def sum(xs: List[Int])      =  (0 :: xs) reduceLeft {(x, y) => x + y}
+%% def product(xs: List[Int])  =  (1 :: xs) reduceLeft {(x, y) => x * y}
+%% \end{lstlisting}
+%% Here is the implementation of \code{reduceLeft}.
+%% \begin{lstlisting}
+%%   def reduceLeft(op: (A, A) => A): A = this match {
+%%     case Nil     => error("Nil.reduceLeft")
+%%     case x :: xs => (xs foldLeft x)(op)
+%%   }
+%%   def foldLeft[B](z: B)(op: (B, A) => B): B = this match {
+%%     case Nil => z
+%%     case x :: xs => (xs foldLeft op(z, x))(op)
+%%   }
+%% }
+%% \end{lstlisting}
 %% We see that the \code{reduceLeft} method is defined in terms of
 %% another generally useful method, \code{foldLeft}.  The latter takes as
 %% additional parameter an {\em accumulator} \code{z}, which is returned
 %% when \code{foldLeft} is applied on an empty list. That is,
-\begin{lstlisting}
-(List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
-\end{lstlisting}
-%%The \code{sum} and \code{product} methods can be defined alternatively
-%%using \code{foldLeft}:
-\begin{lstlisting}
-def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
-def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% (List(x$_1$, ..., x$_n$) foldLeft z)(op)   =  (...(z op x$_1$) op ... ) op x$_n$
+%% \end{lstlisting}
+%% The \code{sum} and \code{product} methods can be defined alternatively
+%% using \code{foldLeft}:
+%% \begin{lstlisting}
+%% def sum(xs: List[Int])      =  (xs foldLeft 0) {(x, y) => x + y}
+%% def product(xs: List[Int])  =  (xs foldLeft 1) {(x, y) => x * y}
+%% \end{lstlisting}
 
-%%\paragraph{FoldRight and ReduceRight}
-%%Applications of \code{foldLeft} and \code{reduceLeft} expand to
-%%left-leaning trees. \todo{insert pictures}.  They have duals
-%%\code{foldRight} and \code{reduceRight}, which produce right-leaning
-%%trees.
-\begin{lstlisting}
-List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
-(List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
-\end{lstlisting}
-%%These are defined as follows.
-\begin{lstlisting}
-  def reduceRight(op: (A, A) => A): A = this match {
-    case Nil => error("Nil.reduceRight")
-    case x :: Nil => x
-    case x :: xs => op(x, xs.reduceRight(op))
-  }
-  def foldRight[B](z: B)(op: (A, B) => B): B = this match {
-    case Nil => z
-    case x :: xs => op(x, (xs foldRight z)(op))
-  }
-\end{lstlisting}
+%% \paragraph{FoldRight and ReduceRight}
+%% Applications of \code{foldLeft} and \code{reduceLeft} expand to
+%% left-leaning trees. \todo{insert pictures}.  They have duals
+%% \code{foldRight} and \code{reduceRight}, which produce right-leaning
+%% trees.
+%% \begin{lstlisting}
+%% List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n$)...)
+%% (List(x$_1$, ..., x$_n$) foldRight acc)(op) =  x$_1$ op ( ... (x$_n$ op acc)...)
+%% \end{lstlisting}
+%% These are defined as follows.
+%% \begin{lstlisting}
+%%   def reduceRight(op: (A, A) => A): A = this match {
+%%     case Nil => error("Nil.reduceRight")
+%%     case x :: Nil => x
+%%     case x :: xs => op(x, xs.reduceRight(op))
+%%   }
+%%   def foldRight[B](z: B)(op: (A, B) => B): B = this match {
+%%     case Nil => z
+%%     case x :: xs => op(x, (xs foldRight z)(op))
+%%   }
+%% \end{lstlisting}
 
-%%Class \code{List} defines also two symbolic abbreviations for
-%%\code{foldLeft} and \code{foldRight}:
-\begin{lstlisting}
-  def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
-  def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
-\end{lstlisting}
+%% Class \code{List} defines also two symbolic abbreviations for
+%% \code{foldLeft} and \code{foldRight}:
+%% \begin{lstlisting}
+%%   def /:[B](z: B)(f: (B, A) => B): B = foldLeft(z)(f)
+%%   def :\[B](z: B)(f: (A, B) => B): B = foldRight(z)(f)
+%% \end{lstlisting}
 %% The method names picture the left/right leaning trees of the fold
 %% operations by forward or backward slashes. The \code{:} points in each
 %% case to the list argument whereas the end of the slash points to the
 %% accumulator (or: zero) argument \code{z}. 
 %% That is, 
-\begin{lstlisting}
-(z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
-(List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% (z /: List(x$_1$, ..., x$_n$))(op) = (...(z op x$_1$) op ... ) op x$_n$ 
+%% (List(x$_1$, ..., x$_n$) :\ z)(op) = x$_1$ op ( ... (x$_n$ op z)...)
+%% \end{lstlisting}
 %% For associative and commutative operators, \code{/:} and
 %% \code{:\\} are equivalent (even though there may be a difference
 %% in efficiency).  
@@ -4917,15 +3822,15 @@ List(x$_1$, ..., x$_n$).reduceRight(op)     =  x$_1$ op ( ... (x$_{n-1}$ op x$_n
 %% \code{flatten} should be the concatenation of all element lists into a
 %% single list. Here is an implementation of this method in terms of 
 %% \code{:\\}.
-\begin{lstlisting}
-def flatten[A](xs: List[List[A]]): List[A] =
-  (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
-\end{lstlisting} 
+%% \begin{lstlisting}
+%% def flatten[A](xs: List[List[A]]): List[A] =
+%%   (xs :\ (Nil: List[A])) {(x, xs) => x ::: xs}
+%% \end{lstlisting} 
 %% Consider replacing the body of \lstinline@flatten@
 %% by 
-\begin{lstlisting}
-  ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   ((Nil: List[A]) /: xs) ((xs, x) => xs ::: x)
+%% \end{lstlisting}
 %% What would be the difference in asymptotic
 %% complexity between the two versions of \lstinline@flatten@?
 
@@ -4943,49 +3848,49 @@ def flatten[A](xs: List[List[A]]): List[A] =
 %% to be reversed. We now develop a new implementation of \code{reverse},
 %% which has linear cost.  The idea is to use a \code{foldLeft}
 %% operation based on the following program scheme.
-\begin{lstlisting}
-class List[+A] { ...
-  def reverse: List[A] = (z? /: this)(op?)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class List[+A] { ...
+%%   def reverse: List[A] = (z? /: this)(op?)
+%% \end{lstlisting}
 %% It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
 %% try to deduce them from examples.
-\begin{lstlisting}
-  Nil
-= Nil.reverse                 // by specification
-= (z /: Nil)(op)              // by the template for reverse
-= (Nil foldLeft z)(op)        // by the definition of /:
-= z                           // by definition of foldLeft
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   Nil
+%% = Nil.reverse                 // by specification
+%% = (z /: Nil)(op)              // by the template for reverse
+%% = (Nil foldLeft z)(op)        // by the definition of /:
+%% = z                           // by definition of foldLeft
+%% \end{lstlisting}
 %% Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
 %% let's study reversal of a list of length one.
-\begin{lstlisting}
-  List(x)
-= List(x).reverse             // by specification
-= (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
-= (List(x) foldLeft Nil)(op)  // by the definition of /:
-= op(Nil, x)                  // by definition of foldLeft
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   List(x)
+%% = List(x).reverse             // by specification
+%% = (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
+%% = (List(x) foldLeft Nil)(op)  // by the definition of /:
+%% = op(Nil, x)                  // by definition of foldLeft
+%% \end{lstlisting}
 %% Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
 %% as \code{x :: Nil}. This suggests to take as \code{op} the
 %% \code{::} operator with its operands exchanged.  Hence, we arrive at
 %% the following implementation for \code{reverse}, which has linear complexity.
-\begin{lstlisting}
-def reverse: List[A] =
-  ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def reverse: List[A] =
+%%   ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
+%% \end{lstlisting}
 %% (Remark: The type annotation of \code{Nil} is necessary 
 %% to make the type inferencer work.)
 
 %% \begin{exercise} Fill in the missing expressions to complete the following
 %% definitions of some basic list-manipulation operations as fold
 %% operations.
-\begin{lstlisting}
-def mapFun[A, B](xs: List[A], f: A => B): List[B] =
-  (xs :\ List[B]()){ ?? }
+%% \begin{lstlisting}
+%% def mapFun[A, B](xs: List[A], f: A => B): List[B] =
+%%   (xs :\ List[B]()){ ?? }
 
-def lengthFun[A](xs: List[A]): int =
-  (0 /: xs){ ?? }
-\end{lstlisting}
+%% def lengthFun[A](xs: List[A]): int =
+%%   (0 /: xs){ ?? }
+%% \end{lstlisting}
 %% \end{exercise}
 
 %% \paragraph{Nested Mappings}
@@ -4998,11 +3903,11 @@ def lengthFun[A](xs: List[A]): int =
 %% integer $n$, find all pairs of positive integers $i$ and $j$, where 
 %% $1 \leq j < i < n$ such that $i + j$ is prime. For instance, if $n = 7$,
 %% the pairs are
-\bda{c|lllllll}
-i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
-j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
-i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
-\eda
+%% \bda{c|lllllll}
+%% i     & 2 & 3 & 4 & 4 & 5 & 6 & 6\\
+%% j     & 1 & 2 & 1 & 3 & 2 & 1 & 5\\ \hline
+%% i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
+%% \eda
 
 %% A natural way to solve this problem consists of two steps. In a first step,
 %% one generates the sequence of all pairs $(i, j)$ of integers such that
@@ -5016,38 +3921,38 @@ i + j & 3 & 5 & 5 & 7 & 7 & 7 & 11
 %% Second, for each integer $i$ between $1$ and $n$, generate the list of
 %% pairs $(i, 1)$ up to $(i, i-1)$. This can be achieved by a
 %% combination of \code{range} and \code{map}:
-\begin{lstlisting}
-  List.range(1, i) map (x => (i, x))
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   List.range(1, i) map (x => (i, x))
+%% \end{lstlisting}
 %% Finally, combine all sublists using \code{foldRight} with \code{:::}.
 %% Putting everything together gives the following expression:
-\begin{lstlisting}
-List.range(1, n)
-  .map(i => List.range(1, i).map(x => (i, x)))
-  .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
-  .filter(pair => isPrime(pair._1 + pair._2))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% List.range(1, n)
+%%   .map(i => List.range(1, i).map(x => (i, x)))
+%%   .foldRight(List[(Int, Int)]()) {(xs, ys) => xs ::: ys}
+%%   .filter(pair => isPrime(pair._1 + pair._2))
+%% \end{lstlisting}
 
 %% \paragraph{Flattening Maps}
 %% The combination of mapping and then concatenating sublists 
 %% resulting from the map
 %% is so common that we there is a special method 
 %% for it in class \code{List}:
-\begin{lstlisting}
-abstract class List[+A] { ...
-  def flatMap[B](f: A => List[B]): List[B] = this match {
-    case Nil => Nil
-    case x :: xs => f(x) ::: (xs flatMap f)
-  }
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class List[+A] { ...
+%%   def flatMap[B](f: A => List[B]): List[B] = this match {
+%%     case Nil => Nil
+%%     case x :: xs => f(x) ::: (xs flatMap f)
+%%   }
+%% }
+%% \end{lstlisting}
 %% With \code{flatMap}, the pairs-whose-sum-is-prime expression 
 %% could have been written more concisely as follows.
-\begin{lstlisting}
-List.range(1, n)
-  .flatMap(i => List.range(1, i).map(x => (i, x)))
-  .filter(pair => isPrime(pair._1 + pair._2))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% List.range(1, n)
+%%   .flatMap(i => List.range(1, i).map(x => (i, x)))
+%%   .filter(pair => isPrime(pair._1 + pair._2))
+%% \end{lstlisting}
 
 
 
@@ -5072,21 +3977,21 @@ List.range(1, n)
 
 %% Recall the concatenation operation for lists:
 
-\begin{lstlisting}
-class List[+A] {
-  ...
-  def ::: (that: List[A]): List[A] =
-    if (isEmpty) that
-    else head :: (tail ::: that)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class List[+A] {
+%%   ...
+%%   def ::: (that: List[A]): List[A] =
+%%     if (isEmpty) that
+%%     else head :: (tail ::: that)
+%% }
+%% \end{lstlisting}
 
 %% We would like to verify that concatenation is associative, with the
 %% empty list \code{List()} as left and right identity:
-\bda{lcl}
-   (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
-   xs ::: List()          &=& xs \gap =\ List() ::: xs
-\eda
+%% \bda{lcl}
+%%    (xs ::: ys) ::: zs &=& xs ::: (ys ::: zs) \\
+%%    xs ::: List()          &=& xs \gap =\ List() ::: xs
+%% \eda
 %% \emph{Q}: How can we prove statements like the one above?
 
 %% \emph{A}: By \emph{structural induction} over lists.
@@ -5106,30 +4011,30 @@ class List[+A] {
 %% \ee
 %% %\es\bs
 %% \emph{Example}: Given
-\begin{lstlisting}
-def factorial(n: Int): Int =
-  if (n == 0) 1
-  else n * factorial(n-1)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def factorial(n: Int): Int =
+%%   if (n == 0) 1
+%%   else n * factorial(n-1)
+%% \end{lstlisting}
 %% show that, for all \code{n >= 4},
-\begin{lstlisting}
-   factorial(n) >= 2$^n$
-\end{lstlisting}
+%% \begin{lstlisting}
+%%    factorial(n) >= 2$^n$
+%% \end{lstlisting}
 %% \es\bs
 %% \Case{\code{4}}
 %% is established by simple calculation of \code{factorial(4) = 24} and \code{2$^4$ = 16}.
 
 %% \Case{\code{n+1}} 
 %% We have for \code{n >= 4}:
-\begin{lstlisting}
-    \= factorial(n + 1)
- =     \> $\expl{by the second clause of factorial(*)}$
-       \> (n + 1) * factorial(n)
- >=    \> $\expl{by calculation}$
-       \> 2 * factorial(n)
- >=    \> $\expl{by the induction hypothesis}$
-       \> 2 * 2$^n$.
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= factorial(n + 1)
+%%  =     \> $\expl{by the second clause of factorial(*)}$
+%%        \> (n + 1) * factorial(n)
+%%  >=    \> $\expl{by calculation}$
+%%        \> 2 * factorial(n)
+%%  >=    \> $\expl{by the induction hypothesis}$
+%%        \> 2 * 2$^n$.
+%% \end{lstlisting}
 %% Note that in our proof we can freely apply reduction steps such as in (*)
 %% anywhere in a term.
 
@@ -5164,17 +4069,17 @@ def factorial(n: Int): Int =
 
 %% \Case{\code{List()}}
 %% For the left-hand side, we have:
-\begin{lstlisting}
-    \= (List() ::: ys) ::: zs
- =     \> $\expl{by first clause of \prog{:::}}$
-       \> ys ::: zs
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= (List() ::: ys) ::: zs
+%%  =     \> $\expl{by first clause of \prog{:::}}$
+%%        \> ys ::: zs
+%% \end{lstlisting}
 %% For the right-hand side, we have:
-\begin{lstlisting}
-    \= List() ::: (ys ::: zs)
- =     \> $\expl{by first clause of \prog{:::}}$
-       \> ys ::: zs
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= List() ::: (ys ::: zs)
+%%  =     \> $\expl{by first clause of \prog{:::}}$
+%%        \> ys ::: zs
+%% \end{lstlisting}
 %% So the case is established.
 
 %% \es
@@ -5182,22 +4087,22 @@ def factorial(n: Int): Int =
 %% \Case{\code{x :: xs}} 
 
 %% For the left-hand side, we have:
-\begin{lstlisting}
-    \= ((x :: xs) ::: ys) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> (x :: (xs ::: ys)) ::: zs
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> x :: ((xs ::: ys) ::: zs)
- =     \> $\expl{by the induction hypothesis}$
-       \> x :: (xs ::: (ys ::: zs))
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= ((x :: xs) ::: ys) ::: zs
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> (x :: (xs ::: ys)) ::: zs
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> x :: ((xs ::: ys) ::: zs)
+%%  =     \> $\expl{by the induction hypothesis}$
+%%        \> x :: (xs ::: (ys ::: zs))
+%% \end{lstlisting}
 
 %% For the right-hand side, we have:
-\begin{lstlisting}
-    \= (x :: xs) ::: (ys ::: zs)
- =     \> $\expl{by second clause of \prog{:::}}$
-       \> x :: (xs ::: (ys ::: zs))
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= (x :: xs) ::: (ys ::: zs)
+%%  =     \> $\expl{by second clause of \prog{:::}}$
+%%        \> x :: (xs ::: (ys ::: zs))
+%% \end{lstlisting}
 %% So the case (and with it the property) is established.
 
 %% \begin{exercise}
@@ -5207,51 +4112,51 @@ def factorial(n: Int): Int =
 %% \end{exercise}
 
 %% As a more difficult example, consider function
-\begin{lstlisting}
-abstract class List[A] { ...
-  def reverse: List[A] = this match {
-    case List() => List()
-    case x :: xs => xs.reverse ::: List(x)
-  }
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class List[A] { ...
+%%   def reverse: List[A] = this match {
+%%     case List() => List()
+%%     case x :: xs => xs.reverse ::: List(x)
+%%   }
+%% }
+%% \end{lstlisting}
 %% We would like to prove the proposition that
-\begin{lstlisting}
-   xs.reverse.reverse  =  xs  .
-\end{lstlisting}
+%% \begin{lstlisting}
+%%    xs.reverse.reverse  =  xs  .
+%% \end{lstlisting}
 %% We proceed by induction over \code{xs}. The base case is easy to establish:
-\begin{lstlisting}
-    \= List().reverse.reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
-       \> List().reverse
- =     \> $\expl{by first clause of \prog{reverse}}$
-       \> List()
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= List().reverse.reverse
+%%  =     \> $\expl{by first clause of \prog{reverse}}$
+%%        \> List().reverse
+%%  =     \> $\expl{by first clause of \prog{reverse}}$
+%%        \> List()
+%% \end{lstlisting}
 %% \es\bs
 %% For the induction step, we try:
-\begin{lstlisting}
-    \= (x :: xs).reverse.reverse
- =     \> $\expl{by second clause of \prog{reverse}}$
-       \> (xs.reverse ::: List(x)).reverse
-\end{lstlisting}
-%%There's nothing more we can do to this expression, so we turn to the right side:
-\begin{lstlisting}
-    \= x :: xs
- =     \> $\expl{by induction hypothesis}$
-       \> x :: xs.reverse.reverse
-\end{lstlisting}
-%%The two sides have simplified to different expressions.
+%% \begin{lstlisting}
+%%     \= (x :: xs).reverse.reverse
+%%  =     \> $\expl{by second clause of \prog{reverse}}$
+%%        \> (xs.reverse ::: List(x)).reverse
+%% \end{lstlisting}
+%% There's nothing more we can do to this expression, so we turn to the right side:
+%% \begin{lstlisting}
+%%     \= x :: xs
+%%  =     \> $\expl{by induction hypothesis}$
+%%        \> x :: xs.reverse.reverse
+%% \end{lstlisting}
+%% The two sides have simplified to different expressions.
 
-%%So we still have to show that
-\begin{lstlisting}
-  (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
-\end{lstlisting}
-%%Trying to prove this directly by induction does not work.
+%% So we still have to show that
+%% \begin{lstlisting}
+%%   (xs.reverse ::: List(x)).reverse  =  x :: xs.reverse.reverse
+%% \end{lstlisting}
+%% Trying to prove this directly by induction does not work.
 
-%%Instead we have to {\em generalize} the equation to:
-\begin{lstlisting}
-  (ys ::: List(x)).reverse  =  x :: ys.reverse
-\end{lstlisting}
+%% Instead we have to {\em generalize} the equation to:
+%% \begin{lstlisting}
+%%   (ys ::: List(x)).reverse  =  x :: ys.reverse
+%% \end{lstlisting}
 %% \es\bs
 %% This equation can be proved by a second induction argument over \code{ys}.
 %% (See blackboard).
@@ -5279,29 +4184,29 @@ abstract class List[A] { ...
 %% \example Recall our definition of \code{IntSet} with 
 %% operations \code{contains} and \code{incl}:
 
-\begin{lstlisting}
-abstract class IntSet {
-  abstract def incl(x: Int): IntSet
-  abstract def contains(x: Int): Boolean
-}
-\end{lstlisting}
-\es\bs
-\begin{lstlisting}
-case class Empty extends IntSet {
-  def contains(x: Int): Boolean = false
-  def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
-}
-case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
-  def contains(x: Int): Boolean =
-    if (x < elem) left contains x
-    else if (x > elem) right contains x
-    else true
-  def incl(x: Int): IntSet =
-    if (x < elem) NonEmpty(elem, left incl x, right)
-    else if (x > elem) NonEmpty(elem, left, right incl x)
-    else this
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% abstract class IntSet {
+%%   abstract def incl(x: Int): IntSet
+%%   abstract def contains(x: Int): Boolean
+%% }
+%% \end{lstlisting}
+%% \es\bs
+%% \begin{lstlisting}
+%% case class Empty extends IntSet {
+%%   def contains(x: Int): Boolean = false
+%%   def incl(x: Int): IntSet = NonEmpty(x, Empty, Empty)
+%% }
+%% case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
+%%   def contains(x: Int): Boolean =
+%%     if (x < elem) left contains x
+%%     else if (x > elem) right contains x
+%%     else true
+%%   def incl(x: Int): IntSet =
+%%     if (x < elem) NonEmpty(elem, left incl x, right)
+%%     else if (x > elem) NonEmpty(elem, left, right incl x)
+%%     else this
+%% }
+%% \end{lstlisting}
 %% (With \code{case} added, so that we can use factory methods instead of \code{new}).
 
 %% What does it mean to prove the correctness of this implementation?
@@ -5315,11 +4220,11 @@ case class NonEmpty(elem: Int, left: Set, right: Set) extends IntSet {
 
 %% For all sets \code{s}, elements \code{x}, \code{y}:
 
-\begin{lstlisting}
-Empty contains x          \= =  false
-(s incl x) contains x     \> =  true
-(s incl x) contains y     \> =  s contains y         if x $\neq$ y
-\end{lstlisting}
+%% \begin{lstlisting}
+%% Empty contains x          \= =  false
+%% (s incl x) contains x     \> =  true
+%% (s incl x) contains y     \> =  s contains y         if x $\neq$ y
+%% \end{lstlisting}
 
 %% (In fact, one can show that these laws characterize the desired data
 %% type completely).
@@ -5334,34 +4239,34 @@ Empty contains x          \= =  false
 
 %% \emph{Proof:}
 
-\Case{\code{Empty}}
-\begin{lstlisting}
-    \= (Empty incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
-       \> NonEmpty(x, Empty, Empty) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-       \> true
-\end{lstlisting}
+%% \Case{\code{Empty}}
+%% \begin{lstlisting}
+%%     \= (Empty incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{Empty}}$
+%%        \> NonEmpty(x, Empty, Empty) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+%%        \> true
+%% \end{lstlisting}
 
-\Case{\code{NonEmpty(x, l, r)}}
-\begin{lstlisting}
-    \= (NonEmpty(x, l, r) incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-       \> NonEmpty(x, l, r) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
-       \> true
-\end{lstlisting}
-\es\bs
-\Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
-\begin{lstlisting}
-    \= (NonEmpty(y, l, r) incl x) contains x
- =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
-       \> NonEmpty(y, l, r incl x) contains x
- =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
-       \> (r incl x) contains x
- =     \> $\expl{by the induction hypothesis}$
-       \> true
-\end{lstlisting}
+%% \Case{\code{NonEmpty(x, l, r)}}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(x, l, r) incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+%%        \> NonEmpty(x, l, r) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{Empty}}$
+%%        \> true
+%% \end{lstlisting}
+%% \es\bs
+%% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(y, l, r) incl x) contains x
+%%  =     \> $\expl{by definition of \prog{incl} in \prog{NonEmpty}}$
+%%        \> NonEmpty(y, l, r incl x) contains x
+%%  =     \> $\expl{by definition of \prog{contains} in \prog{NonEmpty}}$
+%%        \> (r incl x) contains x
+%%  =     \> $\expl{by the induction hypothesis}$
+%%        \> true
+%% \end{lstlisting}
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y > x}} is analogous.
 
@@ -5376,17 +4281,17 @@ Empty contains x          \= =  false
 
 %% Say we add a \code{union} function to \code{IntSet}:
 
-\begin{lstlisting}
-class IntSet { ...
-  def union(other: IntSet): IntSet
-}
-class Expty extends IntSet { ...
-  def union(other: IntSet) = other
-}
-class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
-  def union(other: IntSet): IntSet = l union r union other incl x
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% class IntSet { ...
+%%   def union(other: IntSet): IntSet
+%% }
+%% class Expty extends IntSet { ...
+%%   def union(other: IntSet) = other
+%% }
+%% class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
+%%   def union(other: IntSet): IntSet = l union r union other incl x
+%% }
+%% \end{lstlisting}
 
 %% The correctness of \code{union} can be subsumed with the following
 %% law:
@@ -5407,39 +4312,39 @@ class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
 
-\begin{lstlisting}
-    \= (Empty union ys) contains x 
- =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
-        \> ys contains x
- =      \> $\expl{Boolean algebra}$
-        \> false || ys contains x
- =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
-        \> (Empty contains x) || (ys contains x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= (Empty union ys) contains x 
+%%  =      \> $\expl{by definition of \prog{union} in \prog{Empty}}$
+%%         \> ys contains x
+%%  =      \> $\expl{Boolean algebra}$
+%%         \> false || ys contains x
+%%  =      \> $\expl{by definition of \prog{contains} in \prog{Empty} (reverse)}$
+%%         \> (Empty contains x) || (ys contains x)
+%% \end{lstlisting}
 
-\begin{lstlisting}
-    \= (NonEmpty(x, l, r) union ys) contains x
- =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-        \> (l union r union ys incl x) contains x
- =      \> $\expl{by Proposition 2}$
-        \> true
- =      \> $\expl{Boolean algebra}$
-        \> true || (ys contains x)
- =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
-        \> (NonEmpty(x, l, r) contains x) || (ys contains x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(x, l, r) union ys) contains x
+%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+%%         \> (l union r union ys incl x) contains x
+%%  =      \> $\expl{by Proposition 2}$
+%%         \> true
+%%  =      \> $\expl{Boolean algebra}$
+%%         \> true || (ys contains x)
+%%  =      \> $\expl{by definition of \prog{contains} in \prog{NonEmpty} (reverse)}$
+%%         \> (NonEmpty(x, l, r) contains x) || (ys contains x)
+%% \end{lstlisting}
 
-\begin{lstlisting}
-    \= (NonEmpty(y, l, r) union ys) contains x
- =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
-        \> (l union r union ys incl y) contains x
- =      \> $\expl{by Proposition 3}$
-        \> (l union r union ys) contains x
- =      \> $\expl{by the induction hypothesis}$
-        \> ((l union r) contains x) || (ys contains x)
- =      \> $\expl{by Proposition 3}$
-        \> ((l union r incl y) contains x) || (ys contains x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%     \= (NonEmpty(y, l, r) union ys) contains x
+%%  =      \> $\expl{by definition of \prog{union} in \prog{NonEmpty}}$
+%%         \> (l union r union ys incl y) contains x
+%%  =      \> $\expl{by Proposition 3}$
+%%         \> (l union r union ys) contains x
+%%  =      \> $\expl{by the induction hypothesis}$
+%%         \> ((l union r) contains x) || (ys contains x)
+%%  =      \> $\expl{by Proposition 3}$
+%%         \> ((l union r incl y) contains x) || (ys contains x)
+%% \end{lstlisting}
 
 %% \Case{\code{NonEmpty(y, l, r)} where \code{y < x}}
 %%  ... is analogous.
@@ -5464,21 +4369,21 @@ class NonEmpty(x: Int, l: IntSet, r: IntSet) extends IntSet { ...
 %% As a first example, say we are given a list \code{persons} of persons
 %% with \code{name} and \code{age} fields.  To print the names of all
 %% persons in the sequence which are aged over 20, one can write:
-\begin{lstlisting}
-for (p <- persons if p.age > 20) yield p.name
-\end{lstlisting}
-%%This is equivalent to the following expression , which uses
-%%higher-order functions \code{filter} and \code{map}:
-\begin{lstlisting}
-persons filter (p => p.age > 20) map (p => p.name)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (p <- persons if p.age > 20) yield p.name
+%% \end{lstlisting}
+%% This is equivalent to the following expression , which uses
+%% higher-order functions \code{filter} and \code{map}:
+%% \begin{lstlisting}
+%% persons filter (p => p.age > 20) map (p => p.name)
+%% \end{lstlisting}
 %% The for-comprehension looks a bit like a for-loop in imperative languages,
 %% except that it constructs a list of the results of all iterations.
 
 %% Generally, a for-comprehension is of the form
-\begin{lstlisting}
-for ( $s$ ) yield $e$
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for ( $s$ ) yield $e$
+%% \end{lstlisting}
 %% Here, $s$ is a sequence of {\em generators}, {\em definitions} and
 %% {\em filters}.  A {\em generator} is of the form \code{val x <- e},
 %% where \code{e} is a list-valued expression. It binds \code{x} to
@@ -5500,20 +4405,20 @@ for ( $s$ ) yield $e$
 %% integer $n$, find all pairs of positive integers $i$ and $j$, where $1
 %% \leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
 %% this problem is solved as follows:
-\begin{lstlisting}
-for { i <- List.range(1, n)
-      j <- List.range(1, i)
-      if isPrime(i+j) } yield {i, j}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for { i <- List.range(1, n)
+%%       j <- List.range(1, i)
+%%       if isPrime(i+j) } yield {i, j}
+%% \end{lstlisting}
 %% This is arguably much clearer than the solution using \code{map},
 %% \code{flatMap} and \code{filter} that we have developed previously.
 
 %% As a second example, consider computing the scalar product of two
 %% vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
 %% be written as follows.
-\begin{lstlisting}
-  sum(for ((x, y) <- xs zip ys) yield x * y)
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   sum(for ((x, y) <- xs zip ys) yield x * y)
+%% \end{lstlisting}
 
 %% \section{The N-Queens Problem}
 
@@ -5550,21 +4455,21 @@ for { i <- List.range(1, n)
 %% of solution lists, this time of length $k$. We continue the process
 %% until we have reached solutions of the size of the chess-board $n$.
 %% This algorithmic idea is embodied in function \code{placeQueens} below:
-\begin{lstlisting}
-def queens(n: Int): List[List[Int]] = {
-  def placeQueens(k: Int): List[List[Int]] =
-    if (k == 0) List(List())
-    else for { queens <- placeQueens(k - 1)
-               column <- List.range(1, n + 1)
-               if isSafe(column, queens, 1) } yield column :: queens
-  placeQueens(n)
-}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def queens(n: Int): List[List[Int]] = {
+%%   def placeQueens(k: Int): List[List[Int]] =
+%%     if (k == 0) List(List())
+%%     else for { queens <- placeQueens(k - 1)
+%%                column <- List.range(1, n + 1)
+%%                if isSafe(column, queens, 1) } yield column :: queens
+%%   placeQueens(n)
+%% }
+%% \end{lstlisting}
 
 %% \begin{exercise} Write the function
-\begin{lstlisting}
-  def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
-\end{lstlisting}
+%% \begin{lstlisting}
+%%   def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
+%% \end{lstlisting}
 %% which tests whether a queen in the given column \verb@col@ is safe with 
 %% respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
 %% placed and the row of the first queen in the list.
@@ -5576,56 +4481,56 @@ def queens(n: Int): List[List[Int]] = {
 %% database query languages.  For instance, say we are given a 
 %% database \code{books}, represented as a list of books, where
 %% \code{Book} is defined as follows.
-\begin{lstlisting}
-case class Book(title: String, authors: List[String])
-\end{lstlisting}
+%% \begin{lstlisting}
+%% case class Book(title: String, authors: List[String])
+%% \end{lstlisting}
 %% Here is a small example database:
-\begin{lstlisting}
-val books: List[Book] = List(
-  Book("Structure and Interpretation of Computer Programs",
-       List("Abelson, Harold", "Sussman, Gerald J.")),
-  Book("Principles of Compiler Design",
-       List("Aho, Alfred", "Ullman, Jeffrey")),
-  Book("Programming in Modula-2",
-       List("Wirth, Niklaus")),
-  Book("Introduction to Functional Programming"),
-       List("Bird, Richard")),
-  Book("The Java Language Specification",
-       List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% val books: List[Book] = List(
+%%   Book("Structure and Interpretation of Computer Programs",
+%%        List("Abelson, Harold", "Sussman, Gerald J.")),
+%%   Book("Principles of Compiler Design",
+%%        List("Aho, Alfred", "Ullman, Jeffrey")),
+%%   Book("Programming in Modula-2",
+%%        List("Wirth, Niklaus")),
+%%   Book("Introduction to Functional Programming"),
+%%        List("Bird, Richard")),
+%%   Book("The Java Language Specification",
+%%        List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
+%% \end{lstlisting}
 %% Then, to find the titles of all books whose author's last name is ``Ullman'':
-\begin{lstlisting}
-for (b <- books; a <- b.authors if a startsWith "Ullman")
-yield b.title
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (b <- books; a <- b.authors if a startsWith "Ullman")
+%% yield b.title
+%% \end{lstlisting}
 %% (Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
 %% to find the titles of all books that have the string ``Program'' in
 %% their title:
-\begin{lstlisting}
-for (b <- books if (b.title indexOf "Program") >= 0)
-yield b.title
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (b <- books if (b.title indexOf "Program") >= 0)
+%% yield b.title
+%% \end{lstlisting}
 %% Or, to find the names of all authors that have written at least two
 %% books in the database.
-\begin{lstlisting}
-for (b1 <- books; b2 <- books if b1 != b2;
-     a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
-yield a1
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (b1 <- books; b2 <- books if b1 != b2;
+%%      a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
+%% yield a1
+%% \end{lstlisting}
 %% The last solution is not yet perfect, because authors will appear
 %% several times in the list of results.  We still need to remove
 %% duplicate authors from result lists.  This can be achieved with the
 %% following function.
-\begin{lstlisting}
-def removeDuplicates[A](xs: List[A]): List[A] =
-  if (xs.isEmpty) xs
-  else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def removeDuplicates[A](xs: List[A]): List[A] =
+%%   if (xs.isEmpty) xs
+%%   else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
+%% \end{lstlisting}
 %% Note that the last expression in method \code{removeDuplicates}
 %% can be equivalently expressed using a for-comprehension.
-\begin{lstlisting}
-xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
+%% \end{lstlisting}
 
 %% \section{Translation of For-Comprehensions}
 
@@ -5635,69 +4540,69 @@ xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
 %% \begin{itemize}
 %% \item
 %% A simple for-comprehension
-\begin{lstlisting}
-for (x <- e) yield e'
-\end{lstlisting}
-%%is translated to
-\begin{lstlisting}
-e.map(x => e')
-\end{lstlisting}
-%%\item
-%%A for-comprehension
-\begin{lstlisting}
-for (x <- e if f; s) yield e'
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (x <- e) yield e'
+%% \end{lstlisting}
+%% is translated to
+%% \begin{lstlisting}
+%% e.map(x => e')
+%% \end{lstlisting}
+%% \item
+%% A for-comprehension
+%% \begin{lstlisting}
+%% for (x <- e if f; s) yield e'
+%% \end{lstlisting}
 %% where \code{f} is a filter and \code{s} is a (possibly empty)
 %% sequence of generators or filters
 %% is translated to
-\begin{lstlisting}
-for (x <- e.filter(x => f); s) yield e'
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (x <- e.filter(x => f); s) yield e'
+%% \end{lstlisting}
 %% and then translation continues with the latter expression.
 %% \item
 %% A for-comprehension
-\begin{lstlisting}
-for (x <- e; y <- e'; s) yield e''
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (x <- e; y <- e'; s) yield e''
+%% \end{lstlisting}
 %% where \code{s} is a (possibly empty)
 %% sequence of generators or filters
 %% is translated to
-\begin{lstlisting}
-e.flatMap(x => for (y <- e'; s) yield e'')
-\end{lstlisting}
+%% \begin{lstlisting}
+%% e.flatMap(x => for (y <- e'; s) yield e'')
+%% \end{lstlisting}
 %% and then translation continues with the latter expression.
 %% \end{itemize}
 %% For instance, taking our "pairs of integers whose sum is prime" example:
-\begin{lstlisting}
-for { i <- range(1, n)
-      j <- range(1, i)
-      if isPrime(i+j)
-} yield {i, j}
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for { i <- range(1, n)
+%%       j <- range(1, i)
+%%       if isPrime(i+j)
+%% } yield {i, j}
+%% \end{lstlisting}
 %% Here is what we get when we translate this expression:
-\begin{lstlisting}
-range(1, n)
-  .flatMap(i =>
-    range(1, i)
-      .filter(j => isPrime(i+j))
-      .map(j => (i, j)))
-\end{lstlisting}
+%% \begin{lstlisting}
+%% range(1, n)
+%%   .flatMap(i =>
+%%     range(1, i)
+%%       .filter(j => isPrime(i+j))
+%%       .map(j => (i, j)))
+%% \end{lstlisting}
 
 %% Conversely, it would also be possible to express functions \code{map},
 %% \code{flatMap}{ and \code{filter} using for-comprehensions. Here are the
 %% three functions again, this time implemented using for-comprehensions.
-\begin{lstlisting}
-object Demo {
-  def map[A, B](xs: List[A], f: A => B): List[B] =
-    for (x <- xs) yield f(x)
+%% \begin{lstlisting}
+%% object Demo {
+%%   def map[A, B](xs: List[A], f: A => B): List[B] =
+%%     for (x <- xs) yield f(x)
 
-  def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
-    for (x <- xs; y <- f(x)) yield y
+%%   def flatMap[A, B](xs: List[A], f: A => List[B]): List[B] =
+%%     for (x <- xs; y <- f(x)) yield y
 
-  def filter[A](xs: List[A], p: A => Boolean): List[A] =
-    for (x <- xs if p(x)) yield x
-}
-\end{lstlisting}
+%%   def filter[A](xs: List[A], p: A => Boolean): List[A] =
+%%     for (x <- xs if p(x)) yield x
+%% }
+%% \end{lstlisting}
 %% Not surprisingly, the translation of the for-comprehension in the body of
 %% \code{Demo.map} will produce a call to \code{map} in class \code{List}.
 %% Similarly, \code{Demo.flatMap} and \code{Demo.filter} translate to
@@ -5705,18 +4610,18 @@ object Demo {
 
 %% \begin{exercise}
 %% Define the following function in terms of \code{for}.
-\begin{lstlisting}
-def flatten[A](xss: List[List[A]]): List[A] =
-  (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def flatten[A](xss: List[List[A]]): List[A] =
+%%   (xss :\ (Nil: List[A])) ((xs, ys) => xs ::: ys)
+%% \end{lstlisting}
 %% \end{exercise}
 
 %% \begin{exercise}
 %% Translate
-\begin{lstlisting}
-for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
-for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for (b <- books; a <- b.authors if a startsWith "Bird") yield b.title
+%% for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
+%% \end{lstlisting}
 %% to higher-order functions.
 %% \end{exercise}
 
@@ -5727,9 +4632,9 @@ for (b <- books if (b.title indexOf "Program") >= 0) yield b.title
 %% not needed but we would still like the flexibility of generators and
 %% filters in iterations over lists. This is made possible by a variant
 %% of the for-comprehension syntax, which expresses for-loops:
-\begin{lstlisting}
-for ( $s$ ) $e$
-\end{lstlisting}
+%% \begin{lstlisting}
+%% for ( $s$ ) $e$
+%% \end{lstlisting}
 %% This construct is the same as the standard for-comprehension syntax
 %% except that the keyword \code{yield} is missing. The for-loop is
 %% executed by executing the expression $e$ for each element generated
@@ -5737,12 +4642,12 @@ for ( $s$ ) $e$
 
 %% As an example, the following expression prints out all elements of a
 %% matrix represented as a list of lists:
- \begin{lstlisting}
-for (xs <- xss) {
-  for (x <- xs) print(x + "\t")
-  println()
-}
-\end{lstlisting}
+%%  \begin{lstlisting}
+%% for (xs <- xss) {
+%%   for (x <- xs) print(x + "\t")
+%%   println()
+%% }
+%% \end{lstlisting}
 %% The translation of for-loops to higher-order methods of class
 %% \code{List} is similar to the translation of for-comprehensions, but
 %% is simpler. Where for-comprehensions translate to \code{map} and
@@ -5776,11 +4681,11 @@ for (xs <- xss) {
 %%  \code{C[A]} for which you want to enable for-comprehensions. Then
 %%  \code{C} should define \code{map}, \code{flatMap} and \code{filter}
 %%  with the following types:
-\begin{lstlisting}
-def map[B](f: A => B): C[B]
-def flatMap[B](f: A => C[B]): C[B]
-def filter(p: A => Boolean): C[A]
-\end{lstlisting}
+%% \begin{lstlisting}
+%% def map[B](f: A => B): C[B]
+%% def flatMap[B](f: A => C[B]): C[B]
+%% def filter(p: A => Boolean): C[A]
+%% \end{lstlisting}
 %% It would be attractive to enforce these types statically in the Scala
 %% compiler, for instance by requiring that any type supporting
 %% for-comprehensions implements a standard trait with these methods

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5322,27 +5322,23 @@ def queens(n: Int): List[List[Int]] = {
 }
 \end{lstlisting}
 
-%---------------xpto
-
-\begin{exercise} Write the function
+\begin{exercise} Escreva a função 
 \begin{lstlisting}
   def isSafe(col: Int, queens: List[Int], delta: Int): Boolean
 \end{lstlisting}
-which tests whether a queen in the given column \verb@col@ is safe with 
-respect to the \verb@queens@ already placed. Here, \verb@delta@ is the difference between the row of the queen to be
-placed and the row of the first queen in the list.
+que testa se uma rainha numa dada coluna \verb@col@ está segura com respeito às \verb@queens@ já colocadas.
+Aqui, \verb@delta@ é a diferença entre a linha da rainha a ser colocada e a linha da primeira rainha da lista.
 \end{exercise}
 
-\section{Querying with For-Comprehensions}
+\section{Pesquisando com For-Comprehensions}
 
-The for-notation is essentially equivalent to common operations of
-database query languages.  For instance, say we are given a 
-database \code{books}, represented as a list of books, where
-\code{Book} is defined as follows.
+A notação for é essencialmente equivalente a operações comuns de linguagens de pesquisa de bases de dados.
+Por exemplo, digamos que temos uma base de dados \code{books}, representada como uma lista de livros, onde
+\code{Book} é definido como segue.
 \begin{lstlisting}
 case class Book(title: String, authors: List[String])
 \end{lstlisting}
-Here is a small example database:
+Aqui está um pequeno exemplo de base de dados:
 \begin{lstlisting}
 val books: List[Book] = List(
   Book("Structure and Interpretation of Computer Programs",
@@ -5356,39 +5352,38 @@ val books: List[Book] = List(
   Book("The Java Language Specification",
        List("Gosling, James", "Joy, Bill", "Steele, Guy", "Bracha, Gilad")))
 \end{lstlisting}
-Then, to find the titles of all books whose author's last name is ``Ullman'':
+Então, para encontrar os títulos de todos os livros cujos autores tenham sobrenome ``Ullman'':
 \begin{lstlisting}
 for (b <- books; a <- b.authors if a startsWith "Ullman")
 yield b.title
 \end{lstlisting}
-(Here, \code{startsWith} is a method in \code{java.lang.String}).  Or,
-to find the titles of all books that have the string ``Program'' in
-their title:
+(Aqui, \code{startsWith} é um método dentro em \code{java.lang.String}).  Ou, para encontrar os 
+títulos de todos os livros que tenham a cadeia de caracteres ``Program'' em seu título: 
 \begin{lstlisting}
 for (b <- books if (b.title indexOf "Program") >= 0)
 yield b.title
 \end{lstlisting}
-Or, to find the names of all authors that have written at least two
-books in the database.
+Ou, para encontrar os nomes de todos os autores que escreveram pelo menos dois livros, na base de dados.
 \begin{lstlisting}
 for (b1 <- books; b2 <- books if b1 != b2;
      a1 <- b1.authors; a2 <- b2.authors if a1 == a2)
 yield a1
 \end{lstlisting}
-The last solution is not yet perfect, because authors will appear
-several times in the list of results.  We still need to remove
-duplicate authors from result lists.  This can be achieved with the
-following function.
+A última solução ainda não é perfeita, porque autores aparecerão diversas vezes na lista de resultados.
+Ainda precisamos remover autores duplicados das listas resultantes. Isto pode ser obtido através da seguinte 
+função.
 \begin{lstlisting}
 def removeDuplicates[A](xs: List[A]): List[A] =
   if (xs.isEmpty) xs
   else xs.head :: removeDuplicates(xs.tail filter (x => x != xs.head))
 \end{lstlisting}
-Note that the last expression in method \code{removeDuplicates}
-can be equivalently expressed using a for-comprehension.
+Observe que a última expressão no método \code{removeDuplicates} pode ser equivalentemente expresso usando 
+um for-comprehension.
 \begin{lstlisting}
 xs.head :: removeDuplicates(for (x <- xs.tail if x != xs.head) yield x)
 \end{lstlisting}
+
+%---------------xpto
 
 \section{Translation of For-Comprehensions}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1831,9 +1831,12 @@ Então, \code{sqrt(2)} dá:
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% One way to control such oscillations is to prevent the guess from changing too much. 
 %% This can be achieved by {\em averaging} successive values of the original sequence:
+Um modo de controlar tais oscilações é prevenir guess de mudar muito.
+Isso pode ser obtido pela média (função {\em averaging}) de sucessivos valores da sequência 
+original:
 \begin{lstlisting}
 scala> def sqrt(x: Double) = fixedPoint(y => (y + x/y) / 2)(1.0)
 sqrt: (Double)Double
@@ -1847,14 +1850,19 @@ scala> sqrt(2.0)
 \end{lstlisting}
 %% In fact, expanding the \code{fixedPoint} function yields exactly our 
 %% previous definition of fixed point from Section~\ref{sec:sqrt}.
-
+De fato, expandindo a função \code{fixedPoint} dá exatamente nossa prévia
+definição de ponto fixo da Seção~\ref{sec:sqrt}.
 %% The previous examples showed that the expressive power of a language
 %% is considerably enhanced if functions can be passed as arguments.  The
 %% next example shows that functions which return functions can also be
 %% very useful.
+Os exemplos anteriores mostraram que o poder de expressividade de uma linguagem 
+é consideravelmente aumentado se funções puderem ser passadas como argumentos.
+O próximo exemplo mostra que funções que retornam funções também podem ser
+muito úteis.
 %----------
 
-%----------
+%----------xpto
 %% Consider again fixed point iterations. We started with the observation
 %% that $\sqrt(x)$ is a fixed point of the function \code{y => x / y}.
 %% Then we made the iteration converge by averaging successive values.

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -1033,21 +1033,26 @@ incluir um tipo de retorno para melhor documentaÅÁÅ„o.
 %% As a second step, we define the two functions called by
 %% \code{sqrtIter}: a function to \code{improve} the guess and a
 %% termination test \code{isGoodEnough}. Here is their definition.
-%% \begin{lstlisting}
-%% def improve(guess: Double, x: Double) =
-%%   (guess + x / guess) / 2
-%----------
 
-%----------
-%% def isGoodEnough(guess: Double, x: Double) =
-%%   abs(square(guess) - x) < 0.001
-%% \end{lstlisting}
+Como segundo passo, definimos as duas funÅÁÅıes chamadas por:
+\code{sqrtIter}: uma funÅÁÅ„o para melhorar (\code{improve}) o palpite e um
+teste de terminaÅÁÅ„o \code{isGoodEnough}. Aqui estÅ„o suas definiÅÁÅıes.
+\begin{lstlisting}
+def improve(guess: Double, x: Double) =
+  (guess + x / guess) / 2    
+
+def isGoodEnough(guess: Double, x: Double) =
+  abs(square(guess) - x) < 0.001
+\end{lstlisting}
 
 %% Finally, the \code{sqrt} function itself is defined by an application
 %% of \code{sqrtIter}.
-%% \begin{lstlisting}
-%% def sqrt(x: Double) = sqrtIter(1.0, x)
-%% \end{lstlisting}
+Finalmente, a prÅÛpria funÅÁÅ„o \code{sqrt} ÅÈ definida como uma aplicaÅÁÅ„o de
+\code{sqrtIter}.
+  
+\begin{lstlisting}
+def sqrt(x: Double) = sqrtIter(1.0, x)
+\end{lstlisting}
 %----------
 
 %----------
@@ -1059,9 +1064,16 @@ incluir um tipo de retorno para melhor documentaÅÁÅ„o.
 
 %% \begin{exercise} Trace the execution of the \code{sqrt(4)} expression.
 %% \end{exercise}
+\begin{exercise} O teste \code{isGoodEnough} nÅ„o ÅÈ muito preciso para pequenos 
+nÅ˙meros e podem levar a nÅ„o terminaÅÁÅ„o para nÅ˙meros muito grandes (por que?).
+Crie uma versÅ„o diferente para \code{isGoodEnough} que nÅ„o tenham esses problemas.
+\end{exercise}
+
+\begin{exercise} Simule a execuÅÁÅ„o da expressÅ„o \code{sqrt(4)}.
+\end{exercise}
 %----------
 
-%----------
+%----------xpto
 %% \section{Nested Functions}
 
 %% The functional programming style encourages the construction of many

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3849,40 +3849,41 @@ class Array[+A] {
                                  $\mbox{\sl appears in contravariant position.}$
 }
 \end{lstlisting}
-%----------xpto
 
-So far, so good. Intuitively, the compiler was correct in rejecting
-the \code{update} procedure in a co-variant class because \code{update}
-potentially changes state, and therefore undermines the soundness of
-co-variant subtyping. 
+Até aqui tudo bem. Intuitivamente, o compilador estava correto rejeitando o 
+procedimento \code{update} na classe covariante, porque \code{update} potencialmente 
+muda estado, e portanto mina a integridade da subtipificação covariante.
 
-However, there are also methods which do not mutate state, but where a
-type parameter still appears contra-variantly. An example is
-\code{push} in type \code{Stack}. Again the Scala compiler will reject
-the definition of this method for co-variant stacks.
+Entretanto, há também métodos que não mudam estado, mas onde um parâmetro tipo ainda
+aparece contra-variantemente. Como exemplo temos o \code{push} no tipo \code{Stack}. 
+Novamente o compilador Scala rejeitará a definição deste método para pilhas covariantes.
+
+
 \begin{lstlisting}
 class Stack[+A] {
   def push(x: A): Stack[A] =
               ^ $\mbox{\sl covariant type parameter}$ A
                 $\mbox{\sl appears in contravariant position.}$
 \end{lstlisting}
-This is a pity, because, unlike arrays, stacks are purely functional data
-structures and therefore should enable co-variant subtyping. However,
-there is a a way to solve the problem by using a polymorphic method
-with a lower type parameter bound.
+
+Isto é uma pena, porque diferente de vetores, pilhas são estruturas de dados 
+puramente funcionais e portanto devem habilitar a subtipificação covariante. 
+Entretanto,  há um modo de resolver o problema usando um método polimórfico
+com uma baixa ligação para tipos de parâmetros. 
 
 \section{Lower Bounds}
 
-We have seen upper bounds for type parameters. In a type parameter
-declaration such as \code{T <: U}, the type parameter \code{T} is
-restricted to range only over subtypes of type \code{U}. Symmetrical
-to this are lower bounds in Scala. In a type parameter declaration
-\code{T >: S}, the type parameter \code{T} is restricted to range only
-over {\em supertypes} of type \code{S}. (One can also combine lower and
-upper bounds, as in \code{T >: S <: U}.)
+Nós temos visto ligações fortes para tipos de parâmetros. Em uma declaração 
+de tipo parâmetro tal como \code{T <: U}, o tipo parâmetro \code{T} é restrito
+ao intervalo somente sobre subtipos do tipo \code{U}. Simetrico a isso estão as 
+ligações fracas em Scala. Em uma declaração de tipo parâmetro \code{T >: S}, o 
+tipo parâmetro \code{T} está restrito ao intervalo somente sobre {\em supertipos} 
+do tipo \code{S}. (Pode-se também combinar ligações fracas e fortes, como em \code{T >: S <: U}.) 
 
-Using lower bounds, we can generalize the \code{push} method in
-\code{Stack} as follows.
+Usando ligações fracas, podemos generalizar o método \code{push} dentro de \code{Stack}
+como segue.
+%----------xpto
+
 \begin{lstlisting}
 class Stack[+A] {
   def push[B >: A](x: B): Stack[B] = new NonEmptyStack(x, this)

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -3152,7 +3152,7 @@ usada e, segundo, quais foram os argumentos construtores. Como essa situação 
 bem comum, Scala tem um modo de automatizá-lo para classes case.
 %----------
 
-%----------xpto
+%----------
 %% \section{Case Classes and Case Objects}
 \section{Classes Case e Objetos Case}
 
@@ -3188,6 +3188,8 @@ def Sum(e1: Expr, e2: Expr) = new Sum(e1, e2)
 
 %----------
 %%would be added. Hence, one can now construct expression trees a bit more concisely, as in
+serão adicionadas. Consequentemente, pode-se agora construir árvores-expressões de modo um 
+pouco mais conciso, como em
 \begin{lstlisting}
 Sum(Sum(Number(1), Number(2)), Number(3))
 \end{lstlisting} 
@@ -3198,11 +3200,16 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% of these methods takes in each case the structure of a member of a
 %% case class into account. The \code{toString} method represents an
 %% expression tree the way it was constructed. So,
+\item Classes case e objetos case implicitamente vem com implementações dos métodos 
+\code{toString}, \code{equals} e \code{hashCode}, que sobrescrevem os
+métodos com o mesmo nome na classe \code{AnyRef}. A implementação desses 
+métodos leva em consideração em cada caso a estrutura de um membro de uma classe 
+case. O método \code{toString} representa uma árvore expressão do modo como foi
+construída. Então,  
 \begin{lstlisting}
 Sum(Sum(Number(1), Number(2)), Number(3))
 \end{lstlisting} 
 %----------
-
 
 %----------
 %% would be converted to exactly that string, whereas the default
@@ -3213,6 +3220,13 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% arguments which are themselves pairwise equal. This also affects the
 %% implementation of \code{==} and \code{!=}, which are implemented in
 %% terms of \code{equals} in Scala. So,
+será convertida exatamente naquela cadeia de caracteres, onde a implementação 
+default dentro da classe \code{AnyRef} retornará uma cadeia de caracteres 
+consistindo construtor \code{Sum} mais externo e um número. O método 
+\code{equals} trata dois membros case da classe case do mesmo modo, caso
+eles tenham sido construídos com o mesmo construtor e com argumentos que 
+são par a par iguais. Isso também afeta a implementação de \code{==} e 
+\code{!=}, que são implementados em termos de \code{equals} em Scala. Então,  
  \begin{lstlisting}
  Sum(Number(1), Number(2)) == Sum(Number(1), Number(2))
  \end{lstlisting}
@@ -3231,13 +3245,22 @@ Sum(Sum(Number(1), Number(2)), Number(3))
 %% Case classes implicitly come with nullary accessor methods which
 %% retrieve the constructor arguments.
 %% In our example, \code{Number} would obtain an accessor method
+dará \code{true}. Se \code{Sum} ou \code{Number} não fossem classes case, a 
+mesma expressão seria \code{false}, pois a implementação padrão de \code{equals} na 
+classe \code{AnyRef} sempre trata objetos criados por diferentes chamadas de construtores 
+como sendo diferentes. O método \code{hashCode} segue a mesmo princípio dos 
+outros dois métodos. Computa um código hash a partir do nome do construtor da classe case
+e os códigos hash dos argumentos do construtor, ao invés de o fazer a partir do endereço 
+do objeto, que é o que a implementação default de \code{hashCode} faz.
+\item
+Classes case implicitamente vem com métodos de acesso nulos que recuperam os argumentos 
+do construtor. Em nosso exemplo, \code{Number} obteria um método de acesso  
  \begin{lstlisting}
  def n: Int
  \end{lstlisting}
 %----------
 
-
-%----------
+%----------xpto
 %% which returns the constructor parameter \code{n}, whereas \code{Sum} would obtain two accessor methods
  \begin{lstlisting}
  def e1: Expr, e2: Expr

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2254,19 +2254,24 @@ class Object {
 \end{lstlisting}
 %----------
 
-%----------xpto
+%----------
 %% The implementation of \code{toString} in \code{Object}
 %% forms a string consisting of the object's class name and a number. It
 %% makes sense to redefine this method for objects that are rational
 %% numbers:
+A implementação de \code{toString} em \code{Object} forma uma string que 
+consiste do nome da classe do objeto e um número. Faz sentido redefinir este
+método para objetos que são números racionais:  
 \begin{lstlisting}
 class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
+  ... // como antes
   override def toString = "" + numer + "/" + denom
 }
 \end{lstlisting}
 %% Note that, unlike in Java, redefining definitions need to be preceded
 %% by an \code{override} modifier.
+Observe que, diferentemente de Java, definições que redefinem precisam
+ser precedidas por um modificador \code{override}.  
 %----------
 
 %----------
@@ -2275,6 +2280,12 @@ class Rational(n: Int, d: Int) extends AnyRef {
 %% type $A$ {\em conforms} to type $B$.  For instance, \code{Rational}
 %% conforms to \code{AnyRef}, so it is legal to assign a \code{Rational}
 %% value to a variable of type \code{AnyRef}:
+Se a classe $A$ estende a classe $B$, então objetos do tipo $A$ podem ser
+usados sempre que objetos do tipo $B$ são esperados. Nesse caso dizemos que o 
+tipo $A$ está em {\em conformidade} com o tipo $B$. Por exemplo, \code{Rational}
+está em conformidade com \code{AnyRef}, logo é legal atribuir um valor \code{Rational}
+à variável do tipo \code{AnyRef}:
+ 
  \begin{lstlisting}
  var x: AnyRef = new Rational(1, 2)
  \end{lstlisting}
@@ -2285,6 +2296,8 @@ class Rational(n: Int, d: Int) extends AnyRef {
 %% %Also unlike in Java, methods in Scala do not necessarily take a
 %% %parameter list. An example is \code{toString}; the method is invoked
 %% %by simply mentioning its name. For instance:
+\paragraph{Métodos sem Parâmetros}
+
 \begin{lstlisting}
 val r = new Rational(1,2)
 System.out.println(r.toString);      // prints``1/2''
@@ -2292,9 +2305,12 @@ System.out.println(r.toString);      // prints``1/2''
 %% Unlike in Java, methods in Scala do not necessarily take a
 %% parameter list. An example is the \code{square} method below. This
 %% method is invoked by simply mentioning its name. 
+Distintamente de Java, métodos em Scala não necessariamente precisam 
+receber uma lista de parâmetros. Um exemplo é o método abaixo \code{square}.
+Este método é invocado simplesmente mencionando seu nome. 
 \begin{lstlisting}
 class Rational(n: Int, d: Int) extends AnyRef {
-  ... // as before
+  ... // como antes
   def square = new Rational(numer*numer, denom*denom)
 }
 val r = new Rational(3, 4)
@@ -2313,9 +2329,19 @@ println(r.square)           // prints``9/16''*
 %% the implementer of a class. Often, a field in one version of a class
 %% becomes a computed value in the next version. Uniform access ensures
 %% that clients do not have to be rewritten because of that change.
+Ou seja, métodos sem parâmetros são acessados como campos valor, tais como 
+\code{number} são. A diferença entre valores e métodos sem parâmetros 
+reside em suas definições. O lado direito de um valor é avaliado quando o 
+objeto é criado, e o valor não muda depois. Um lado direito de um método sem
+parâmetros, por outro lado, é avaliado cada vez que o método é chamado. O 
+acesso uniforme dos campos de métodos sem parâmetros resulta em crescente
+flexibilidade para o implementador de uma classe. Frequentemente, um campo
+em uma versão da classe torna-se um valor computado na próxima versão. 
+O acesso uniforme garante que clientes não tenham de ser reescritos 
+por conta desta mudança.
 %----------
 
-%----------
+%----------xpto
 %% \paragraph{Abstract Classes}
 
 %% Consider the task of writing a class for sets of integer numbers with

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -5260,68 +5260,57 @@ o valor de \code{e} no restante da abrangência. Um {\em filtro} é uma express�
 \code{Boolean}. Omite da consideração todas as ligações para as quais \code{f} é \code{falso}. A
 sequência $s$
 
-%----------------xpto 
+A sequência $s$ pode também ser envolvida em chaves ao invés de parênteses, e os dois pontos 
+entre geradores, definições e filtros podem ser omitidos. 
 
-
-The sequence $s$ may also be enclosed in braces instead of
-parentheses, in which case the semicolons between generators,
-definitions and filters can be omitted.
-
-Here are two examples that show how for-comprehensions are used.
-First, let's redo an example of the previous chapter: Given a positive
-integer $n$, find all pairs of positive integers $i$ and $j$, where $1
-\leq j < i < n$ such that $i + j$ is prime. With a for-comprehension
-this problem is solved as follows:
+Aqui estão dois exemplos que mostram como for-comprehensions são usados. Primeiro, vamos refazer um 
+exemplo do capítulo anterior: Dado um inteiro positivo $n$, encontre todos os pares de inteiros 
+positivos $i$ e $j$, onde $1 \leq j < i < n$ such that $i + j$ é primo. Com um for-comprehension
+este problema é resolvido como segue:
 \begin{lstlisting}
 for { i <- List.range(1, n)
       j <- List.range(1, i)
       if isPrime(i+j) } yield {i, j}
 \end{lstlisting}
-This is arguably much clearer than the solution using \code{map},
-\code{flatMap} and \code{filter} that we have developed previously.
 
-As a second example, consider computing the scalar product of two
-vectors \code{xs} and \code{ys}. Using a for-comprehension, this can
-be written as follows.
+Isto é discutivelmente mais claro que a solução usando \code{map}, \code{flatMap} e \code{filter}
+que desenvolvemos previamente.
+
+Como segundo exemplo, considere calcular o produto escalar de dois vetores \code{xs} e \code{ys}. 
+Usando um for-comprehension, isto pode ser escrito como segue.
 \begin{lstlisting}
   sum(for ((x, y) <- xs zip ys) yield x * y)
 \end{lstlisting}
 
-\section{The N-Queens Problem}
+\section{O Problema da N-Rainhas}
 
-For-comprehensions are especially useful for solving combinatorial
-puzzles. An example of such a puzzle is the 8-queens problem: Given a
-standard chess-board, place 8 queens such that no queen is in check from any
-other (a queen can check another piece if they are on the same
-column, row, or diagonal). We will now develop a solution to this
-problem, generalizing it to chess-boards of arbitrary size. Hence, the
-problem is to place $n$ queens on a chess-board of size $n \times n$.
+For-comprehensions são especialmente úteis para resolver puzzles combinatórios. Um exemplo é o problema 
+das $8$-rainhas: Dado um tabuleiro de xadrez padrão, coloque $8$ rainhas, tal que nenhuma rainha
+esteja atacada por nenhuma outra (uma rainha pode atacar qualquer outra peça se estiver na mesma coluna, 
+linha ou diagonal que a mesma). Desenvolveremos agora uma solução para este problema, generalizando 
+para tabuleiros de xadrez de tamanho arbitrário. Consequentemente, o problema é colocar $n$ rainhas 
+em um tabuleiro de xadrez de tamanho $n \times n$.
 
-To solve this problem, note that we need to place a queen in each row.
-So we could place queens in successive rows, each time checking that a
-newly placed queen is not in check from any other queens that have
-already been placed. In the course of this search, it might arrive
-that a queen to be placed in row $k$ would be in check in all fields
-of that row from queens in row $1$ to $k-1$. In that case, we need to
-abort that part of the search in order to continue with a different
-configuration of queens in columns $1$ to $k-1$.
+Para resolver este problema, observe que precisamos colocar uma rainha em cada linha. 
+Logo podemos colocar rainhas em linhas sucessivas, cada vez checando que uma rainha recentemente colocada
+não esteja atacada por qualquer outra rainha que já se encontra no tabuleiro. No curso desta busca, pode 
+acontecer que uma rainha a ser colocada na linha $k$ esteja atacada em todas as casas desta linha por rainhas
+rainhas das linhas $1$ até $k-1$. Neste caso, precisamos interromper esta parte da busca e continuar com uma 
+configuração diferente de rainhas nas colunas $1$ até $k-1$.
 
-This suggests a recursive algorithm.  Assume that we have already
-generated all solutions of placing $k-1$ queens on a board of size $n
-\times n$. We can represent each such solution by a list of length
-$k-1$ of column numbers (which can range from $1$ to $n$).  We treat
-these partial solution lists as stacks, where the column number of the
-queen in row $k-1$ comes first in the list, followed by the column
-number of the queen in row $k-2$, etc. The bottom of the stack is the
-column number of the queen placed in the first row of the board.  All
-solutions together are then represented as a list of lists, with one
-element for each solution.
+Isso sugere um algoritmo recursivo. Assuma que já geramos todas as soluções para colocar $k-1$ rainhas em
+um tabuleiro de tamanho $n \times n$. Podemos representar tal solução por uma lista de tamanho $k-1$ de 
+números das colunas (no intervalo de $1$ a $n$). Tratamos estas listas de soluções parciais como pilhas,
+onde o número da coluna da rainha na linha $k-1$ vem primeiro dentro da lista, seguido pelo número da 
+coluna da rainha na linha $k-2$ etc. O fundo da pilha é o número da coluna da rainha colocada na 
+primeira linha do tabuleiro. Todas as soluções juntas são então representadas como uma lista de listas, 
+com um elemento para cada solução.
 
-Now, to place the $k$'the queen, we generate all possible extensions
-of each previous solution by one more queen. This yields another list
-of solution lists, this time of length $k$. We continue the process
-until we have reached solutions of the size of the chess-board $n$.
-This algorithmic idea is embodied in function \code{placeQueens} below:
+Agora, para colocar a $k$-ésima rainha, geramos todas as possíveis extensões para cada solução prévia com uma 
+rainha a mais. Isto leva a uma outra lista de listas soluções, desta vez de tamanho $k$. Continuamos o processo
+até atingirmos soluções do tamanho $n$ do tabuleiro de xadrez. Esta idéia algorítmica é incorporada na 
+função \code{placeQueens} abaixo: 
+
 \begin{lstlisting}
 def queens(n: Int): List[List[Int]] = {
   def placeQueens(k: Int): List[List[Int]] =
@@ -5332,6 +5321,8 @@ def queens(n: Int): List[List[Int]] = {
   placeQueens(n)
 }
 \end{lstlisting}
+
+%---------------xpto
 
 \begin{exercise} Write the function
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -711,7 +711,7 @@ um vetor, ou uma lista.
 %----------
 
 
-%----------xpto
+%----------
 %% \example
 %% Here is an evaluation of an arithmetic expression.
 %% \begin{lstlisting}
@@ -723,6 +723,19 @@ um vetor, ou uma lista.
 %% \end{lstlisting}
 %% The process of stepwise simplification of expressions to values is
 %% called {\em reduction}.
+
+\example
+Aqui está uma avaliação de uma expressão aritmética.
+
+\begin{lstlisting}
+$\,\,\,$   (2 * pi) * radius
+$\rightarrow$  (2 * 3.141592653589793) * radius
+$\rightarrow$  6.283185307179586 * radius
+$\rightarrow$  6.283185307179586 * 10
+$\rightarrow$  62.83185307179586
+\end{lstlisting}
+O processo de simplificar gradualmente expressões para valores é 
+chamado {\em redução}.
 %----------
 
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -4732,39 +4732,35 @@ class List[+A] { ...
   def reverse: List[A] = (z? /: this)(op?)
 \end{lstlisting}
 
-%-------------xpto
-It only remains to fill in the \code{z?} and \code{op?} parts.  Let's
-try to deduce them from examples.
+
+Agora falta preencher \code{z?} e \code{op?}. Vamos tentar deduzir a partir dos exemplos.
 \begin{lstlisting}
   Nil
-= Nil.reverse                 // by specification
-= (z /: Nil)(op)              // by the template for reverse
-= (Nil foldLeft z)(op)        // by the definition of /:
-= z                           // by definition of foldLeft
+= Nil.reverse                 // pela especificação 
+= (z /: Nil)(op)              // pelo template para reverse
+= (Nil foldLeft z)(op)        // pela definição de /:
+= z                           // pela definição de foldLeft
 \end{lstlisting}
-Hence, \code{z?} must be \code{Nil}. To deduce the second operand,
-let's study reversal of a list of length one.
+Consequentemente, \code{z?} deve ser \code{Nil}. Para deduzir o segundo operando, vamos estudar
+o inverso de uma lista de tamanho um.
 \begin{lstlisting}
   List(x)
-= List(x).reverse             // by specification
-= (Nil /: List(x))(op)        // by the template for reverse, with z = Nil
-= (List(x) foldLeft Nil)(op)  // by the definition of /:
-= op(Nil, x)                  // by definition of foldLeft
+= List(x).reverse             // pela especificação 
+= (Nil /: List(x))(op)        // pelo template para reverse, com  z = Nil
+= (List(x) foldLeft Nil)(op)  // pela definição de /:
+= op(Nil, x)                  // pela definição de foldLeft
 \end{lstlisting}
-Hence, \code{op(Nil, x)} equals \code{List(x)}, which is the same
-as \code{x :: Nil}. This suggests to take as \code{op} the
-\code{::} operator with its operands exchanged.  Hence, we arrive at
-the following implementation for \code{reverse}, which has linear complexity.
+Consequentemente, \code{op(Nil, x)} é igual a \code{List(x)}, o que é o mesmo que \code{x :: Nil}.
+Isto sugere pegar como \code{op} o operador \code{::} com seus operandos trocados. Consequentemente,
+chegamos a seguinte implementação para \code{reverse}, que tem complexidade linear.
 \begin{lstlisting}
 def reverse: List[A] =
   ((Nil: List[A]) /: this) {(xs, x) => x :: xs}
 \end{lstlisting}
-(Remark: The type annotation of \code{Nil} is necessary 
-to make the type inferencer work.)
+(Obs: O tipo de anotação para \code{Nil} é necessário para que a inferência de tipos funcione.)
 
-\begin{exercise} Fill in the missing expressions to complete the following
-definitions of some basic list-manipulation operations as fold
-operations.
+\begin{exercise} Preencha as expressões faltantes para completar as seguintes definições de 
+algumas operações básicas de manipulação de listas como operações fold. 
 \begin{lstlisting}
 def mapFun[A, B](xs: List[A], f: A => B): List[B] =
   (xs :\ List[B]()){ ?? }
@@ -4773,6 +4769,8 @@ def lengthFun[A](xs: List[A]): int =
   (0 /: xs){ ?? }
 \end{lstlisting}
 \end{exercise}
+
+%------------xpto
 
 \paragraph{Nested Mappings}
 

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -6292,24 +6292,22 @@ constructing a stream with first element \code{x} and (unevaluated)
 rest \code{xs}.  Instead of \code{xs ::: ys}, one uses the operation
 \code{xs append ys}.  
 
-\chapter{Iterators}
+\chapter{Iteradores}
 
-Iterators are the imperative version of streams. Like streams,
-iterators describe potentially infinite lists. However, there is no
-data-structure which contains the elements of an iterator. Instead, 
-iterators allow one to step through the sequence, using two abstract methods \code{next} and \code{hasNext}.
+Iteradores s\~{a}o uma vers\~{a}o imperativa dos streams. Assim como streams,
+iteradores descrevem listas potencialmente infinitas. No entanto, não existe uma estrutura de dados
+que contenha os elementos de um iterador. Ao invés disso, os iteradores permitem que se ande somente um passo
+na sequ\^{e}ncia de cada vez, usando os métodos abstratos \code{next} e \code{hasNext}.
 \begin{lstlisting}
 trait Iterator[+A] {
   def hasNext: Boolean
   def next: A
 \end{lstlisting}
-Method \code{next} returns successive elements.  Method \code{hasNext}
-indicates whether there are still more elements to be returned by
-\code{next}. Iterators also support some other methods, which are
-explained later.
+O método \code{next} retorna sucessivos elementos.  O método \code{hasNext}
+indica se existem mais elementos a serem retornados por
+\code{next}. Iteradores também possuem outros métodos que serão explicados posteriormente.
 
-As an example, here is an application which prints the squares of all
-numbers from 1 to 100.
+Como exemplo, esta é uma aplicação que imprime os quadrados de todos os números de 1 à 100.
 \begin{lstlisting}
 val it: Iterator[Int] = Iterator.range(1, 100)
 while (it.hasNext) {
@@ -6318,11 +6316,11 @@ while (it.hasNext) {
 }
 \end{lstlisting}
 
-\section{Iterator Methods}
+\section{Métodos dos Iteradores}
 
-Iterators support a rich set of methods besides \code{next} and
-\code{hasNext}, which is described in the following. Many of these
-methods mimic a corresponding functionality in lists.
+Os iteradores possuem um conjunto de métodos além de \code{next} e
+\code{hasNext}, que são descritos a seguir. Muitos destes métodos
+oferecem uma funcionalidade correspondente à do método equivalente em uma lista.
 
 \paragraph{Append}
 Method \code{append} constructs an iterator which resumes with the

--- a/documentation/src/reference/pt-BR/ExamplesPart.tex
+++ b/documentation/src/reference/pt-BR/ExamplesPart.tex
@@ -2118,7 +2118,7 @@ defini\c{c}\~{o}es de valor tal como \code{val y = square(2)}.
 %----------
 
 %----------
-\chapter{Classes and Objects}
+\chapter{Classes e Objetos}
 \label{chap:classes}
 
 %% Scala does not have a built-in type of rational numbers, but it is
@@ -6422,10 +6422,10 @@ de pares dos respectivos elementos retornados pelos dois iteradores.
 
 \section{Construindo Iteradores}
 
-Concrete iterators need to provide implementations for the two
-abstract methods \code{next} and \code{hasNext} in class
-\code{Iterator}. The simplest iterator is \code{Iterator.empty} which
-always returns an empty sequence:
+As classes concretas de iteradores precisam implementar os dois métodos abstratos
+ \code{next} e \code{hasNext} definidos na classe
+\code{Iterator}. O iterador mais simples é \code{Iterator.empty} que sempre retorna uma
+sequência vazia:
 \begin{lstlisting}
 object Iterator {
   object empty extends Iterator[Nothing] {
@@ -6433,8 +6433,8 @@ object Iterator {
     def next = error("next on empty iterator")
   }
 \end{lstlisting}
-A more interesting iterator enumerates all elements of an array. This
-iterator is constructed by the \code{fromArray} method, which is also defined in the object \code{Iterator}
+Um iterador um pouco mais interessante enumera todos os elementos de um vetor. Este iterador
+é construído a partir do método \code{fromArray}, que também foi definido no objeto \code{Iterator}
 \begin{lstlisting}
   def fromArray[A](xs: Array[A]) = new Iterator[A] {
     private var i = 0
@@ -6445,9 +6445,9 @@ iterator is constructed by the \code{fromArray} method, which is also defined in
       else error("next on empty iterator")
   }
 \end{lstlisting}
-Another iterator enumerates an integer interval.  The
-\code{Iterator.range} function returns an iterator which traverses a
-given interval of integer values. It is defined as follows.
+Um outro iterador enumera um intervalo de inteiros. A função
+\code{Iterator.range} retorna o iterador que caminha em um intervalo dado de valores inteiros.
+Sua definição é a seguinte:
 \begin{lstlisting}
 object Iterator {
   def range(start: Int, end: Int) = new Iterator[Int] {
@@ -6462,11 +6462,10 @@ object Iterator {
   }
 }
 \end{lstlisting}
-All iterators seen so far terminate eventually. It is also possible to
-define iterators that go on forever. For instance, the following
-iterator returns successive integers from some start
-value\footnote{Due to the finite representation of type \prog{int},
-numbers will wrap around at $2^{31}$.}.
+Todos os iteradores mostrados até agora tem um fim. Também é possível
+definir iteradores que nunca terminam. Por exemplo, o iterador a seguir
+retorna inteiros sucessivos a partir de um valor inicial. 
+\footnote{Como a representação do tipo \prog{int} é finita, os números acabaram em $2^{31}$.}.
 \begin{lstlisting}
 def from(start: Int) = new Iterator[Int] {
   private var last = start - 1
@@ -6475,22 +6474,20 @@ def from(start: Int) = new Iterator[Int] {
 }
 \end{lstlisting}
 
-\section{Using Iterators}
+\section{Usando Iteradores}
 
-Here are two more examples how iterators are used. First, to print all
-elements of an array \code{xs: Array[Int]}, one can write:
+Existem mais 2 exemplos de como os iteradores são usados. Primeiro, para imprimir todos
+os elementos de um vetor \code{xs: Array[Int]}, uma pessoa pode escrever:
 \begin{lstlisting}
   Iterator.fromArray(xs) foreach (x => println(x))
 \end{lstlisting}
-Or, using a for-comprehension:
+Ou, usando for-comprehension:
 \begin{lstlisting}
   for (x <- Iterator.fromArray(xs))
     println(x)
 \end{lstlisting}
-As a second example, consider the problem of finding the indices of
-all the elements in an array of \code{double}s greater than some
-\code{limit}. The indices should be returned as an iterator.
-This is achieved by the following expression.
+Como um segundo exemplo, considere o problema de encontrar os índices de todos os elementos de um vetor de \code{double}s maiores que um dado \code{limit}. Os índices devem ser retornado na forma de um iterador.
+Isto pode ser obtido pela expressão:
 \begin{lstlisting}
 import Iterator._
 fromArray(xs)
@@ -6498,21 +6495,19 @@ fromArray(xs)
 .filter(case (x, i) => x > limit)
 .map(case (x, i) => i)
 \end{lstlisting}
-Or, using a for-comprehension:
+Ou usando for-comprehension:
 \begin{lstlisting}
 import Iterator._
 for ((x, i) <- fromArray(xs) zip from(0); x > limit)
 yield i
 \end{lstlisting}
 
-\chapter{Lazy Values}
+\chapter{Valores Preguiçosos (Lazy)}
 
-Lazy values provide a way to delay initialization of a value until the
-first time it is accessed. This may be useful when dealing with
-values that might not be needed during execution, and whose
-computational cost is signifficant. As a first example, let's consider
-a database of employees, containing for each employee its manager and
-its team.
+Valores Preguiçosos oferecem uma maneira de postergar a inicialização de um valor até o primeiro 
+momento em que seja acessado. Isto pode ser útil quando estiver lidando com valores que podem não ser
+necessários durante a execução e cujo custo computacional seja significativo. Como primeiro exemplo,
+vamos considerar um banco de dados de empregados contendo cada empregado e seu gestor e sua equipe.
 \begin{lstlisting}
 case class Employee(id: Int, 
                     name: String, 
@@ -6522,11 +6517,9 @@ case class Employee(id: Int,
 }
 \end{lstlisting}
 
-The \lstinline@Employee@ class given above will eagerly initialize
-all its fields, loading the whole employee table in memory. This is
-certainly not optimal, and it can be easily  improved my making the
-fields lazy. This way we delay the database access until it is really
-needed, if it is ever needed.
+A classe \lstinline@Employee@ dada anteriormente irá tentar inicializar todos os seus campos, carregando todoa a tabela
+de empregados na memória. Isto certamente não é o ideal e pode ser melhorado como facilidade tornando os campos
+preguiçosos. Desta forma, atrasamos o acesso ao banco de dados até o momento em que ele seja realmente necessário, se isto ocorrer.
 \begin{lstlisting}
 case class Employee(id: Int, 
                     name: String, 
@@ -6535,9 +6528,8 @@ case class Employee(id: Int,
   lazy val team: List[Employee] = Db.team(id)
 }
 \end{lstlisting}
-
-To see what is really happening, we can use this mockup
-database which shows when records are fetched:
+Para ver o que realmente está acontecendo, podemos usar este banco de dados mock
+que mostra quando os registros são acessados:
 \begin{lstlisting}
 object Db {
   val table = Map(1 -> (1, "Haruki Murakami", -1),
@@ -6559,9 +6551,8 @@ object Db {
   }
 }
 \end{lstlisting}
-The output when running a program that retrieves one employee 
-confirms that the database is only accessed when referring  the lazy
-values.
+Ao rodar o programa, a saída confirma que ele retorna um empregado e que
+o banco somente é acessado quando é feita uma referência ao valor preguiçoso.
 
 Another use of lazy values is to resolve the
 initialization order of applications composed of several

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -377,6 +377,15 @@ latter, each subclass of \code{Map} defines its own set of
 methods, which override the methods in the base class. The pattern
 matches of the algebraic implementation have been replaced by the
 dynamic binding that comes with method overriding.
+
+Observe a estrutura de aninhamento diferente de \code{AlgBinTree} e
+\code{OOBinTree}. No primeiro, todos os métodos são parte da classe base
+\code{Map}. O comportamento distinto para árvores vazias e não vazias 
+é expresso usando um casamento de padrões na própria árvore. No 
+último, cada subclasse do \code{Map} define seu próprio conjunto de 
+métodos, que sobrescrevem os métodos da classe base. O casamento de 
+padrões da implementação algébrica foi substituído pela ligação 
+dinâmica que veio com o método sobrescrito.
 %--------
 
 %--------

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -11,6 +11,9 @@
 \renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
 \renewcommand{\mychaptername}{Capítulo}
 \renewcommand*{\contentsname}{Índice}
+\renewcommand\lstlistingname{Listagem}
+\renewcommand\lstlistlistingname{Listagens}
+
 
 
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -397,6 +397,9 @@ hand, if the type is extended with additional methods, then it is
 preferable to keep only one implementation of methods and to rely on
 pattern matching, since this way existing subclasses need not be
 modified.
+
+Qual dos dois esquemas é preferível depende em grande parte de quais
+estensões do tipo são antecipadas. Se o tipo é
 %--------
 
 \begin{figure}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -1,4 +1,3 @@
-
 \documentclass[a4paper,12pt,twoside,titlepage]{book}
 
 \usepackage{scaladoc}
@@ -6,14 +5,16 @@
 \usepackage{modefs}
 \usepackage{math}
 \usepackage{scaladefs}
+\usepackage[utf8]{inputenc}
 \renewcommand{\todo}[1]{}
 
+\renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
 
 
 \ifpdf
     \pdfinfo {
         /Author   (Martin Odersky)
-        /Title    (Scala através de exemplos)
+        /Title    (Scala atravÃ©s de exemplos)
         /Keywords (Scala)
         /Subject  ()
         /Creator  (TeX)
@@ -21,7 +22,7 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através de Exemplos\\[33mm]\ }
+\renewcommand{\doctitle}{Scala AtravÃ©s de Exemplos\\[33mm]\ }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
 \begin{document}
@@ -33,29 +34,28 @@
 \mainmatter
 \sloppy
 
-\chapter{\label{chap:intro}Introduction}
+\chapter{\label{chap:intro}IntroduÃ§Ã£o}
 %Scala smoothly integrates object-oriented and functional
 %programming. It is designed to express common programming patterns in
 %a concise, elegant, and type-safe way.  Scala introduces several
 %innovative language constructs. For instance:
-Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
-Foi criada para expressar padrões de programação comuns de modo conciso, elegante e type-safe. Scala introduz
-diversas construções de linguagem inovadoras. Por exemplo:
+Scala facilita a integraÃ§Ã£o entre a  programaÂ¿Â¿o orientada a objetos e a programaÂ¿Â¿o funcional.
+Foi criada para expressar padrÂ¿es de programaÂ¿Â¿o comuns de modo conciso, elegante e fortemente tipada. Scala introduz diversas construÃ§Ãµes de linguagem inovadoras. Por exemplo:
 \begin{itemize}
 
 \item 
 %Abstract types and mixin composition unify concepts from object and module systems.
-Tipos abstratos e composições mistas unificam conceitos de objetos e módulos de sistema.
+Tipos abstratos e composiÂ¿Â¿es mistas unificam conceitos de objetos e mÂ¿dulos de sistema.
 \item 
 %Pattern matching over class hierarchies unifies functional and
 %  object-oriented data access. It greatly simplifies the processing of XML trees.
-Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
-objetos. Simplifica bastante o processamento de árvores XML.
+Casamento de padrÂ¿es sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
+objetos. Simplifica bastante o processamento de Â¿rvores XML.
 \item
 %A flexible syntax and type system enables the construction of advanced
 %  libraries and new domain specific languages.
-Sintaxe flexível e sistema de tipos habilitam a construção de avançadas 
-bibliotecas e um novo domínio específico de linguagens.
+Sintaxe flexÂ¿vel e sistema de tipos habilitam a construÂ¿Â¿o de avanÂ¿adas 
+bibliotecas e um novo domÂ¿nio especÂ¿fico de linguagens.
 \end{itemize}
 
 %At the same time, Scala is compatible with Java.  Java libraries and
@@ -64,10 +64,10 @@ bibliotecas e um novo domínio específico de linguagens.
 %This document introduces Scala in an informal way, through a sequence
 %of examples.
 
-Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
-podem ser usados sem código extra ou declarações adicionais.
+Ao mesmo tempo, Scala Â¿ compatÂ¿vel com Java. Bibliotecas Java e frameworks
+podem ser usados sem cÂ¿digo extra ou declaraÂ¿Â¿es adicionais.
 
-Este documento introduz Scala de um modo informal, através de uma sequência
+Este documento introduz Scala de um modo informal, atravÂ¿s de uma sequÂ¿ncia
 de examplos.
 
 
@@ -81,15 +81,15 @@ de examplos.
 %meant to be complemented by the Scala Language Reference Manual which
 %specifies Scala in a more detailed and precise way.
 
-Capítulos~\ref{chap:example-one} e \ref{chap:example-auction}
+CapÂ¿tulos~\ref{chap:example-one} e \ref{chap:example-auction}
 salientam alguns dos aspectos que tornam Scala interessante. Os
-capítulos seguintes introduzem as construções da linguagem Scala de um
-modo mais completo, começando com expressões e funções simples, e 
-desenvolvendo até objetos e classes, listas e streams, estado 
-mutável, casamento de padrões até exemplos mais completos que mostram
-interessantes técnicas de programação. A presente exposição informal
-pretende ser complementada por um Manual de Referência da Linguagem Scala, que
-especificará Scala de modo mais detalhado e preciso. 
+capÂ¿tulos seguintes introduzem as construÂ¿Â¿es da linguagem Scala de um
+modo mais completo, comeÂ¿ando com expressÂ¿es e funÂ¿Â¿es simples, e 
+desenvolvendo atÂ¿ objetos e classes, listas e streams, estado 
+mutÂ¿vel, casamento de padrÂ¿es atÂ¿ exemplos mais completos que mostram
+interessantes tÂ¿cnicas de programaÂ¿Â¿o. A presente exposiÂ¿Â¿o informal
+pretende ser complementada por um Manual de ReferÂ¿ncia da Linguagem Scala, que
+especificarÃƒÂ¡ Scala de modo mais detalhado e preciso. 
 
 
 \paragraph{Acknowledgment}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -181,7 +181,7 @@ A classe \code{MapStruct} é parametrizada com um tipo de chaves
 \code{kt} e um tipo de valores \code{vt}. Específica um tipo
 abstrato \code{Map} e um valor abstrato \code{empty}, o qual
 denota mapas vazios. Cada implementação \code{Map} precisa
-conformar com aquele tipo abstrato, o qual estende a função tipo
+estar de acordo com aquele tipo abstrato, o qual estende a função tipo
  \code{kt => vt} com quatro novos métodos. O método \code{domain}
 herda um stream que enumera o domínio do mapa, ou seja, o conjunto
 de chaves que são mapeadas com valores não nulos. O método 
@@ -631,49 +631,88 @@ Isto vale no nosso exemplo, porque \code{Rational} está de acordo com \code{Obj
 De certo modo, composição mixin resulta em sobrescrever a superclasse de uma classe.
 %----------
 
-\paragraph{Final Classes}
-Note that class \code{OrderedRational} was defined
-\code{final}. This means that no classes extending \code{OrderedRational}
-may be defined in other parts of the program.
-%Within final classes the
-%type \code{this} is an alias of the defined class itself. Therefore,
-%we could define our \code{<} method with an argument of type
-%\code{OrderedRational} as a well-formed implementation of the abstract class
-%\code{less(that: this)} in class \code{Ord}.
+%----------
+%\paragraph{Final Classes}
+%Note that class \code{OrderedRational} was defined
+%\code{final}. This means that no classes extending \code{OrderedRational}
+%may be defined in other parts of the program.
 
-\chapter{\label{sec:simple-examples}Pattern Matching}
+\paragraph{Classes Finais}
+Observe que a classe \code{OrderedRational} foi definida \code{final}. Isto
+significa que nenhuma classe estendendo \code{OrderedRational} pode ser
+definida em outras partes do programa.
+%----------
 
-\todo{Complete}
+%%Within final classes the
+%%type \code{this} is an alias of the defined class itself. Therefore,
+%%we could define our \code{<} method with an argument of type
+%%\code{OrderedRational} as a well-formed implementation of the abstract class
+%%\code{less(that: this)} in class \code{Ord}.
 
-Consider binary trees whose leafs contain integer arguments. This can
-be described by a class for trees, with subclasses for leafs and
-branch nodes:
+
+%----------
+%\chapter{\label{sec:simple-examples}Pattern Matching}
+
+%\todo{Complete}
+
+%Consider binary trees whose leafs contain integer arguments. This can
+%be described by a class for trees, with subclasses for leafs and
+%branch nodes:
+
+\chapter{\label{sec:simple-examples}Casamento de Padrões}
+
+Considere árvores binárias cujas folhas contém argumentos inteiros. Isto pode
+ser descrito por uma classe para árvores, com subclasses para folhas e 
+nós internos:
+%----------
 \begin{lstlisting}
 abstract class Tree;
 case class Branch(left: Tree, right: Tree) extends Tree;
 case class Leaf(x: int) extends Tree;
 \end{lstlisting}
-Note that the class \code{Tree} is not followed by an extends
-clause or a body. This defines \code{Tree} to be an empty
-subclass of \code{Object}, as if we had written
+
+
+%----------
+%Note that the class \code{Tree} is not followed by an extends
+%clause or a body. This defines \code{Tree} to be an empty
+%subclass of \code{Object}, as if we had written
+%\begin{lstlisting}
+%class Tree extends Object {}
+%\end{lstlisting}
+%Note also that the two subclasses of \code{Tree} have a \code{case}
+%modifier.  That modifier has two effects. First, it lets us construct
+%values of a case class by simply calling the constructor, without
+%needing a preceding \code{new}. Example:
+%\begin{lstlisting}
+%val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
+%\end{lstlisting}
+%Second, it lets us use constructors for these classes in patterns, as
+%is illustrated in the following example.
+
+Observe que a classe \code{Tree} não é seguida por uma cláusula estensora
+ou por um corpo. Isto define \code{Tree} para ser uma subclasse vazia de
+\code{Object}, como se tivessemos escrito
 \begin{lstlisting}
 class Tree extends Object {}
 \end{lstlisting}
-Note also that the two subclasses of \code{Tree} have a \code{case}
-modifier.  That modifier has two effects. First, it lets us construct
-values of a case class by simply calling the constructor, without
-needing a preceding \code{new}. Example:
+Observe também que as duas subclasses de \code{Tree} têm um modificador
+\code{case}. Aquele modificador tem dois efeitos. Primeiro, no permite
+construir valores de uma classe case simplesmente chamando o construtor, sem
+a necessidade de que um \code{new} o preceda. Examplo:
 \begin{lstlisting}
 val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
 \end{lstlisting}
-Second, it lets us use constructors for these classes in patterns, as
-is illustrated in the following example.
+Segundo, nos permite usar construtores para estas classes dentro de padrões,
+conforme ilustrado no seguinte exemplo.
+%-----------
 \begin{lstlisting}
 def sumLeaves(t: Tree): int = t match {
   case Branch(l, r) => sumLeaves(l) + sumLeaves(r)
   case Leaf(x) => x
 }
 \end{lstlisting}
+
+
 The function \code{sumLeaves} sums up all the integer values in the
 leaves of a given tree \code{t}. It is is implemented by calling the
 \code{match} method of \code{t} with a {\em choice expression} as

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -9,6 +9,9 @@
 \renewcommand{\todo}[1]{}
 
 \renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
+\renewcommand{\mychaptername}{Capítulo}
+\renewcommand*{\contentsname}{Índice}
+
 
 
 \ifpdf
@@ -22,7 +25,7 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através de Exemplos\\[33mm]\ }
+\renewcommand{\doctitle}{Scala Através de Exemplos\\[43mm]\ }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
 \begin{document}
@@ -107,7 +110,7 @@ pretende ser complementada por um Manual de Referência da Linguagem Scala, que
 especificarão Scala de modo mais detalhado e preciso. 
 %--------
 
-\paragraph{Acknowledgment}
+\paragraph{Reconhecimento}
 %--------
 %We owe a great debt to Abelson's and Sussman's wonderful book
 %``Structure and Interpretation of Computer

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -28,7 +28,7 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através de Exemplos\\ \\
+\renewcommand{\doctitle}{Scala Através\\  de Exemplos \\
 \Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -581,32 +581,55 @@ declaração abstrata de \code{<} na classe \code{Ord}. Os outros métodos de
 comparação herdados referem-se, então, a esta implementação nos seus corpos.
 %----------
 
+%----------
+%The clause ``\code{Rational(d, d) with Ord}'' is an instance of {\em
+%mixin composition}. It describes a template for an object that is
+%compatible with both \code{Rational} and \code{Ord} and that contains
+%all members of either class. \code{Rational} is called the {\em
+%superclass} of \code{OrderedRational} while \code{Ord} is called a
+%{\em mixin class}. The type of this template is the {\em compound
+%type} ``\code{Rational with Ord}''.
 
+A cláusula ``\code{Rational(d, d) with Ord}'' é uma instância da {\em
+composição mixin}. Descreve um template para um objeto que é compatível
+com ambos \code{Rational} e \code{Ord} e que contém todos os membros de 
+cada classe. \code{Rational} é chamado a {\em
+superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado um
+{\em classe mixin}. O tipo para este template é o {\em tipo composto}
+``\code{Rational with Ord}''.
+%----------
 
+%----------
+%On the surface, mixin composition looks much like multiple
+%inheritance. The difference between the two becomes apparent if we
+%look at superclasses of inherited classes. With multiple inheritance,
+%both \code{Rational} and \code{Ord} would contribute a superclass
+%\code{Object} to the template. We therefore have to answer some
+%tricky questions, such as whether members of \code{Object} are present
+%once or twice and whether the initializer of \code{Object} is called
+%once or twice. Mixin composition avoids these complications.  In the
+%mixin composition \code{Rational with Ord}, class
+%\code{Rational} is treated as actual superclass of class \code{Ord}.
+%A mixin composition \code{C with M} is well-formed as long as the
+%first operand \code{C} conforms to the declared superclass of the
+%second operand \code{M}. This holds in our example, because
+%\code{Rational} conforms to \code{Object}. In a sense, mixin composition
+%amounts to overriding the superclass of a class.
 
-The clause ``\code{Rational(d, d) with Ord}'' is an instance of {\em
-mixin composition}. It describes a template for an object that is
-compatible with both \code{Rational} and \code{Ord} and that contains
-all members of either class. \code{Rational} is called the {\em
-superclass} of \code{OrderedRational} while \code{Ord} is called a
-{\em mixin class}. The type of this template is the {\em compound
-type} ``\code{Rational with Ord}''.
-
-On the surface, mixin composition looks much like multiple
-inheritance. The difference between the two becomes apparent if we
-look at superclasses of inherited classes. With multiple inheritance,
-both \code{Rational} and \code{Ord} would contribute a superclass
-\code{Object} to the template. We therefore have to answer some
-tricky questions, such as whether members of \code{Object} are present
-once or twice and whether the initializer of \code{Object} is called
-once or twice. Mixin composition avoids these complications.  In the
-mixin composition \code{Rational with Ord}, class
-\code{Rational} is treated as actual superclass of class \code{Ord}.
-A mixin composition \code{C with M} is well-formed as long as the
-first operand \code{C} conforms to the declared superclass of the
-second operand \code{M}. This holds in our example, because
-\code{Rational} conforms to \code{Object}. In a sense, mixin composition
-amounts to overriding the superclass of a class.
+Na superfície, composição mixin se parece muito com herança múltipla.
+A diferença entre os dois se torna aparente se olharmos para as superclasses
+das classes herdadas. Com herança múltipla, ambos \code{Rational} e \code{Ord}
+contribuiriam uma superclasse \code{Object} para o template. Por essa razão 
+temos de responder algumas questões delicadas, tais como se membros de \code{Object} 
+estão presentes uma ou duas vezes e se o inicializador de \code{Object} é chamado
+uma ou duas vezes. Composição mixin evita tais complicações. Na composição mixin
+\code{Rational with Ord}, a classe \code{Rational} é tratada como superclasse efetiva
+da classe \code{Ord}.
+Uma composição mixin \code{C with M} é bem formada contanto que o primeiro operando
+\code{C} esteja de acordo com a superclasse declarada do segundo operando \code{M}. 
+Isto vale no nosso exemplo, porque \code{Rational} está de acordo com \code{Object}. 
+De certo modo, composição mixin resulta em sobrescrever a superclasse de uma classe.
+%----------
 
 \paragraph{Final Classes}
 Note that class \code{OrderedRational} was defined

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -51,7 +51,7 @@ Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
 %\item 
 %Abstract types and mixin composition unify concepts from object and module systems.
 \item
-Tipos abstratos e composições mistas unificam conceitos de objetos e módulos de sistema.
+Tipos abstratos e composições mixin unificam conceitos de objetos e módulos de sistema.
 %--------
 
 %--------
@@ -590,12 +590,11 @@ comparação herdados referem-se, então, a esta implementação nos seus corpos
 %{\em mixin class}. The type of this template is the {\em compound
 %type} ``\code{Rational with Ord}''.
 
-% parei de revisar aqui - Vinicius
 A cláusula ``\code{Rational(d, d) with Ord}'' é uma instância da {\em
 composição mixin}. Descreve um template para um objeto que é compatível
 com ambos \code{Rational} e \code{Ord} e que contém todos os membros de 
-cada classe. \code{Rational} é chamado a {\em
-superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado um
+cada classe. \code{Rational} é chamada de {\em
+superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado de
 {\em classe mixin}. O tipo para este template é o {\em tipo composto}
 ``\code{Rational with Ord}''.
 %----------
@@ -620,8 +619,8 @@ superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado um
 Na superfície, composição mixin se parece muito com herança múltipla.
 A diferença entre os dois se torna aparente se olharmos para as superclasses
 das classes herdadas. Com herança múltipla, ambos \code{Rational} e \code{Ord}
-contribuiriam uma superclasse \code{Object} para o template. Por essa razão 
-temos de responder algumas questões delicadas, tais como se membros de \code{Object} 
+trariam a superclasse \code{Object} para o template. Por essa razão 
+teríamos de responder algumas questões delicadas, tais como se membros de \code{Object} 
 estão presentes uma ou duas vezes e se o inicializador de \code{Object} é chamado
 uma ou duas vezes. Composição mixin evita tais complicações. Na composição mixin
 \code{Rational with Ord}, a classe \code{Rational} é tratada como superclasse efetiva
@@ -690,14 +689,14 @@ case class Leaf(x: int) extends Tree;
 %Second, it lets us use constructors for these classes in patterns, as
 %is illustrated in the following example.
 
-Observe que a classe \code{Tree} não é seguida por uma cláusula estensora
+Observe que a classe \code{Tree} não é seguida por uma cláusula \code{extends}
 ou por um corpo. Isto define \code{Tree} para ser uma subclasse vazia de
 \code{Object}, como se tivessemos escrito
 \begin{lstlisting}
 class Tree extends Object {}
 \end{lstlisting}
 Observe também que as duas subclasses de \code{Tree} têm um modificador
-\code{case}. Aquele modificador tem dois efeitos. Primeiro, no permite
+\code{case}. Aquele modificador tem dois efeitos. Primeiro, nos permite
 construir valores de uma classe case simplesmente chamando o construtor, sem
 a necessidade de que um \code{new} o preceda. Examplo:
 \begin{lstlisting}
@@ -729,13 +728,13 @@ def sumLeaves(t: Tree): int = t match {
 
 A função \code{sumLeaves} soma todos os valores inteiros das folhas de
 uma dada árvore \code{t}. É implementada chamando o método \code{match}
-de \code{t}. com uma {\em expressão escolhida} como argumento (\code{match}
-é um método prédefinido dentro da classe \code{Object}). A expressão 
-escolhida consiste de dois cases que casam um padrão com uma expressão.
+de \code{t} com uma {\em dada expressão} como argumento. (\code{match}
+é um método pré-definido da classe \code{Object}). A expressão passada 
+como argumento consiste de dois cases que casam um padrão com a expressão.
 O padrão do primeiro case, \code{Branch(l, r)} casa com todas as instâncias
 da classe \code{Branch} e liga as {\em variáveis padrão} \code{l} e \code{r} 
-ao argumentos do construtor, ou seja, às subárvores esquerda e direita do nó.
-Variáveis padrão sempre iniciam com letra minúscula;  para evitar ambiguidades,
+ao argumentos do construtor, ou seja, às sub-árvores esquerda e direita do nó.
+Variáveis padrão sempre iniciam com letra minúscula e, para evitar ambiguidades,
 construtores nos padrões deveriam iniciar com uma letra maiúscula.
 %-----------
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -730,7 +730,12 @@ A função \code{sumLeaves} soma todos os valores inteiros das folhas de
 uma dada árvore \code{t}. É implementada chamando o método \code{match}
 de \code{t}. com uma {\em expressão escolhida} como argumento (\code{match}
 é um método prédefinido dentro da classe \code{Object}). A expressão 
-escolhida consiste de dois cases que 
+escolhida consiste de dois cases que casam um padrão com uma expressão.
+O padrão do primeiro case, \code{Branch(l, r)} casa com todas as instâncias
+da classe \code{Branch} e liga as {\em variáveis padrão} \code{l} e \code{r} 
+ao argumentos do construtor, ou seja, às subárvores esquerda e direita do nó.
+Variáveis padrão sempre iniciam com letra minúscula;  para evitar ambiguidades,
+construtores nos padrões deveriam iniciar com uma letra maiúscula.
 %-----------
 
 %-----------

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -39,23 +39,24 @@
 %programming. It is designed to express common programming patterns in
 %a concise, elegant, and type-safe way.  Scala introduces several
 %innovative language constructs. For instance:
-Scala facilita a integração entre a  programa¿¿o orientada a objetos e a programa¿¿o funcional.
-Foi criada para expressar padr¿es de programa¿¿o comuns de modo conciso, elegante e fortemente tipada. Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
+Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
+Foi criada para expressar padr¿es de programação comuns de modo conciso, elegante e fortemente tipada. 
+Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
 \begin{itemize}
 
 \item 
 %Abstract types and mixin composition unify concepts from object and module systems.
-Tipos abstratos e composi¿¿es mistas unificam conceitos de objetos e m¿dulos de sistema.
+Tipos abstratos e composições mistas unificam conceitos de objetos e módulos de sistema.
 \item 
 %Pattern matching over class hierarchies unifies functional and
 %  object-oriented data access. It greatly simplifies the processing of XML trees.
-Casamento de padr¿es sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
-objetos. Simplifica bastante o processamento de ¿rvores XML.
+Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
+objetos. Simplifica bastante o processamento de árvores XML.
 \item
 %A flexible syntax and type system enables the construction of advanced
 %  libraries and new domain specific languages.
-Sintaxe flex¿vel e sistema de tipos habilitam a constru¿¿o de avan¿adas 
-bibliotecas e um novo dom¿nio espec¿fico de linguagens.
+Sintaxe flexível e sistema de tipos habilitam a construção de avançadas 
+bibliotecas e um novo dom¿nio específico de linguagens.
 \end{itemize}
 
 %At the same time, Scala is compatible with Java.  Java libraries and
@@ -64,10 +65,10 @@ bibliotecas e um novo dom¿nio espec¿fico de linguagens.
 %This document introduces Scala in an informal way, through a sequence
 %of examples.
 
-Ao mesmo tempo, Scala ¿ compat¿vel com Java. Bibliotecas Java e frameworks
-podem ser usados sem c¿digo extra ou declara¿¿es adicionais.
+Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
+podem ser usados sem código extra ou declarações adicionais.
 
-Este documento introduz Scala de um modo informal, atrav¿s de uma sequ¿ncia
+Este documento introduz Scala de um modo informal, através de uma sequência
 de examplos.
 
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -12,8 +12,8 @@
 \renewcommand{\todo}[1]{}
 
 \renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
-\renewcommand{\mychaptername}{Capítulo}
-\renewcommand*{\contentsname}{Índice}
+\renewcommand{\mychaptername}{Cap\'{i}tulo}
+\renewcommand*{\contentsname}{\'{I}ndice}
 \renewcommand\lstlistingname{Listagem}
 \renewcommand\lstlistlistingname{Listagens}
 \renewcommand{\bibname}{Bibliografia}
@@ -30,7 +30,7 @@
 \ifpdf
     \pdfinfo {
         /Author   (Martin Odersky)
-        /Title    (Scala através de exemplos)
+        /Title    (Scala atrav\'{e}s de exemplos)
         /Keywords (Scala)
         /Subject  ()
         /Creator  (TeX)
@@ -38,7 +38,7 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através\\  de Exemplos \\
+\renewcommand{\doctitle}{Scala Atrav\'{e}s\\  de Exemplos \\
 \Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
@@ -51,97 +51,48 @@
 \mainmatter
 \sloppy
 
-\chapter{\label{chap:intro}Introdução}
-%--------
-%Scala smoothly integrates object-oriented and functional
-%programming. It is designed to express common programming patterns in
-%a concise, elegant, and type-safe way.  Scala introduces several
-%innovative language constructs. For instance:
+\chapter{\label{chap:intro}Introdu\'{c}\~{a}o}
 
-Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
-Foi criada para expressar padrões de programação comuns de forma concisa, elegante e fortemente tipada. 
-Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
-%--------
+Scala facilita a integra\'{c}\~{a}o entre a  programa\'{c}\~{a}o orientada a objetos e a programa\'{c}\~{a}o funcional.
+Foi criada para expressar padr\~{o}es de programa\'{c}\~{a}o comuns de forma concisa, elegante e fortemente tipada. 
+Scala introduz diversas constru\'{c}\~{o}es de linguagem inovadoras. Por exemplo:
 
 \begin{itemize}
-%--------
-%\item 
-%Abstract types and mixin composition unify concepts from object and module systems.
-\item
-Tipos abstratos e composições mixin unificam conceitos de objetos e módulos de sistema.
-%--------
 
-%--------
-%\item 
-%Pattern matching over class hierarchies unifies functional and
-%  object-oriented data access. It greatly simplifies the processing of XML trees.
 \item
-Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
-objetos, simplificando bastante o processamento de árvores XML.
-%--------
-
-%--------
-%\item
-%A flexible syntax and type system enables the construction of advanced
-%  libraries and new domain specific languages.
+Tipos abstratos e composi\'{c}\~{o}es mixin unificam conceitos de objetos e m\'{o}dulos de sistema.
 \item
-Sintaxe flexível e sistema de tipos que habilitam a construção de avançadas 
-bibliotecas e um novas linguagens específicas a um domínio.
-%--------
+Casamento de padr\~{o}es sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
+objetos, simplificando bastante o processamento de \'{a}rvores XML.
+\item
+Sintaxe flex\'{i}vel e sistema de tipos que habilitam a constru\'{c}\~{a}o de avan\'{c}adas 
+bibliotecas e um novas linguagens espec\'{i}ficas a um dom\'{i}nio.
 \end{itemize}
 
-%--------
-%At the same time, Scala is compatible with Java.  Java libraries and
-%frameworks can be used without glue code or additional declarations.
-%This document introduces Scala in an informal way, through a sequence
-%of examples.
-
-Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
-podem ser usados sem código extra ou declarações adicionais.
-Este documento introduz Scala de um modo informal, através de uma sequência
+Ao mesmo tempo, Scala \'{e} compat\'{i}vel com Java. Bibliotecas Java e frameworks
+podem ser usados sem c\'{o}digo extra ou declara\'{c}\~{o}es adicionais.
+Este documento introduz Scala de um modo informal, atrav\'{e}s de uma sequ\^{e}ncia
 de exemplos.
-%--------
 
-%--------
-%Chapters~\ref{chap:example-one} and \ref{chap:example-auction}
-%highlight some of the features that make Scala interesting. The
-%following chapters introduce the language constructs of Scala in a
-%more thorough way, starting with simple expressions and functions, and
-%working up through objects and classes, lists and streams, mutable
-%state, pattern matching to more complete examples that show
-%interesting programming techniques. The present informal exposition is
-%meant to be complemented by the Scala Language Reference Manual which
-%specifies Scala in a more detailed and precise way.
-
-Capítulos~\ref{chap:example-one} e \ref{chap:example-auction}
+Os cap\'{i}tulos~\ref{chap:example-one} e \ref{chap:example-auction}
 salientam alguns dos aspectos que tornam Scala interessante. Os
-capítulos seguintes introduzem as construções da linguagem Scala de um
-modo mais completo, começando com expressões e funções simples, e 
-desenvolvendo até objetos e classes, listas e streams, estado 
-mutável, casamento de padrões até exemplos mais completos que mostram
-interessantes técnicas de programação. A presente exposição informal
-pretende ser complementada por um Manual de Referência da Linguagem Scala, que
-especificarão Scala de modo mais detalhado e preciso. 
-%--------
+cap\'{i}tulos seguintes introduzem as constru\'{c}\~{o}es da linguagem Scala de um
+modo mais completo, come\'{c}ando com express\~{o}es e fun\'{c}\~{o}es simples, e 
+desenvolvendo at\'{e} objetos e classes, listas e streams, estado 
+mut\'{a}vel, casamento de padr\~{o}es at\'{e} exemplos mais completos que mostram
+interessantes t\'{e}cnicas de programa\'{c}\~{a}o. A presente exposi\'{c}\~{a}o informal
+pretende ser complementada por um Manual de Refer\^{e}ncia da Linguagem Scala, que
+especificar\~{a}o Scala de modo mais detalhado e preciso. 
 
 \paragraph{Reconhecimento}
-%--------
-%We owe a great debt to Abelson's and Sussman's wonderful book
-%``Structure and Interpretation of Computer
-%Programs''\cite{abelson-sussman:structure}. Many of their examples and
-%exercises are also present here. Of course, the working language has
-%in each case been changed from Scheme to Scala. Furthermore, the
-%examples make use of Scala's object-oriented constructs where
-%appropriate.
 
-Temos um grande débito ao maravilhoso livro de Abelson e Sussman
+Temos um grande d\'{e}bito ao maravilhoso livro de Abelson e Sussman
 ``Structure and Interpretation of Computer
-Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exercícios 
-deles também estão presentes aqui. Naturalmente a linguagem utilizada em
-cada caso foi mudada do Scheme para o Scala. Além disso, os exemplos
-fazem uso de construções da orientação a objetos do Scala onde isto foi
+Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exerc\'{i}cios 
+deles tamb\'{e}m est\~{a}o presentes aqui. Naturalmente a linguagem utilizada em
+cada caso foi mudada do Scheme para o Scala. Al\'{e}m disso, os exemplos
+fazem uso de constru\'{c}\~{o}es da orienta\'{c}\~{a}o a objetos do Scala onde isto foi
 considerado apropriado. 
-%--------
 
 \input{ExamplesPart}
 \bibliographystyle{alpha}
@@ -149,17 +100,11 @@ considerado apropriado.
 
 \end{document}
 
-%--------
-%\chapter{Implementing Abstract Types: Search Trees}
-%This chapter presents unbalanced binary search trees, implemented in
-%three different styles: algebraic, object-oriented, and imperative.
-%In each case, a search tree package is seen as an implementation
-%of a class {\em MapStruct}.
 
-\chapter{Implementando Tipos Abstratos: Árvores de Busca}
-Este capítulo apresenta árvores binárias de busca não balanceadas implementadas em
-três diferentes estilos: algébrico, orientado a objetos, e imperativo.
-Em cada caso, um pacote de árvore de busca é visto como uma implementação
+\chapter{Implementando Tipos Abstratos: \'{A}rvores de Busca}
+Este cap\'{i}tulo apresenta \'{a}rvores bin\'{a}rias de busca n\~{a}o balanceadas implementadas em
+tr\^{e}s diferentes estilos: alg\'{e}brico, orientado a objetos, e imperativo.
+Em cada caso, um pacote de \'{a}rvore de busca \'{e} visto como uma implementa\'{c}\~{a}o
 de uma classe {\em MapStruct}.
 %--------
 
@@ -176,39 +121,22 @@ de uma classe {\em MapStruct}.
   }
 \end{lstlisting}
 
-%--------
-%The \code{MapStruct} class is parameterized with a type of keys
-%\code{kt} and a type of values \code{vt}. It
-%specifies an abstract type \code{Map} and an abstract value
-%\code{empty}, which represents empty maps.  Every implementation
-%\code{Map} needs to conform to that abstract type, which
-%extends the function type \code{kt => vt}
-%with four new
-%methods. The method \code{domain} yields a stream that enumerates the
-%map's domain, i.e. the set of keys that are mapped to non-null values.
-%The method \code{range} yields a stream that enumerates the function's
-%range, i.e.\ the values obtained by applying the function to arguments
-%in its domain.  The method
-%\code{extend} extends the map with a given key/value binding, whereas
-%\code{remove} removes a given key from the map's domain. Both
-%methods yield a new map value as result, which has the same
-%representation as the receiver object.
 
-A classe \code{MapStruct} é parametrizada com um tipo de chaves
-\code{kt} e um tipo de valores \code{vt}. Também especifica um tipo
+A classe \code{MapStruct} \'{e} parametrizada com um tipo de chaves
+\code{kt} e um tipo de valores \code{vt}. Tamb\'{e}m especifica um tipo
 abstrato \code{Map} e um valor abstrato \code{empty} que serve para
 representar mapas vazios. 
-Toda implementação de \code{Map} precisa atender à interface definida
-por este tipo abstrato, que por sua vez, estende a função do tipo
- \code{kt => vt} com quatro novos métodos. O método \code{domain}
-retorna um stream que enumera o domínio do mapa, ou seja, o conjunto
-de chaves que são mapeadas com valores não nulos. O método 
-\code{range} retorna um stream que enumera a imagem da função, ou seja,
-os valores obtidos pela aplicação dos argumentos da função no seu
-domínio. O método \code{extend} retorna o mapa acrescido de um novo par 
-chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
-Ambos os métodos retornam um novo mapa de valores como resultado, o qual
-tem a mesma representação do objeto recebedor.
+Toda implementa\'{c}\~{a}o de \code{Map} precisa atender à interface definida
+por este tipo abstrato, que por sua vez, estende a fun\'{c}\~{a}o do tipo
+ \code{kt => vt} com quatro novos m\'{e}todos. O m\'{e}todo \code{domain}
+retorna um stream que enumera o dom\'{i}nio do mapa, ou seja, o conjunto
+de chaves que s\~{a}o mapeadas com valores n\~{a}o nulos. O m\'{e}todo 
+\code{range} retorna um stream que enumera a imagem da fun\'{c}\~{a}o, ou seja,
+os valores obtidos pela aplica\'{c}\~{a}o dos argumentos da fun\'{c}\~{a}o no seu
+dom\'{i}nio. O m\'{e}todo \code{extend} retorna o mapa acrescido de um novo par 
+chave/valor, onde \code{remove} remove uma dada chave do mapa do dom\'{i}nio.
+Ambos os m\'{e}todos retornam um novo mapa de valores como resultado, o qual
+tem a mesma representa\'{c}\~{a}o do objeto recebedor.
 %--------
 
 \begin{figure}[t]
@@ -260,69 +188,34 @@ class AlgBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   def empty: Map = Empty
 }
 \end{lstlisting}
-%--------
-%\caption{\label{fig:algbintree}Algebraic implementation of binary
-%search trees}
 
-\caption{\label{fig:algbintree}Implementação algébrica de árvores 
-binárias de busca}
-%--------
+\caption{\label{fig:algbintree}Implementa\'{c}\~{a}o alg\'{e}brica de \'{a}rvores 
+bin\'{a}rias de busca}
 \end{figure}
 
 
-%--------
-%We now present three implementations of \code{Map}, which are all
-%based on binary search trees. The \code{apply} method of a map is
-%implemented in each case by the usual search function over binary
-%trees, which compares a given key with the key stored in the topmost
-%tree node, and depending on the result of the comparison, searches the
-%left or the right hand sub-tree. The type of keys must implement the
-%\code{Ord} class, which contains comparison methods
-%(see Chapter~\ref{chap:classes} for a definition of class \code{Ord}).
-
-Nós agora apresentaremos três implementações de \code{Map}, todas elas
-baseadas em árvores binárias de busca. O método \code{apply} de um mapa é
-implementado em cada caso pela função de busca usual sobre árvores binárias, 
-que compara uma dada chave com a chave guardada no mais alto nó da árvore, 
-e dependendo do resultado da comparação, segue a busca por sua sub-árvore 
+N\'{o}s agora apresentaremos tr\^{e}s implementa\'{c}\~{o}es de \code{Map}, todas elas
+baseadas em \'{a}rvores bin\'{a}rias de busca. O m\'{e}todo \code{apply} de um mapa \'{e}
+implementado em cada caso pela fun\'{c}\~{a}o de busca usual sobre \'{a}rvores bin\'{a}rias, 
+que compara uma dada chave com a chave guardada no mais alto n\'{o} da \'{a}rvore, 
+e dependendo do resultado da compara\'{c}\~{a}o, segue a busca por sua sub-\'{a}rvore 
 esquerda ou direita. O tipo das chaves deve implementar a classe \code{Ord},
-que contém métodos de comparação (ver Capítulo~\ref{chap:classes} para uma
-definição da classe \code{Ord}).
-%--------
+que cont\'{e}m m\'{e}todos de compara\'{c}\~{a}o (ver Cap\'{i}tulo~\ref{chap:classes} para uma
+defini\'{c}\~{a}o da classe \code{Ord}).
 
-%--------
-%The first implementation, \code{AlgBinTree}, is given in
-%Figure~\ref{fig:algbintree}. It represents a map with a
-%data type \code{Map} with two cases, \code{Empty} and \code{Node}.
-
-A primeira implementação, \code{AlgBinTree}, é dada na 
+A primeira implementa\'{c}\~{a}o, \code{AlgBinTree}, \'{e} dada na 
 Figura~\ref{fig:algbintree}. Representa um mapa com um 
 tipo de dados \code{Map} com dois casos, \code{Empty} e \code{Node}.
-%--------
 
-%--------
-%Every method of \code{AlgBinTree[kt, vt].Map} performs a pattern
-%match on the value of
-%\code{this} using the \code{match} method which is defined as postfix
-%function application in class \code{Object} (\sref{sec:class-object}).
-
-Cada método do \code{AlgBinTree[kt, vt].Map} executa um casamento
-de padrões sobre o valor do \code{this} usando o método \code{match}
-que é definido como uma aplicação pós-fixa da função na classe \code{Object} 
+Cada m\'{e}todo do \code{AlgBinTree[kt, vt].Map} executa um casamento
+de padr\~{o}es sobre o valor do \code{this} usando o m\'{e}todo \code{match}
+que \'{e} definido como uma aplica\'{c}\~{a}o p\'{o}s-fixa da fun\'{c}\~{a}o na classe \code{Object} 
 (\sref{sec:class-object}).
-%--------
 
-%--------
-%The functions \code{domain} and \code{range} return their results as
-%lazily constructed lists. The \code{Stream} class is an alias of
-%\code{List} which should be used to indicate the fact that its values
-%are constructed lazily.
-
-As funções \code{domain} e \code{range} retornam seus resultados como
-listas construídas de forma ``preguiçosa'' (lazy-lists). A classe \code{Stream}
-é um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
-o fato que seus valores foram construídos de modo preguiçoso.
-%--------
+As fun\'{c}\~{o}es \code{domain} e \code{range} retornam seus resultados como
+listas constru\'{i}das de forma ``pregui\'{c}osa'' (lazy-lists). A classe \code{Stream}
+\'{e} um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
+o fato que seus valores foram constru\'{i}dos de modo pregui\'{c}oso.
 
 
 \begin{figure}[thb]
@@ -365,66 +258,35 @@ class OOBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   }
 }
 \end{lstlisting}
-%--------
-\caption{\label{fig:oobintree}Object-oriented implementation of binary
-search trees}
-\caption{\label{fig:oobintree}Implementação orientada a objetos de 
-árvores binárias de busca}
-%--------
+
+\caption{\label{fig:oobintree}Implementa\'{c}\~{a}o orientada a objetos de 
+\'{a}rvores bin\'{a}rias de busca}
+
 \end{figure}
 
-%--------
-%The second implementation of maps is given in
-%Figure~\ref{fig:oobintree}.  Class \code{OOBinTree} implements the
-%type \code{Map} with a module \code{empty} and a class
-%\code{Node}, which define the behavior of empty and non-empty trees,
-%respectively.
 
-A segunda implementação dos mapas é dada na
+A segunda implementa\'{c}\~{a}o dos mapas \'{e} dada na
 Figura~\ref{fig:oobintree}.  A classe \code{OOBinTree} implementa o 
-tipo \code{Map} com um módulo \code{empty} e uma classe \code{Node}
-que define o comportamento de árvores vazias e não-vazias, respectivamente.
-%--------
-
-%--------
-%Note the different nesting structure of \code{AlgBinTree} and
-%\code{OOBinTree}. In the former, all methods form part of the base
-%class \code{Map}. The different behavior of empty and non-empty trees
-%is expressed using a pattern match on the tree itself. In the
-%latter, each subclass of \code{Map} defines its own set of
-%methods, which override the methods in the base class. The pattern
-%matches of the algebraic implementation have been replaced by the
-%dynamic binding that comes with method overriding.
+tipo \code{Map} com um m\'{o}dulo \code{empty} e uma classe \code{Node}
+que define o comportamento de \'{a}rvores vazias e n\~{a}o-vazias, respectivamente.
 
 Observe a estrutura de aninhamento diferente de \code{AlgBinTree} e
-\code{OOBinTree}. Na primeira, todos os métodos são parte da classe base
-\code{Map}. O comportamento distinto para árvores vazias e não vazias 
-é expresso usando um casamento de padrões na própria árvore. Na segunda,
- cada subclasse do \code{Map} define seu próprio conjunto de 
-métodos, que sobrescrevem os métodos da classe base. O casamento de 
-padrões da implementação algébrica foi substituído pela ligação 
-dinâmica que veio com o método sobrescrito.
-%--------
+\code{OOBinTree}. Na primeira, todos os m\'{e}todos s\~{a}o parte da classe base
+\code{Map}. O comportamento distinto para \'{a}rvores vazias e n\~{a}o vazias 
+\'{e} expresso usando um casamento de padr\~{o}es na pr\'{o}pria \'{a}rvore. Na segunda,
+ cada subclasse do \code{Map} define seu pr\'{o}prio conjunto de 
+m\'{e}todos, que sobrescrevem os m\'{e}todos da classe base. O casamento de 
+padr\~{o}es da implementa\'{c}\~{a}o alg\'{e}brica foi substitu\'{i}do pela liga\'{c}\~{a}o 
+din\^{a}mica que veio com o m\'{e}todo sobrescrito.
 
-%--------
-%Which of the two schemes is preferable depends to a large degree on
-%which extensions of the type are anticipated. If the type is later
-%extended with a new alternative, it is best to keep methods in each
-%alternative, the way it was done in \code{OOBinTree}.  On the other
-%hand, if the type is extended with additional methods, then it is
-%preferable to keep only one implementation of methods and to rely on
-%pattern matching, since this way existing subclasses need not be
-%modified.
-
-Qual dos dois esquemas é preferível depende em grande parte de quais
-estensões do tipo são antecipadas. Se o tipo for mais tarde estendido
-com uma nova alternativa, é melhor manter os métodos em cada 
+Qual dos dois esquemas \'{e} prefer\'{i}vel depende em grande parte de quais
+estens\~{o}es do tipo s\~{a}o antecipadas. Se o tipo for mais tarde estendido
+com uma nova alternativa, \'{e} melhor manter os m\'{e}todos em cada 
 alternativa, do modo como foi feito em \code{OOBinTree}. Por outro 
-lado, se o tipo for estendido com métodos adicionais, então é preferível
-manter apenas uma implementação dos métodos e confiar no casamento de
-padrões, pois desta forma subclasses existentes não precisarão ser
+lado, se o tipo for estendido com m\'{e}todos adicionais, ent\~{a}o \'{e} prefer\'{i}vel
+manter apenas uma implementa\'{c}\~{a}o dos m\'{e}todos e confiar no casamento de
+padr\~{o}es, pois desta forma subclasses existentes n\~{a}o precisar\~{a}o ser
 modificadas. 
-%--------
 
 \begin{figure}
 \begin{lstlisting}
@@ -469,71 +331,33 @@ class MutBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   let empty = new Map(null, null)
 }
 \end{lstlisting}
-%--------
-%\caption{\label{fig:impbintree}Side-effecting implementation of binary
-%search trees}
-\caption{\label{fig:impbintree}Implementação com efeitos colaterais de
-árvores binárias de busca}
+\caption{\label{fig:impbintree}Implementa\'{c}\~{a}o com efeitos colaterais de
+\'{a}rvores bin\'{a}rias de busca}
 \end{figure}
-%--------
 
-%--------
-%The two versions of binary trees presented so far are {\em
-%persistent}, in the sense that maps are values that cannot be changed
-%by side effects. By contrast, in the next implementation of binary
-%trees, the implementations of \code{extend} and
-%\code{remove} do have an effect on the state of their receiver
-%object. This corresponds to the way binary trees are usually
-%implemented in imperative languages. The new implementation can lead
-%to some savings in computing time and memory allocation, but care is
-%required not to use the original tree after it has been modified by a
-%side-effecting operation.
+As duas vers\~{o}es apresentadas de \'{a}rvores bin\'{a}rias de fato s\~{a}o 
+\em{persistentes}, no sentido que mapas s\~{a}o valores que n\~{a}o podem ser
+alterados atrav\'{e}s de efeitos colaterais. Em contraste, a pr\'{o}xima 
+implementa\'{c}\~{a}o de \'{a}rvores bin\'{a}rias, as implementa\'{c}\~{o}es de \code{extend} e 
+\code{remove} t\^{e}m um efeito sobre o estado de seus objetos recebedores.
+Isto corresponde ao modo como \'{a}rvores bin\'{a}rias s\~{a}o geralmente implementadas
+em linguagens imperativas. A nova implementa\'{c}\~{a}o pode levar a uma economia 
+de tempo computacional e aloca\'{c}\~{a}o de mem\'{o}ria, mas \'{e} preciso tomar cuidado
+para n\~{a}o usar a \'{a}rvore original ap\'{o}s sua modifica\'{c}\~{a}o por efeito colateral.
 
-As duas versões apresentadas de árvores binárias de fato são 
-\em{persistentes}, no sentido que mapas são valores que não podem ser
-alterados através de efeitos colaterais. Em contraste, a próxima 
-implementação de árvores binárias, as implementações de \code{extend} e 
-\code{remove} têm um efeito sobre o estado de seus objetos recebedores.
-Isto corresponde ao modo como árvores binárias são geralmente implementadas
-em linguagens imperativas. A nova implementação pode levar a uma economia 
-de tempo computacional e alocação de memória, mas é preciso tomar cuidado
-para não usar a árvore original após sua modificação por efeito colateral.
-%--------
-
-%--------
-%In this implementation, \code{value}, \code{l} and \code{r} are
-%variables that can be affected by method calls.  The
-%class \code{MutBinTree[kt, vt].Map} takes two instance parameters
-%which define the \code{key} value and the initial value of the
-%\code{value} variable. Empty trees are represented by a
-%value \code{empty}, which has \code{null} (signifying undefined) in
-%both its key and value fields. Note that this value needs to be
-%defined lazily using \code{let} since its definition involves the
-%creation of a \code{Map} object,
-%which accesses \code{empty} recursively as part of its initialization.
-%All methods test first whether the current tree is empty using the
-%reference equality operator \code{eq} (\sref{sec:class-object}).
-
-Nesta implementação, \code{value}, \code{l} e \code{r} são variáveis
-que podem ser afetadas por chamadas de métodos. A classe
-\code{MutBinTree[kt, vt].Map} leva dois parâmetros de instância que 
-definem o valor de \code{key} e o valor inicial da variável \code{value}.
-Árvores vazias são representadas por um valor \code{empty}, que tem \code{null} 
+Nesta implementa\'{c}\~{a}o, \code{value}, \code{l} e \code{r} s\~{a}o vari\'{a}veis
+que podem ser afetadas por chamadas de m\'{e}todos. A classe
+\code{MutBinTree[kt, vt].Map} leva dois par\^{a}metros de inst\^{a}ncia que 
+definem o valor de \code{key} e o valor inicial da vari\'{a}vel \code{value}.
+\'{A}rvores vazias s\~{a}o representadas por um valor \code{empty}, que tem \code{null} 
 (significando indefinido) em seus campos chave e valor. Observe que este valor
-precisa ser definido de modo lazy (preguiçoso) usando \code{let}, pois sua definição
-envolve a criação de um objeto \code{Map}, que acessa \code{empty} recursivamente como
-parte da sua inicialização. Todos os métodos primeiro testam se a árvore corrente é 
-vazia usando a referência ao operador de igualdade \code{eq} (\sref{sec:class-object}).
-%--------
+precisa ser definido de modo lazy (pregui\'{c}oso) usando \code{let}, pois sua defini\'{c}\~{a}o
+envolve a cria\'{c}\~{a}o de um objeto \code{Map}, que acessa \code{empty} recursivamente como
+parte da sua inicializa\'{c}\~{a}o. Todos os m\'{e}todos primeiro testam se a \'{a}rvore corrente \'{e} 
+vazia usando a refer\^{e}ncia ao operador de igualdade \code{eq} (\sref{sec:class-object}).
 
-%--------
-%As a program using the \code{MapStruct} abstraction, consider a function
-%which creates a map from strings to integers and then applies it to a
-%key string:
-
-Como um programa usando a abstração \code{MapStruct}, considere uma função
-que cria um mapa de cadeias de caracteres a inteiros e então o aplica à cadeia chave:
-%--------
+Como um programa usando a abstra\'{c}\~{a}o \code{MapStruct}, considere uma fun\'{c}\~{a}o
+que cria um mapa de cadeias de caracteres a inteiros e ent\~{a}o o aplica à cadeia chave:
 
 \begin{lstlisting}
 def mapTest(mapImpl: => MapStruct[String, int]): int = {
@@ -542,15 +366,9 @@ def mapTest(mapImpl: => MapStruct[String, int]): int = {
 }
 \end{lstlisting}
 
-%--------
-%The function is parameterized with the particular implementation of
-%\code{MapStruct}. It can be applied to any one of the three implementations
-%described above. E.g.:
-
-A função é parametrizada com a implementação particular de \code{MapStruct}. 
-Pode ser aplicada a qualquer uma das três implementações descritas acima.
+A fun\'{c}\~{a}o \'{e} parametrizada com a implementa\'{c}\~{a}o particular de \code{MapStruct}. 
+Pode ser aplicada a qualquer uma das tr\^{e}s implementa\'{c}\~{o}es descritas acima.
 Por exemplo:
-%--------
 \begin{lstlisting}
 mapTest(AlgBinTree[String, int])
 mapTest(OOBinTree[String, int])
@@ -558,15 +376,9 @@ mapTest(MutBinTree[String, int])
 \end{lstlisting}
 }
  
-%--------
-%\paragraph{Mixin Composition}
-%We can now define a class of \code{Rational} numbers that
-%support comparison operators.
-
-\paragraph{Composição Mixin}
-Agora podemos definir uma classe de números tipo \code{Rational} que 
-suportam operadores de comparação.
-%--------
+\paragraph{Composi\'{c}\~{a}o Mixin}
+Agora podemos definir uma classe de n\'{u}meros tipo \code{Rational} que 
+suportam operadores de compara\'{c}\~{a}o.
 \begin{lstlisting}
 final class OrderedRational(n: int, d: int)
  extends Rational(n, d) with Ord {
@@ -577,151 +389,68 @@ final class OrderedRational(n: int, d: int)
 }
 \end{lstlisting}
 
-%---------
-%Class \code{OrderedRational} redefines method \code{==}, which is
-%defined as reference equality in class \code{Object}. It also
-%implements the abstract method \code{<} from class \code{Ord}.  In
-%addition, it inherits all members of class \code{Rational} and all
-%non-abstract members of class \code{Ord}. The implementations of
-%\code{==} and \code{<} replace the definition of \code{==} in class
-%\code{Object} and the abstract declaration of \code{<} in class
-%\code{Ord}. The other inherited comparison methods then refer to this
-%implementation in their body.
+A classe \code{OrderedRational} redefine o m\'{e}todo \code{==}, que \'{e}
+definido como refer\^{e}ncia a igualdade na classe \code{Object}. Tamb\'{e}m
+implementa o m\'{e}todo abstrato \code{<} da classe \code{Ord}. Al\'{e}m disso, 
+herda todos os membros da classe \code{Rational} e todos os membros n\~{a}o
+abstratos da classe \code{Ord}. As implementa\'{c}\~{o}es de \code{==} e \code{<} 
+substituem as defini\'{c}\~{o}es de \code{==} na classe \code{Object} e a 
+declara\'{c}\~{a}o abstrata de \code{<} na classe \code{Ord}. Os outros m\'{e}todos de 
+compara\'{c}\~{a}o herdados referem-se, ent\~{a}o, a esta implementa\'{c}\~{a}o nos seus corpos.
 
-A classe \code{OrderedRational} redefine o método \code{==}, que é
-definido como referência a igualdade na classe \code{Object}. Também
-implementa o método abstrato \code{<} da classe \code{Ord}. Além disso, 
-herda todos os membros da classe \code{Rational} e todos os membros não
-abstratos da classe \code{Ord}. As implementações de \code{==} e \code{<} 
-substituem as definições de \code{==} na classe \code{Object} e a 
-declaração abstrata de \code{<} na classe \code{Ord}. Os outros métodos de 
-comparação herdados referem-se, então, a esta implementação nos seus corpos.
-%----------
-
-%----------
-%The clause ``\code{Rational(d, d) with Ord}'' is an instance of {\em
-%mixin composition}. It describes a template for an object that is
-%compatible with both \code{Rational} and \code{Ord} and that contains
-%all members of either class. \code{Rational} is called the {\em
-%superclass} of \code{OrderedRational} while \code{Ord} is called a
-%{\em mixin class}. The type of this template is the {\em compound
-%type} ``\code{Rational with Ord}''.
-
-A cláusula ``\code{Rational(d, d) with Ord}'' é uma instância da {\em
-composição mixin}. Descreve um template para um objeto que é compatível
-com ambos \code{Rational} e \code{Ord} e que contém todos os membros de 
-cada classe. \code{Rational} é chamada de {\em
-superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado de
-{\em classe mixin}. O tipo para este template é o {\em tipo composto}
+A cl\'{a}usula ``\code{Rational(d, d) with Ord}'' \'{e} uma inst\^{a}ncia da {\em
+composi\'{c}\~{a}o mixin}. Descreve um template para um objeto que \'{e} compat\'{i}vel
+com ambos \code{Rational} e \code{Ord} e que cont\'{e}m todos os membros de 
+cada classe. \code{Rational} \'{e} chamada de {\em
+superclasse} de \code{OrderedRational} enquanto \code{Ord} \'{e} chamado de
+{\em classe mixin}. O tipo para este template \'{e} o {\em tipo composto}
 ``\code{Rational with Ord}''.
-%----------
 
-%----------
-%On the surface, mixin composition looks much like multiple
-%inheritance. The difference between the two becomes apparent if we
-%look at superclasses of inherited classes. With multiple inheritance,
-%both \code{Rational} and \code{Ord} would contribute a superclass
-%\code{Object} to the template. We therefore have to answer some
-%tricky questions, such as whether members of \code{Object} are present
-%once or twice and whether the initializer of \code{Object} is called
-%once or twice. Mixin composition avoids these complications.  In the
-%mixin composition \code{Rational with Ord}, class
-%\code{Rational} is treated as actual superclass of class \code{Ord}.
-%A mixin composition \code{C with M} is well-formed as long as the
-%first operand \code{C} conforms to the declared superclass of the
-%second operand \code{M}. This holds in our example, because
-%\code{Rational} conforms to \code{Object}. In a sense, mixin composition
-%amounts to overriding the superclass of a class.
-
-Na superfície, composição mixin se parece muito com herança múltipla.
-A diferença entre os dois se torna aparente se olharmos para as superclasses
-das classes herdadas. Com herança múltipla, ambos \code{Rational} e \code{Ord}
-trariam a superclasse \code{Object} para o template. Por essa razão 
-teríamos de responder algumas questões delicadas, tais como se membros de \code{Object} 
-estão presentes uma ou duas vezes e se o inicializador de \code{Object} é chamado
-uma ou duas vezes. Composição mixin evita tais complicações. Na composição mixin
-\code{Rational with Ord}, a classe \code{Rational} é tratada como superclasse efetiva
+Na superf\'{i}cie, composi\'{c}\~{a}o mixin se parece muito com heran\'{c}a m\'{u}ltipla.
+A diferen\'{c}a entre os dois se torna aparente se olharmos para as superclasses
+das classes herdadas. Com heran\'{c}a m\'{u}ltipla, ambos \code{Rational} e \code{Ord}
+trariam a superclasse \code{Object} para o template. Por essa raz\~{a}o 
+ter\'{i}amos de responder algumas quest\~{o}es delicadas, tais como se membros de \code{Object} 
+est\~{a}o presentes uma ou duas vezes e se o inicializador de \code{Object} \'{e} chamado
+uma ou duas vezes. Composi\'{c}\~{a}o mixin evita tais complica\'{c}\~{o}es. Na composi\'{c}\~{a}o mixin
+\code{Rational with Ord}, a classe \code{Rational} \'{e} tratada como superclasse efetiva
 da classe \code{Ord}.
-Uma composição mixin \code{C with M} é bem formada contanto que o primeiro operando
+Uma composi\'{c}\~{a}o mixin \code{C with M} \'{e} bem formada contanto que o primeiro operando
 \code{C} esteja de acordo com a superclasse declarada do segundo operando \code{M}. 
-Isto vale no nosso exemplo, porque \code{Rational} está de acordo com \code{Object}. 
-De certo modo, composição mixin resulta em sobrescrever a superclasse de uma classe.
-%----------
-
-%----------
-%\paragraph{Final Classes}
-%Note that class \code{OrderedRational} was defined
-%\code{final}. This means that no classes extending \code{OrderedRational}
-%may be defined in other parts of the program.
+Isto vale no nosso exemplo, porque \code{Rational} est\'{a} de acordo com \code{Object}. 
+De certo modo, composi\'{c}\~{a}o mixin resulta em sobrescrever a superclasse de uma classe.
 
 \paragraph{Classes Finais}
 Observe que a classe \code{OrderedRational} foi definida \code{final}. Isto
 significa que nenhuma classe estendendo \code{OrderedRational} pode ser
 definida em outras partes do programa.
-%----------
 
-%%Within final classes the
-%%type \code{this} is an alias of the defined class itself. Therefore,
-%%we could define our \code{<} method with an argument of type
-%%\code{OrderedRational} as a well-formed implementation of the abstract class
-%%\code{less(that: this)} in class \code{Ord}.
+\chapter{\label{sec:simple-examples}Casamento de Padr\~{o}es}
 
-
-%----------
-%\chapter{\label{sec:simple-examples}Pattern Matching}
-
-%\todo{Complete}
-
-%Consider binary trees whose leafs contain integer arguments. This can
-%be described by a class for trees, with subclasses for leafs and
-%branch nodes:
-
-\chapter{\label{sec:simple-examples}Casamento de Padrões}
-
-Considere árvores binárias cujas folhas contém argumentos inteiros. Isto pode
-ser descrito por uma classe para árvores, com subclasses para folhas e 
-nós internos:
-%----------
+Considere \'{a}rvores bin\'{a}rias cujas folhas cont\'{e}m argumentos inteiros. Isto pode
+ser descrito por uma classe para \'{a}rvores, com subclasses para folhas e 
+n\'{o}s internos:
 \begin{lstlisting}
 abstract class Tree;
 case class Branch(left: Tree, right: Tree) extends Tree;
 case class Leaf(x: int) extends Tree;
 \end{lstlisting}
 
-
-%----------
-%Note that the class \code{Tree} is not followed by an extends
-%clause or a body. This defines \code{Tree} to be an empty
-%subclass of \code{Object}, as if we had written
-%\begin{lstlisting}
-%class Tree extends Object {}
-%\end{lstlisting}
-%Note also that the two subclasses of \code{Tree} have a \code{case}
-%modifier.  That modifier has two effects. First, it lets us construct
-%values of a case class by simply calling the constructor, without
-%needing a preceding \code{new}. Example:
-%\begin{lstlisting}
-%val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
-%\end{lstlisting}
-%Second, it lets us use constructors for these classes in patterns, as
-%is illustrated in the following example.
-
-Observe que a classe \code{Tree} não é seguida por uma cláusula \code{extends}
+Observe que a classe \code{Tree} n\~{a}o \'{e} seguida por uma cl\'{a}usula \code{extends}
 ou por um corpo. Isto define \code{Tree} para ser uma subclasse vazia de
 \code{Object}, como se tivessemos escrito
 \begin{lstlisting}
 class Tree extends Object {}
 \end{lstlisting}
-Observe também que as duas subclasses de \code{Tree} têm um modificador
+Observe tamb\'{e}m que as duas subclasses de \code{Tree} t\^{e}m um modificador
 \code{case}. Aquele modificador tem dois efeitos. Primeiro, nos permite
 construir valores de uma classe case simplesmente chamando o construtor, sem
 a necessidade de que um \code{new} o preceda. Examplo:
 \begin{lstlisting}
 val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
 \end{lstlisting}
-Segundo, nos permite usar construtores para estas classes dentro de padrões,
+Segundo, nos permite usar construtores para estas classes dentro de padr\~{o}es,
 conforme ilustrado no seguinte exemplo.
-%-----------
 \begin{lstlisting}
 def sumLeaves(t: Tree): int = t match {
   case Branch(l, r) => sumLeaves(l) + sumLeaves(r)
@@ -729,57 +458,28 @@ def sumLeaves(t: Tree): int = t match {
 }
 \end{lstlisting}
 
-%-----------
-%The function \code{sumLeaves} sums up all the integer values in the
-%leaves of a given tree \code{t}. It is is implemented by calling the
-%\code{match} method of \code{t} with a {\em choice expression} as
-%argument (\code{match} is a predefined method in class \code{Object}).
-%The choice expression consists of two cases which botrelate a pattern 
-%with an expression. The pattern of the first case,
-%\code{Branch(l, r)} matches all instances of class \code{Branch}
-%and binds the {\em pattern variables} \code{l} and \code{r} to the
-%constructor arguments, i.e.\ the left and right subtrees of the
-%branch.  Pattern variables always start with a lower case letter; to
-%avoid ambiguities, constructors in patterns should start with an upper
-%case letter.
+A fun\'{c}\~{a}o \code{sumLeaves} soma todos os valores inteiros das folhas de
+uma dada \'{a}rvore \code{t}. É implementada chamando o m\'{e}todo \code{match}
+de \code{t} com uma {\em dada express\~{a}o} como argumento. (\code{match}
+\'{e} um m\'{e}todo pr\'{e}-definido da classe \code{Object}). A express\~{a}o passada 
+como argumento consiste de dois cases que casam um padr\~{a}o com a express\~{a}o.
+O padr\~{a}o do primeiro case, \code{Branch(l, r)} casa com todas as inst\^{a}ncias
+da classe \code{Branch} e liga as {\em vari\'{a}veis padr\~{a}o} \code{l} e \code{r} 
+ao argumentos do construtor, ou seja, às sub-\'{a}rvores esquerda e direita do n\'{o}.
+Vari\'{a}veis padr\~{a}o sempre iniciam com letra min\'{u}scula e, para evitar ambiguidades,
+construtores nos padr\~{o}es deveriam iniciar com uma letra mai\'{u}scula.
 
-A função \code{sumLeaves} soma todos os valores inteiros das folhas de
-uma dada árvore \code{t}. É implementada chamando o método \code{match}
-de \code{t} com uma {\em dada expressão} como argumento. (\code{match}
-é um método pré-definido da classe \code{Object}). A expressão passada 
-como argumento consiste de dois cases que casam um padrão com a expressão.
-O padrão do primeiro case, \code{Branch(l, r)} casa com todas as instâncias
-da classe \code{Branch} e liga as {\em variáveis padrão} \code{l} e \code{r} 
-ao argumentos do construtor, ou seja, às sub-árvores esquerda e direita do nó.
-Variáveis padrão sempre iniciam com letra minúscula e, para evitar ambiguidades,
-construtores nos padrões deveriam iniciar com uma letra maiúscula.
-%-----------
-
-%-----------
-%The effect of the choice expression is to select the first alternative
-%whose pattern matches the given select value, and to evaluate the body
-%of this alternative in a context where pattern variables are bound to
-%corresponding parts of the selector. For instance, the application
-%\code{sumLeaves(tree1)} would select the first alternative with the
-%\code{Branch(l,r)} pattern, and would evaluate the expression
-%\code{sumLeaves(l) + sumLeaves(r)} with bindings
-%\begin{lstlisting}
-%l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
-%\end{lstlisting}
-%As another example, consider the following class
-
-O efeito da expressão escolhida é selecionar a primeira alternativa
-cujo padrão casa com um dado valor selecionado, e avaliar o corpo
-desta alternativa no contexto onde variáveis padrão são ligadas às
-partes correspondentes do seletor. Por exemplo, a aplicação
+O efeito da express\~{a}o escolhida \'{e} selecionar a primeira alternativa
+cujo padr\~{a}o casa com um dado valor selecionado, e avaliar o corpo
+desta alternativa no contexto onde vari\'{a}veis padr\~{a}o s\~{a}o ligadas às
+partes correspondentes do seletor. Por exemplo, a aplica\'{c}\~{a}o
 \code{sumLeaves(tree1)} deveria selecionar a primeira alternativa
-com o padrão \code{Branch(l,r)}, e deveria avaliar a expressão
-\code{sumLeaves(l) + sumLeaves(r)} com ligações
+com o padr\~{a}o \code{Branch(l,r)}, e deveria avaliar a express\~{a}o
+\code{sumLeaves(l) + sumLeaves(r)} com liga\'{c}\~{o}es
 \begin{lstlisting}
 l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
 \end{lstlisting}
 Como outro exemplo, considere a seguinte classe
-%-----------
 
 \begin{lstlisting}
 abstract final class Option[+a];
@@ -789,7 +489,6 @@ case class Some[a](item: a) extends Option[a];
 ...
 
 %\todo{Several simple and intermediate examples needed}.
-
 \begin{lstlisting}
 def find[a,b](it: Iterator[(a, b)], x: a): Option[b] = {
   var result: Option[b] = None;

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -40,7 +40,7 @@
 %a concise, elegant, and type-safe way.  Scala introduces several
 %innovative language constructs. For instance:
 Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
-Foi criada para expressar padr¿es de programação comuns de modo conciso, elegante e fortemente tipada. 
+Foi criada para expressar padrões de programação comuns de modo conciso, elegante e fortemente tipada. 
 Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
 \begin{itemize}
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -82,15 +82,15 @@ de examplos.
 %meant to be complemented by the Scala Language Reference Manual which
 %specifies Scala in a more detailed and precise way.
 
-Cap¿tulos~\ref{chap:example-one} e \ref{chap:example-auction}
+Capítulos~\ref{chap:example-one} e \ref{chap:example-auction}
 salientam alguns dos aspectos que tornam Scala interessante. Os
-cap¿tulos seguintes introduzem as constru¿¿es da linguagem Scala de um
-modo mais completo, come¿ando com express¿es e fun¿¿es simples, e 
-desenvolvendo at¿ objetos e classes, listas e streams, estado 
-mut¿vel, casamento de padr¿es at¿ exemplos mais completos que mostram
-interessantes t¿cnicas de programa¿¿o. A presente exposi¿¿o informal
-pretende ser complementada por um Manual de Refer¿ncia da Linguagem Scala, que
-especificarÃ¡ Scala de modo mais detalhado e preciso. 
+capítulos seguintes introduzem as construções da linguagem Scala de um
+modo mais completo, começando com expressões e funções simples, e 
+desenvolvendo até objetos e classes, listas e streams, estado 
+mutável, casamento de padrões até exemplos mais completos que mostram
+interessantes técnicas de programação. A presente exposição informal
+pretende ser complementada por um Manual de Referência da Linguagem Scala, que
+especificarão Scala de modo mais detalhado e preciso. 
 
 
 \paragraph{Acknowledgment}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -117,13 +117,19 @@ apropriado.
 \end{document}
 
 
+%\chapter{Implementing Abstract Types: Search Trees}
 
-\chapter{Implementing Abstract Types: Search Trees}
+%This chapter presents unbalanced binary search trees, implemented in
+%three different styles: algebraic, object-oriented, and imperative.
+%In each case, a search tree package is seen as an implementation
+%of a class {\em MapStruct}.
+\chapter{Implementando Tipos Abstratos: Árvores de Busca}
+Este capítulo apresenta árvores binárias de busca não balanceadas, implementadas em
+três diferentes estilos: algébrico, orientado a objetos, e imperativo.
+Em cada caso, um pacote de árvore de busca é visto como uma implementação
+de uma classe {\em MapStruct}.
 
-This chapter presents unbalanced binary search trees, implemented in
-three different styles: algebraic, object-oriented, and imperative.
-In each case, a search tree package is seen as an implementation
-of a class {\em MapStruct}.
+
 \begin{lstlisting}
   trait MapStruct[kt, vt] {
     trait Map with Function1[kt, vt] {

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -12,8 +12,8 @@
 \renewcommand{\todo}[1]{}
 
 \renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
-\renewcommand{\mychaptername}{Capítulo}
-\renewcommand*{\contentsname}{Índice}
+\renewcommand{\mychaptername}{Cap\'{i}tulo}
+\renewcommand*{\contentsname}{\'{I}ndice}
 \renewcommand\lstlistingname{Listagem}
 \renewcommand\lstlistlistingname{Listagens}
 \renewcommand{\bibname}{Bibliografia}
@@ -30,7 +30,7 @@
 \ifpdf
     \pdfinfo {
         /Author   (Martin Odersky)
-        /Title    (Scala através de exemplos)
+        /Title    (Scala atrav\'{e}s de exemplos)
         /Keywords (Scala)
         /Subject  ()
         /Creator  (TeX)
@@ -38,7 +38,7 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através\\  de Exemplos \\
+\renewcommand{\doctitle}{Scala Atrav\'{e}s\\  de Exemplos \\
 \Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
@@ -51,97 +51,48 @@
 \mainmatter
 \sloppy
 
-\chapter{\label{chap:intro}Introdução}
-%--------
-%Scala smoothly integrates object-oriented and functional
-%programming. It is designed to express common programming patterns in
-%a concise, elegant, and type-safe way.  Scala introduces several
-%innovative language constructs. For instance:
+\chapter{\label{chap:intro}Introdu\c{c}\~{a}o}
 
-Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
-Foi criada para expressar padrões de programação comuns de forma concisa, elegante e fortemente tipada. 
-Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
-%--------
+Scala facilita a integra\c{c}\~{a}o entre a  programa\c{c}\~{a}o orientada a objetos e a programa\c{c}\~{a}o funcional.
+Foi criada para expressar padr\~{o}es de programa\c{c}\~{a}o comuns de forma concisa, elegante e fortemente tipada. 
+Scala introduz diversas constru\c{c}\~{o}es de linguagem inovadoras. Por exemplo:
 
 \begin{itemize}
-%--------
-%\item 
-%Abstract types and mixin composition unify concepts from object and module systems.
-\item
-Tipos abstratos e composições mixin unificam conceitos de objetos e módulos de sistema.
-%--------
 
-%--------
-%\item 
-%Pattern matching over class hierarchies unifies functional and
-%  object-oriented data access. It greatly simplifies the processing of XML trees.
 \item
-Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
-objetos, simplificando bastante o processamento de árvores XML.
-%--------
-
-%--------
-%\item
-%A flexible syntax and type system enables the construction of advanced
-%  libraries and new domain specific languages.
+Tipos abstratos e composi\c{c}\~{o}es mixin unificam conceitos de objetos e m\'{o}dulos de sistema.
 \item
-Sintaxe flexível e sistema de tipos que habilitam a construção de avançadas 
-bibliotecas e um novas linguagens específicas a um domínio.
-%--------
+Casamento de padr\~{o}es sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
+objetos, simplificando bastante o processamento de \'{a}rvores XML.
+\item
+Sintaxe flex\'{i}vel e sistema de tipos que habilitam a constru\c{c}\~{a}o de avan\c{c}adas 
+bibliotecas e um novas linguagens espec\'{i}ficas a um dom\'{i}nio.
 \end{itemize}
 
-%--------
-%At the same time, Scala is compatible with Java.  Java libraries and
-%frameworks can be used without glue code or additional declarations.
-%This document introduces Scala in an informal way, through a sequence
-%of examples.
-
-Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
-podem ser usados sem código extra ou declarações adicionais.
-Este documento introduz Scala de um modo informal, através de uma sequência
+Ao mesmo tempo, Scala \'{e} compat\'{i}vel com Java. Bibliotecas Java e frameworks
+podem ser usados sem c\'{o}digo extra ou declara\c{c}\~{o}es adicionais.
+Este documento introduz Scala de um modo informal, atrav\'{e}s de uma sequ\^{e}ncia
 de exemplos.
-%--------
 
-%--------
-%Chapters~\ref{chap:example-one} and \ref{chap:example-auction}
-%highlight some of the features that make Scala interesting. The
-%following chapters introduce the language constructs of Scala in a
-%more thorough way, starting with simple expressions and functions, and
-%working up through objects and classes, lists and streams, mutable
-%state, pattern matching to more complete examples that show
-%interesting programming techniques. The present informal exposition is
-%meant to be complemented by the Scala Language Reference Manual which
-%specifies Scala in a more detailed and precise way.
-
-Capítulos~\ref{chap:example-one} e \ref{chap:example-auction}
+Os cap\'{i}tulos~\ref{chap:example-one} e \ref{chap:example-auction}
 salientam alguns dos aspectos que tornam Scala interessante. Os
-capítulos seguintes introduzem as construções da linguagem Scala de um
-modo mais completo, começando com expressões e funções simples, e 
-desenvolvendo até objetos e classes, listas e streams, estado 
-mutável, casamento de padrões até exemplos mais completos que mostram
-interessantes técnicas de programação. A presente exposição informal
-pretende ser complementada por um Manual de Referência da Linguagem Scala, que
-especificarão Scala de modo mais detalhado e preciso. 
-%--------
+cap\'{i}tulos seguintes introduzem as constru\c{c}\~{o}es da linguagem Scala de um
+modo mais completo, come\c{c}ando com express\~{o}es e fun\c{c}\~{o}es simples, e 
+desenvolvendo at\'{e} objetos e classes, listas e streams, estado 
+mut\'{a}vel, casamento de padr\~{o}es at\'{e} exemplos mais completos que mostram
+interessantes t\'{e}cnicas de programa\c{c}\~{a}o. A presente exposi\c{c}\~{a}o informal
+pretende ser complementada por um Manual de Refer\^{e}ncia da Linguagem Scala, que
+especificar\~{a}o Scala de modo mais detalhado e preciso. 
 
 \paragraph{Reconhecimento}
-%--------
-%We owe a great debt to Abelson's and Sussman's wonderful book
-%``Structure and Interpretation of Computer
-%Programs''\cite{abelson-sussman:structure}. Many of their examples and
-%exercises are also present here. Of course, the working language has
-%in each case been changed from Scheme to Scala. Furthermore, the
-%examples make use of Scala's object-oriented constructs where
-%appropriate.
 
-Temos um grande débito ao maravilhoso livro de Abelson e Sussman
+Temos um grande d\'{e}bito ao maravilhoso livro de Abelson e Sussman
 ``Structure and Interpretation of Computer
-Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exercícios 
-deles também estão presentes aqui. Naturalmente a linguagem utilizada em
-cada caso foi mudada do Scheme para o Scala. Além disso, os exemplos
-fazem uso de construções da orientação a objetos do Scala onde isto foi
+Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exerc\'{i}cios 
+deles tamb\'{e}m est\~{a}o presentes aqui. Naturalmente a linguagem utilizada em
+cada caso foi mudada do Scheme para o Scala. Al\'{e}m disso, os exemplos
+fazem uso de constru\c{c}\~{o}es da orienta\c{c}\~{a}o a objetos do Scala onde isto foi
 considerado apropriado. 
-%--------
 
 \input{ExamplesPart}
 \bibliographystyle{alpha}
@@ -149,17 +100,11 @@ considerado apropriado.
 
 \end{document}
 
-%--------
-%\chapter{Implementing Abstract Types: Search Trees}
-%This chapter presents unbalanced binary search trees, implemented in
-%three different styles: algebraic, object-oriented, and imperative.
-%In each case, a search tree package is seen as an implementation
-%of a class {\em MapStruct}.
 
-\chapter{Implementando Tipos Abstratos: Árvores de Busca}
-Este capítulo apresenta árvores binárias de busca não balanceadas implementadas em
-três diferentes estilos: algébrico, orientado a objetos, e imperativo.
-Em cada caso, um pacote de árvore de busca é visto como uma implementação
+\chapter{Implementando Tipos Abstratos: \'{A}rvores de Busca}
+Este cap\'{i}tulo apresenta \'{a}rvores bin\'{a}rias de busca n\~{a}o balanceadas implementadas em
+tr\^{e}s diferentes estilos: alg\'{e}brico, orientado a objetos, e imperativo.
+Em cada caso, um pacote de \'{a}rvore de busca \'{e} visto como uma implementa\c{c}\~{a}o
 de uma classe {\em MapStruct}.
 %--------
 
@@ -176,39 +121,22 @@ de uma classe {\em MapStruct}.
   }
 \end{lstlisting}
 
-%--------
-%The \code{MapStruct} class is parameterized with a type of keys
-%\code{kt} and a type of values \code{vt}. It
-%specifies an abstract type \code{Map} and an abstract value
-%\code{empty}, which represents empty maps.  Every implementation
-%\code{Map} needs to conform to that abstract type, which
-%extends the function type \code{kt => vt}
-%with four new
-%methods. The method \code{domain} yields a stream that enumerates the
-%map's domain, i.e. the set of keys that are mapped to non-null values.
-%The method \code{range} yields a stream that enumerates the function's
-%range, i.e.\ the values obtained by applying the function to arguments
-%in its domain.  The method
-%\code{extend} extends the map with a given key/value binding, whereas
-%\code{remove} removes a given key from the map's domain. Both
-%methods yield a new map value as result, which has the same
-%representation as the receiver object.
 
-A classe \code{MapStruct} é parametrizada com um tipo de chaves
-\code{kt} e um tipo de valores \code{vt}. Também especifica um tipo
+A classe \code{MapStruct} \'{e} parametrizada com um tipo de chaves
+\code{kt} e um tipo de valores \code{vt}. Tamb\'{e}m especifica um tipo
 abstrato \code{Map} e um valor abstrato \code{empty} que serve para
 representar mapas vazios. 
-Toda implementação de \code{Map} precisa atender à interface definida
-por este tipo abstrato, que por sua vez, estende a função do tipo
- \code{kt => vt} com quatro novos métodos. O método \code{domain}
-retorna um stream que enumera o domínio do mapa, ou seja, o conjunto
-de chaves que são mapeadas com valores não nulos. O método 
-\code{range} retorna um stream que enumera a imagem da função, ou seja,
-os valores obtidos pela aplicação dos argumentos da função no seu
-domínio. O método \code{extend} retorna o mapa acrescido de um novo par 
-chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
-Ambos os métodos retornam um novo mapa de valores como resultado, o qual
-tem a mesma representação do objeto recebedor.
+Toda implementa\c{c}\~{a}o de \code{Map} precisa atender à interface definida
+por este tipo abstrato, que por sua vez, estende a fun\c{c}\~{a}o do tipo
+ \code{kt => vt} com quatro novos m\'{e}todos. O m\'{e}todo \code{domain}
+retorna um stream que enumera o dom\'{i}nio do mapa, ou seja, o conjunto
+de chaves que s\~{a}o mapeadas com valores n\~{a}o nulos. O m\'{e}todo 
+\code{range} retorna um stream que enumera a imagem da fun\c{c}\~{a}o, ou seja,
+os valores obtidos pela aplica\c{c}\~{a}o dos argumentos da fun\c{c}\~{a}o no seu
+dom\'{i}nio. O m\'{e}todo \code{extend} retorna o mapa acrescido de um novo par 
+chave/valor, onde \code{remove} remove uma dada chave do mapa do dom\'{i}nio.
+Ambos os m\'{e}todos retornam um novo mapa de valores como resultado, o qual
+tem a mesma representa\c{c}\~{a}o do objeto recebedor.
 %--------
 
 \begin{figure}[t]
@@ -260,69 +188,34 @@ class AlgBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   def empty: Map = Empty
 }
 \end{lstlisting}
-%--------
-%\caption{\label{fig:algbintree}Algebraic implementation of binary
-%search trees}
 
-\caption{\label{fig:algbintree}Implementação algébrica de árvores 
-binárias de busca}
-%--------
+\caption{\label{fig:algbintree}Implementa\c{c}\~{a}o alg\'{e}brica de \'{a}rvores 
+bin\'{a}rias de busca}
 \end{figure}
 
 
-%--------
-%We now present three implementations of \code{Map}, which are all
-%based on binary search trees. The \code{apply} method of a map is
-%implemented in each case by the usual search function over binary
-%trees, which compares a given key with the key stored in the topmost
-%tree node, and depending on the result of the comparison, searches the
-%left or the right hand sub-tree. The type of keys must implement the
-%\code{Ord} class, which contains comparison methods
-%(see Chapter~\ref{chap:classes} for a definition of class \code{Ord}).
-
-Nós agora apresentaremos três implementações de \code{Map}, todas elas
-baseadas em árvores binárias de busca. O método \code{apply} de um mapa é
-implementado em cada caso pela função de busca usual sobre árvores binárias, 
-que compara uma dada chave com a chave guardada no mais alto nó da árvore, 
-e dependendo do resultado da comparação, segue a busca por sua sub-árvore 
+N\'{o}s agora apresentaremos tr\^{e}s implementa\c{c}\~{o}es de \code{Map}, todas elas
+baseadas em \'{a}rvores bin\'{a}rias de busca. O m\'{e}todo \code{apply} de um mapa \'{e}
+implementado em cada caso pela fun\c{c}\~{a}o de busca usual sobre \'{a}rvores bin\'{a}rias, 
+que compara uma dada chave com a chave guardada no mais alto n\'{o} da \'{a}rvore, 
+e dependendo do resultado da compara\c{c}\~{a}o, segue a busca por sua sub-\'{a}rvore 
 esquerda ou direita. O tipo das chaves deve implementar a classe \code{Ord},
-que contém métodos de comparação (ver Capítulo~\ref{chap:classes} para uma
-definição da classe \code{Ord}).
-%--------
+que cont\'{e}m m\'{e}todos de compara\c{c}\~{a}o (ver Cap\'{i}tulo~\ref{chap:classes} para uma
+defini\c{c}\~{a}o da classe \code{Ord}).
 
-%--------
-%The first implementation, \code{AlgBinTree}, is given in
-%Figure~\ref{fig:algbintree}. It represents a map with a
-%data type \code{Map} with two cases, \code{Empty} and \code{Node}.
-
-A primeira implementação, \code{AlgBinTree}, é dada na 
+A primeira implementa\c{c}\~{a}o, \code{AlgBinTree}, \'{e} dada na 
 Figura~\ref{fig:algbintree}. Representa um mapa com um 
 tipo de dados \code{Map} com dois casos, \code{Empty} e \code{Node}.
-%--------
 
-%--------
-%Every method of \code{AlgBinTree[kt, vt].Map} performs a pattern
-%match on the value of
-%\code{this} using the \code{match} method which is defined as postfix
-%function application in class \code{Object} (\sref{sec:class-object}).
-
-Cada método do \code{AlgBinTree[kt, vt].Map} executa um casamento
-de padrões sobre o valor do \code{this} usando o método \code{match}
-que é definido como uma aplicação pós-fixa da função na classe \code{Object} 
+Cada m\'{e}todo do \code{AlgBinTree[kt, vt].Map} executa um casamento
+de padr\~{o}es sobre o valor do \code{this} usando o m\'{e}todo \code{match}
+que \'{e} definido como uma aplica\c{c}\~{a}o p\'{o}s-fixa da fun\c{c}\~{a}o na classe \code{Object} 
 (\sref{sec:class-object}).
-%--------
 
-%--------
-%The functions \code{domain} and \code{range} return their results as
-%lazily constructed lists. The \code{Stream} class is an alias of
-%\code{List} which should be used to indicate the fact that its values
-%are constructed lazily.
-
-As funções \code{domain} e \code{range} retornam seus resultados como
-listas construídas de forma ``preguiçosa'' (lazy-lists). A classe \code{Stream}
-é um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
-o fato que seus valores foram construídos de modo preguiçoso.
-%--------
+As fun\c{c}\~{o}es \code{domain} e \code{range} retornam seus resultados como
+listas constru\'{i}das de forma ``pregui\c{c}osa'' (lazy-lists). A classe \code{Stream}
+\'{e} um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
+o fato que seus valores foram constru\'{i}dos de modo pregui\c{c}oso.
 
 
 \begin{figure}[thb]
@@ -365,66 +258,35 @@ class OOBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   }
 }
 \end{lstlisting}
-%--------
-\caption{\label{fig:oobintree}Object-oriented implementation of binary
-search trees}
-\caption{\label{fig:oobintree}Implementação orientada a objetos de 
-árvores binárias de busca}
-%--------
+
+\caption{\label{fig:oobintree}Implementa\c{c}\~{a}o orientada a objetos de 
+\'{a}rvores bin\'{a}rias de busca}
+
 \end{figure}
 
-%--------
-%The second implementation of maps is given in
-%Figure~\ref{fig:oobintree}.  Class \code{OOBinTree} implements the
-%type \code{Map} with a module \code{empty} and a class
-%\code{Node}, which define the behavior of empty and non-empty trees,
-%respectively.
 
-A segunda implementação dos mapas é dada na
+A segunda implementa\c{c}\~{a}o dos mapas \'{e} dada na
 Figura~\ref{fig:oobintree}.  A classe \code{OOBinTree} implementa o 
-tipo \code{Map} com um módulo \code{empty} e uma classe \code{Node}
-que define o comportamento de árvores vazias e não-vazias, respectivamente.
-%--------
-
-%--------
-%Note the different nesting structure of \code{AlgBinTree} and
-%\code{OOBinTree}. In the former, all methods form part of the base
-%class \code{Map}. The different behavior of empty and non-empty trees
-%is expressed using a pattern match on the tree itself. In the
-%latter, each subclass of \code{Map} defines its own set of
-%methods, which override the methods in the base class. The pattern
-%matches of the algebraic implementation have been replaced by the
-%dynamic binding that comes with method overriding.
+tipo \code{Map} com um m\'{o}dulo \code{empty} e uma classe \code{Node}
+que define o comportamento de \'{a}rvores vazias e n\~{a}o-vazias, respectivamente.
 
 Observe a estrutura de aninhamento diferente de \code{AlgBinTree} e
-\code{OOBinTree}. Na primeira, todos os métodos são parte da classe base
-\code{Map}. O comportamento distinto para árvores vazias e não vazias 
-é expresso usando um casamento de padrões na própria árvore. Na segunda,
- cada subclasse do \code{Map} define seu próprio conjunto de 
-métodos, que sobrescrevem os métodos da classe base. O casamento de 
-padrões da implementação algébrica foi substituído pela ligação 
-dinâmica que veio com o método sobrescrito.
-%--------
+\code{OOBinTree}. Na primeira, todos os m\'{e}todos s\~{a}o parte da classe base
+\code{Map}. O comportamento distinto para \'{a}rvores vazias e n\~{a}o vazias 
+\'{e} expresso usando um casamento de padr\~{o}es na pr\'{o}pria \'{a}rvore. Na segunda,
+ cada subclasse do \code{Map} define seu pr\'{o}prio conjunto de 
+m\'{e}todos, que sobrescrevem os m\'{e}todos da classe base. O casamento de 
+padr\~{o}es da implementa\c{c}\~{a}o alg\'{e}brica foi substitu\'{i}do pela liga\c{c}\~{a}o 
+din\^{a}mica que veio com o m\'{e}todo sobrescrito.
 
-%--------
-%Which of the two schemes is preferable depends to a large degree on
-%which extensions of the type are anticipated. If the type is later
-%extended with a new alternative, it is best to keep methods in each
-%alternative, the way it was done in \code{OOBinTree}.  On the other
-%hand, if the type is extended with additional methods, then it is
-%preferable to keep only one implementation of methods and to rely on
-%pattern matching, since this way existing subclasses need not be
-%modified.
-
-Qual dos dois esquemas é preferível depende em grande parte de quais
-estensões do tipo são antecipadas. Se o tipo for mais tarde estendido
-com uma nova alternativa, é melhor manter os métodos em cada 
+Qual dos dois esquemas \'{e} prefer\'{i}vel depende em grande parte de quais
+estens\~{o}es do tipo s\~{a}o antecipadas. Se o tipo for mais tarde estendido
+com uma nova alternativa, \'{e} melhor manter os m\'{e}todos em cada 
 alternativa, do modo como foi feito em \code{OOBinTree}. Por outro 
-lado, se o tipo for estendido com métodos adicionais, então é preferível
-manter apenas uma implementação dos métodos e confiar no casamento de
-padrões, pois desta forma subclasses existentes não precisarão ser
+lado, se o tipo for estendido com m\'{e}todos adicionais, ent\~{a}o \'{e} prefer\'{i}vel
+manter apenas uma implementa\c{c}\~{a}o dos m\'{e}todos e confiar no casamento de
+padr\~{o}es, pois desta forma subclasses existentes n\~{a}o precisar\~{a}o ser
 modificadas. 
-%--------
 
 \begin{figure}
 \begin{lstlisting}
@@ -469,71 +331,33 @@ class MutBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   let empty = new Map(null, null)
 }
 \end{lstlisting}
-%--------
-%\caption{\label{fig:impbintree}Side-effecting implementation of binary
-%search trees}
-\caption{\label{fig:impbintree}Implementação com efeitos colaterais de
-árvores binárias de busca}
+\caption{\label{fig:impbintree}Implementa\c{c}\~{a}o com efeitos colaterais de
+\'{a}rvores bin\'{a}rias de busca}
 \end{figure}
-%--------
 
-%--------
-%The two versions of binary trees presented so far are {\em
-%persistent}, in the sense that maps are values that cannot be changed
-%by side effects. By contrast, in the next implementation of binary
-%trees, the implementations of \code{extend} and
-%\code{remove} do have an effect on the state of their receiver
-%object. This corresponds to the way binary trees are usually
-%implemented in imperative languages. The new implementation can lead
-%to some savings in computing time and memory allocation, but care is
-%required not to use the original tree after it has been modified by a
-%side-effecting operation.
+As duas vers\~{o}es apresentadas de \'{a}rvores bin\'{a}rias de fato s\~{a}o 
+\em{persistentes}, no sentido que mapas s\~{a}o valores que n\~{a}o podem ser
+alterados atrav\'{e}s de efeitos colaterais. Em contraste, a pr\'{o}xima 
+implementa\c{c}\~{a}o de \'{a}rvores bin\'{a}rias, as implementa\c{c}\~{o}es de \code{extend} e 
+\code{remove} t\^{e}m um efeito sobre o estado de seus objetos recebedores.
+Isto corresponde ao modo como \'{a}rvores bin\'{a}rias s\~{a}o geralmente implementadas
+em linguagens imperativas. A nova implementa\c{c}\~{a}o pode levar a uma economia 
+de tempo computacional e aloca\c{c}\~{a}o de mem\'{o}ria, mas \'{e} preciso tomar cuidado
+para n\~{a}o usar a \'{a}rvore original ap\'{o}s sua modifica\c{c}\~{a}o por efeito colateral.
 
-As duas versões apresentadas de árvores binárias de fato são 
-\em{persistentes}, no sentido que mapas são valores que não podem ser
-alterados através de efeitos colaterais. Em contraste, a próxima 
-implementação de árvores binárias, as implementações de \code{extend} e 
-\code{remove} têm um efeito sobre o estado de seus objetos recebedores.
-Isto corresponde ao modo como árvores binárias são geralmente implementadas
-em linguagens imperativas. A nova implementação pode levar a uma economia 
-de tempo computacional e alocação de memória, mas é preciso tomar cuidado
-para não usar a árvore original após sua modificação por efeito colateral.
-%--------
-
-%--------
-%In this implementation, \code{value}, \code{l} and \code{r} are
-%variables that can be affected by method calls.  The
-%class \code{MutBinTree[kt, vt].Map} takes two instance parameters
-%which define the \code{key} value and the initial value of the
-%\code{value} variable. Empty trees are represented by a
-%value \code{empty}, which has \code{null} (signifying undefined) in
-%both its key and value fields. Note that this value needs to be
-%defined lazily using \code{let} since its definition involves the
-%creation of a \code{Map} object,
-%which accesses \code{empty} recursively as part of its initialization.
-%All methods test first whether the current tree is empty using the
-%reference equality operator \code{eq} (\sref{sec:class-object}).
-
-Nesta implementação, \code{value}, \code{l} e \code{r} são variáveis
-que podem ser afetadas por chamadas de métodos. A classe
-\code{MutBinTree[kt, vt].Map} leva dois parâmetros de instância que 
-definem o valor de \code{key} e o valor inicial da variável \code{value}.
-Árvores vazias são representadas por um valor \code{empty}, que tem \code{null} 
+Nesta implementa\c{c}\~{a}o, \code{value}, \code{l} e \code{r} s\~{a}o vari\'{a}veis
+que podem ser afetadas por chamadas de m\'{e}todos. A classe
+\code{MutBinTree[kt, vt].Map} leva dois par\^{a}metros de inst\^{a}ncia que 
+definem o valor de \code{key} e o valor inicial da vari\'{a}vel \code{value}.
+\'{A}rvores vazias s\~{a}o representadas por um valor \code{empty}, que tem \code{null} 
 (significando indefinido) em seus campos chave e valor. Observe que este valor
-precisa ser definido de modo lazy (preguiçoso) usando \code{let}, pois sua definição
-envolve a criação de um objeto \code{Map}, que acessa \code{empty} recursivamente como
-parte da sua inicialização. Todos os métodos primeiro testam se a árvore corrente é 
-vazia usando a referência ao operador de igualdade \code{eq} (\sref{sec:class-object}).
-%--------
+precisa ser definido de modo lazy (pregui\c{c}oso) usando \code{let}, pois sua defini\c{c}\~{a}o
+envolve a cria\c{c}\~{a}o de um objeto \code{Map}, que acessa \code{empty} recursivamente como
+parte da sua inicializa\c{c}\~{a}o. Todos os m\'{e}todos primeiro testam se a \'{a}rvore corrente \'{e} 
+vazia usando a refer\^{e}ncia ao operador de igualdade \code{eq} (\sref{sec:class-object}).
 
-%--------
-%As a program using the \code{MapStruct} abstraction, consider a function
-%which creates a map from strings to integers and then applies it to a
-%key string:
-
-Como um programa usando a abstração \code{MapStruct}, considere uma função
-que cria um mapa de cadeias de caracteres a inteiros e então o aplica à cadeia chave:
-%--------
+Como um programa usando a abstra\c{c}\~{a}o \code{MapStruct}, considere uma fun\c{c}\~{a}o
+que cria um mapa de cadeias de caracteres a inteiros e ent\~{a}o o aplica à cadeia chave:
 
 \begin{lstlisting}
 def mapTest(mapImpl: => MapStruct[String, int]): int = {
@@ -542,15 +366,9 @@ def mapTest(mapImpl: => MapStruct[String, int]): int = {
 }
 \end{lstlisting}
 
-%--------
-%The function is parameterized with the particular implementation of
-%\code{MapStruct}. It can be applied to any one of the three implementations
-%described above. E.g.:
-
-A função é parametrizada com a implementação particular de \code{MapStruct}. 
-Pode ser aplicada a qualquer uma das três implementações descritas acima.
+A fun\c{c}\~{a}o \'{e} parametrizada com a implementa\c{c}\~{a}o particular de \code{MapStruct}. 
+Pode ser aplicada a qualquer uma das tr\^{e}s implementa\c{c}\~{o}es descritas acima.
 Por exemplo:
-%--------
 \begin{lstlisting}
 mapTest(AlgBinTree[String, int])
 mapTest(OOBinTree[String, int])
@@ -558,15 +376,9 @@ mapTest(MutBinTree[String, int])
 \end{lstlisting}
 }
  
-%--------
-%\paragraph{Mixin Composition}
-%We can now define a class of \code{Rational} numbers that
-%support comparison operators.
-
-\paragraph{Composição Mixin}
-Agora podemos definir uma classe de números tipo \code{Rational} que 
-suportam operadores de comparação.
-%--------
+\paragraph{Composi\c{c}\~{a}o Mixin}
+Agora podemos definir uma classe de n\'{u}meros tipo \code{Rational} que 
+suportam operadores de compara\c{c}\~{a}o.
 \begin{lstlisting}
 final class OrderedRational(n: int, d: int)
  extends Rational(n, d) with Ord {
@@ -577,151 +389,68 @@ final class OrderedRational(n: int, d: int)
 }
 \end{lstlisting}
 
-%---------
-%Class \code{OrderedRational} redefines method \code{==}, which is
-%defined as reference equality in class \code{Object}. It also
-%implements the abstract method \code{<} from class \code{Ord}.  In
-%addition, it inherits all members of class \code{Rational} and all
-%non-abstract members of class \code{Ord}. The implementations of
-%\code{==} and \code{<} replace the definition of \code{==} in class
-%\code{Object} and the abstract declaration of \code{<} in class
-%\code{Ord}. The other inherited comparison methods then refer to this
-%implementation in their body.
+A classe \code{OrderedRational} redefine o m\'{e}todo \code{==}, que \'{e}
+definido como refer\^{e}ncia a igualdade na classe \code{Object}. Tamb\'{e}m
+implementa o m\'{e}todo abstrato \code{<} da classe \code{Ord}. Al\'{e}m disso, 
+herda todos os membros da classe \code{Rational} e todos os membros n\~{a}o
+abstratos da classe \code{Ord}. As implementa\c{c}\~{o}es de \code{==} e \code{<} 
+substituem as defini\c{c}\~{o}es de \code{==} na classe \code{Object} e a 
+declara\c{c}\~{a}o abstrata de \code{<} na classe \code{Ord}. Os outros m\'{e}todos de 
+compara\c{c}\~{a}o herdados referem-se, ent\~{a}o, a esta implementa\c{c}\~{a}o nos seus corpos.
 
-A classe \code{OrderedRational} redefine o método \code{==}, que é
-definido como referência a igualdade na classe \code{Object}. Também
-implementa o método abstrato \code{<} da classe \code{Ord}. Além disso, 
-herda todos os membros da classe \code{Rational} e todos os membros não
-abstratos da classe \code{Ord}. As implementações de \code{==} e \code{<} 
-substituem as definições de \code{==} na classe \code{Object} e a 
-declaração abstrata de \code{<} na classe \code{Ord}. Os outros métodos de 
-comparação herdados referem-se, então, a esta implementação nos seus corpos.
-%----------
-
-%----------
-%The clause ``\code{Rational(d, d) with Ord}'' is an instance of {\em
-%mixin composition}. It describes a template for an object that is
-%compatible with both \code{Rational} and \code{Ord} and that contains
-%all members of either class. \code{Rational} is called the {\em
-%superclass} of \code{OrderedRational} while \code{Ord} is called a
-%{\em mixin class}. The type of this template is the {\em compound
-%type} ``\code{Rational with Ord}''.
-
-A cláusula ``\code{Rational(d, d) with Ord}'' é uma instância da {\em
-composição mixin}. Descreve um template para um objeto que é compatível
-com ambos \code{Rational} e \code{Ord} e que contém todos os membros de 
-cada classe. \code{Rational} é chamada de {\em
-superclasse} de \code{OrderedRational} enquanto \code{Ord} é chamado de
-{\em classe mixin}. O tipo para este template é o {\em tipo composto}
+A cl\'{a}usula ``\code{Rational(d, d) with Ord}'' \'{e} uma inst\^{a}ncia da {\em
+composi\c{c}\~{a}o mixin}. Descreve um template para um objeto que \'{e} compat\'{i}vel
+com ambos \code{Rational} e \code{Ord} e que cont\'{e}m todos os membros de 
+cada classe. \code{Rational} \'{e} chamada de {\em
+superclasse} de \code{OrderedRational} enquanto \code{Ord} \'{e} chamado de
+{\em classe mixin}. O tipo para este template \'{e} o {\em tipo composto}
 ``\code{Rational with Ord}''.
-%----------
 
-%----------
-%On the surface, mixin composition looks much like multiple
-%inheritance. The difference between the two becomes apparent if we
-%look at superclasses of inherited classes. With multiple inheritance,
-%both \code{Rational} and \code{Ord} would contribute a superclass
-%\code{Object} to the template. We therefore have to answer some
-%tricky questions, such as whether members of \code{Object} are present
-%once or twice and whether the initializer of \code{Object} is called
-%once or twice. Mixin composition avoids these complications.  In the
-%mixin composition \code{Rational with Ord}, class
-%\code{Rational} is treated as actual superclass of class \code{Ord}.
-%A mixin composition \code{C with M} is well-formed as long as the
-%first operand \code{C} conforms to the declared superclass of the
-%second operand \code{M}. This holds in our example, because
-%\code{Rational} conforms to \code{Object}. In a sense, mixin composition
-%amounts to overriding the superclass of a class.
-
-Na superfície, composição mixin se parece muito com herança múltipla.
-A diferença entre os dois se torna aparente se olharmos para as superclasses
-das classes herdadas. Com herança múltipla, ambos \code{Rational} e \code{Ord}
-trariam a superclasse \code{Object} para o template. Por essa razão 
-teríamos de responder algumas questões delicadas, tais como se membros de \code{Object} 
-estão presentes uma ou duas vezes e se o inicializador de \code{Object} é chamado
-uma ou duas vezes. Composição mixin evita tais complicações. Na composição mixin
-\code{Rational with Ord}, a classe \code{Rational} é tratada como superclasse efetiva
+Na superf\'{i}cie, composi\c{c}\~{a}o mixin se parece muito com heran\c{c}a m\'{u}ltipla.
+A diferen\c{c}a entre os dois se torna aparente se olharmos para as superclasses
+das classes herdadas. Com heran\c{c}a m\'{u}ltipla, ambos \code{Rational} e \code{Ord}
+trariam a superclasse \code{Object} para o template. Por essa raz\~{a}o 
+ter\'{i}amos de responder algumas quest\~{o}es delicadas, tais como se membros de \code{Object} 
+est\~{a}o presentes uma ou duas vezes e se o inicializador de \code{Object} \'{e} chamado
+uma ou duas vezes. Composi\c{c}\~{a}o mixin evita tais complica\c{c}\~{o}es. Na composi\c{c}\~{a}o mixin
+\code{Rational with Ord}, a classe \code{Rational} \'{e} tratada como superclasse efetiva
 da classe \code{Ord}.
-Uma composição mixin \code{C with M} é bem formada contanto que o primeiro operando
+Uma composi\c{c}\~{a}o mixin \code{C with M} \'{e} bem formada contanto que o primeiro operando
 \code{C} esteja de acordo com a superclasse declarada do segundo operando \code{M}. 
-Isto vale no nosso exemplo, porque \code{Rational} está de acordo com \code{Object}. 
-De certo modo, composição mixin resulta em sobrescrever a superclasse de uma classe.
-%----------
-
-%----------
-%\paragraph{Final Classes}
-%Note that class \code{OrderedRational} was defined
-%\code{final}. This means that no classes extending \code{OrderedRational}
-%may be defined in other parts of the program.
+Isto vale no nosso exemplo, porque \code{Rational} est\'{a} de acordo com \code{Object}. 
+De certo modo, composi\c{c}\~{a}o mixin resulta em sobrescrever a superclasse de uma classe.
 
 \paragraph{Classes Finais}
 Observe que a classe \code{OrderedRational} foi definida \code{final}. Isto
 significa que nenhuma classe estendendo \code{OrderedRational} pode ser
 definida em outras partes do programa.
-%----------
 
-%%Within final classes the
-%%type \code{this} is an alias of the defined class itself. Therefore,
-%%we could define our \code{<} method with an argument of type
-%%\code{OrderedRational} as a well-formed implementation of the abstract class
-%%\code{less(that: this)} in class \code{Ord}.
+\chapter{\label{sec:simple-examples}Casamento de Padr\~{o}es}
 
-
-%----------
-%\chapter{\label{sec:simple-examples}Pattern Matching}
-
-%\todo{Complete}
-
-%Consider binary trees whose leafs contain integer arguments. This can
-%be described by a class for trees, with subclasses for leafs and
-%branch nodes:
-
-\chapter{\label{sec:simple-examples}Casamento de Padrões}
-
-Considere árvores binárias cujas folhas contém argumentos inteiros. Isto pode
-ser descrito por uma classe para árvores, com subclasses para folhas e 
-nós internos:
-%----------
+Considere \'{a}rvores bin\'{a}rias cujas folhas cont\'{e}m argumentos inteiros. Isto pode
+ser descrito por uma classe para \'{a}rvores, com subclasses para folhas e 
+n\'{o}s internos:
 \begin{lstlisting}
 abstract class Tree;
 case class Branch(left: Tree, right: Tree) extends Tree;
 case class Leaf(x: int) extends Tree;
 \end{lstlisting}
 
-
-%----------
-%Note that the class \code{Tree} is not followed by an extends
-%clause or a body. This defines \code{Tree} to be an empty
-%subclass of \code{Object}, as if we had written
-%\begin{lstlisting}
-%class Tree extends Object {}
-%\end{lstlisting}
-%Note also that the two subclasses of \code{Tree} have a \code{case}
-%modifier.  That modifier has two effects. First, it lets us construct
-%values of a case class by simply calling the constructor, without
-%needing a preceding \code{new}. Example:
-%\begin{lstlisting}
-%val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
-%\end{lstlisting}
-%Second, it lets us use constructors for these classes in patterns, as
-%is illustrated in the following example.
-
-Observe que a classe \code{Tree} não é seguida por uma cláusula \code{extends}
+Observe que a classe \code{Tree} n\~{a}o \'{e} seguida por uma cl\'{a}usula \code{extends}
 ou por um corpo. Isto define \code{Tree} para ser uma subclasse vazia de
 \code{Object}, como se tivessemos escrito
 \begin{lstlisting}
 class Tree extends Object {}
 \end{lstlisting}
-Observe também que as duas subclasses de \code{Tree} têm um modificador
+Observe tamb\'{e}m que as duas subclasses de \code{Tree} t\^{e}m um modificador
 \code{case}. Aquele modificador tem dois efeitos. Primeiro, nos permite
 construir valores de uma classe case simplesmente chamando o construtor, sem
 a necessidade de que um \code{new} o preceda. Examplo:
 \begin{lstlisting}
 val tree1 = Branch(Branch(Leaf(1), Leaf(2)), Branch(Leaf(3), Leaf(4)))
 \end{lstlisting}
-Segundo, nos permite usar construtores para estas classes dentro de padrões,
+Segundo, nos permite usar construtores para estas classes dentro de padr\~{o}es,
 conforme ilustrado no seguinte exemplo.
-%-----------
 \begin{lstlisting}
 def sumLeaves(t: Tree): int = t match {
   case Branch(l, r) => sumLeaves(l) + sumLeaves(r)
@@ -729,57 +458,28 @@ def sumLeaves(t: Tree): int = t match {
 }
 \end{lstlisting}
 
-%-----------
-%The function \code{sumLeaves} sums up all the integer values in the
-%leaves of a given tree \code{t}. It is is implemented by calling the
-%\code{match} method of \code{t} with a {\em choice expression} as
-%argument (\code{match} is a predefined method in class \code{Object}).
-%The choice expression consists of two cases which botrelate a pattern 
-%with an expression. The pattern of the first case,
-%\code{Branch(l, r)} matches all instances of class \code{Branch}
-%and binds the {\em pattern variables} \code{l} and \code{r} to the
-%constructor arguments, i.e.\ the left and right subtrees of the
-%branch.  Pattern variables always start with a lower case letter; to
-%avoid ambiguities, constructors in patterns should start with an upper
-%case letter.
+A fun\c{c}\~{a}o \code{sumLeaves} soma todos os valores inteiros das folhas de
+uma dada \'{a}rvore \code{t}. É implementada chamando o m\'{e}todo \code{match}
+de \code{t} com uma {\em dada express\~{a}o} como argumento. (\code{match}
+\'{e} um m\'{e}todo pr\'{e}-definido da classe \code{Object}). A express\~{a}o passada 
+como argumento consiste de dois cases que casam um padr\~{a}o com a express\~{a}o.
+O padr\~{a}o do primeiro case, \code{Branch(l, r)} casa com todas as inst\^{a}ncias
+da classe \code{Branch} e liga as {\em vari\'{a}veis padr\~{a}o} \code{l} e \code{r} 
+ao argumentos do construtor, ou seja, às sub-\'{a}rvores esquerda e direita do n\'{o}.
+Vari\'{a}veis padr\~{a}o sempre iniciam com letra min\'{u}scula e, para evitar ambiguidades,
+construtores nos padr\~{o}es deveriam iniciar com uma letra mai\'{u}scula.
 
-A função \code{sumLeaves} soma todos os valores inteiros das folhas de
-uma dada árvore \code{t}. É implementada chamando o método \code{match}
-de \code{t} com uma {\em dada expressão} como argumento. (\code{match}
-é um método pré-definido da classe \code{Object}). A expressão passada 
-como argumento consiste de dois cases que casam um padrão com a expressão.
-O padrão do primeiro case, \code{Branch(l, r)} casa com todas as instâncias
-da classe \code{Branch} e liga as {\em variáveis padrão} \code{l} e \code{r} 
-ao argumentos do construtor, ou seja, às sub-árvores esquerda e direita do nó.
-Variáveis padrão sempre iniciam com letra minúscula e, para evitar ambiguidades,
-construtores nos padrões deveriam iniciar com uma letra maiúscula.
-%-----------
-
-%-----------
-%The effect of the choice expression is to select the first alternative
-%whose pattern matches the given select value, and to evaluate the body
-%of this alternative in a context where pattern variables are bound to
-%corresponding parts of the selector. For instance, the application
-%\code{sumLeaves(tree1)} would select the first alternative with the
-%\code{Branch(l,r)} pattern, and would evaluate the expression
-%\code{sumLeaves(l) + sumLeaves(r)} with bindings
-%\begin{lstlisting}
-%l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
-%\end{lstlisting}
-%As another example, consider the following class
-
-O efeito da expressão escolhida é selecionar a primeira alternativa
-cujo padrão casa com um dado valor selecionado, e avaliar o corpo
-desta alternativa no contexto onde variáveis padrão são ligadas às
-partes correspondentes do seletor. Por exemplo, a aplicação
+O efeito da express\~{a}o escolhida \'{e} selecionar a primeira alternativa
+cujo padr\~{a}o casa com um dado valor selecionado, e avaliar o corpo
+desta alternativa no contexto onde vari\'{a}veis padr\~{a}o s\~{a}o ligadas às
+partes correspondentes do seletor. Por exemplo, a aplica\c{c}\~{a}o
 \code{sumLeaves(tree1)} deveria selecionar a primeira alternativa
-com o padrão \code{Branch(l,r)}, e deveria avaliar a expressão
-\code{sumLeaves(l) + sumLeaves(r)} com ligações
+com o padr\~{a}o \code{Branch(l,r)}, e deveria avaliar a express\~{a}o
+\code{sumLeaves(l) + sumLeaves(r)} com liga\c{c}\~{o}es
 \begin{lstlisting}
 l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
 \end{lstlisting}
 Como outro exemplo, considere a seguinte classe
-%-----------
 
 \begin{lstlisting}
 abstract final class Option[+a];
@@ -789,7 +489,6 @@ case class Some[a](item: a) extends Option[a];
 ...
 
 %\todo{Several simple and intermediate examples needed}.
-
 \begin{lstlisting}
 def find[a,b](it: Iterator[(a, b)], x: a): Option[b] = {
   var result: Option[b] = None;

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -241,16 +241,22 @@ binárias de busca}
 Nós agora apresentaremos três implementações de \code{Map}, todas elas
 baseadas em árvores binárias de busca. O método \code{apply} de um mapa é
 implementado em cada caso pela função de busca usual sobre árvores binárias, 
-que comparam uma dada chave com a chave guardada no mais alto nó da árvore, 
+que compara uma dada chave com a chave guardada no mais alto nó da árvore, 
 e dependendo do resultado da comparação, segue a busca por sua sub-árvore 
 esquerda ou direita. O tipo das chaves deve implementar a classe \code{Ord},
 que contém métodos de comparação (ver Capítulo~\ref{chap:classes} para uma
 definição da classe \code{Ord}).
 
 
-The first implementation, \code{AlgBinTree}, is given in
-Figure~\ref{fig:algbintree}. It represents a map with a
-data type \code{Map} with two cases, \code{Empty} and \code{Node}.
+%The first implementation, \code{AlgBinTree}, is given in
+%Figure~\ref{fig:algbintree}. It represents a map with a
+%data type \code{Map} with two cases, \code{Empty} and \code{Node}.
+
+A primeira implementação, \code{AlgBinTree}, é dada na 
+Figura~\ref{fig:algbintree}. Representa um mapa com um 
+tipo de dados \code{Map} com dois casos, \code{Empty} e \code{Node}.
+
+
 
 Every method of \code{AlgBinTree[kt, vt].Map} performs a pattern
 match on the value of

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -1,11 +1,14 @@
 \documentclass[a4paper,12pt,twoside,titlepage]{book}
 
+
+
 \usepackage{scaladoc}
 \usepackage{fleqn}
 \usepackage{modefs}
 \usepackage{math}
 \usepackage{scaladefs}
 \usepackage[utf8]{inputenc}
+
 \renewcommand{\todo}[1]{}
 
 \renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
@@ -13,6 +16,13 @@
 \renewcommand*{\contentsname}{Índice}
 \renewcommand\lstlistingname{Listagem}
 \renewcommand\lstlistlistingname{Listagens}
+\renewcommand{\bibname}{Bibliografia}
+\def\example{
+   \def\theresult{Exemplo~\thesection.\arabic{result}}
+   \refstepcounter{result}
+   \trivlist\item[\hskip
+   \labelsep{\bf \theresult}]}
+\def\endexample{\endtrivlist}
 
 
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -542,9 +542,13 @@ mapTest(MutBinTree[String, int])
 }
  
 %--------
-\paragraph{Mixin Composition}
-We can now define a class of \code{Rational} numbers that
-support comparison operators.
+%\paragraph{Mixin Composition}
+%We can now define a class of \code{Rational} numbers that
+%support comparison operators.
+
+\paragraph{Composição Mixin}
+Agora podemos definir uma classe de números tipo \code{Rational} que 
+suportam operadores de comparação.
 %--------
 \begin{lstlisting}
 final class OrderedRational(n: int, d: int)
@@ -555,15 +559,30 @@ final class OrderedRational(n: int, d: int)
     numer * that.denom < that.numer * denom;
 }
 \end{lstlisting}
-Class \code{OrderedRational} redefines method \code{==}, which is
-defined as reference equality in class \code{Object}. It also
-implements the abstract method \code{<} from class \code{Ord}.  In
-addition, it inherits all members of class \code{Rational} and all
-non-abstract members of class \code{Ord}. The implementations of
-\code{==} and \code{<} replace the definition of \code{==} in class
-\code{Object} and the abstract declaration of \code{<} in class
-\code{Ord}. The other inherited comparison methods then refer to this
-implementation in their body.
+
+%---------
+%Class \code{OrderedRational} redefines method \code{==}, which is
+%defined as reference equality in class \code{Object}. It also
+%implements the abstract method \code{<} from class \code{Ord}.  In
+%addition, it inherits all members of class \code{Rational} and all
+%non-abstract members of class \code{Ord}. The implementations of
+%\code{==} and \code{<} replace the definition of \code{==} in class
+%\code{Object} and the abstract declaration of \code{<} in class
+%\code{Ord}. The other inherited comparison methods then refer to this
+%implementation in their body.
+
+A classe \code{OrderedRational} redefine o método \code{==}, que é
+definido como referência a igualdade na classe \code{Object}. Também
+implementa o método abstrato \code{<} da classe \code{Ord}. Além disso, 
+herda todos os membros da classe \code{Rational} e todos os membros não
+abstratos da classe \code{Ord}. As implementações de \code{==} e \code{<} 
+substituem as definições de \code{==} na classe \code{Object} e a 
+declaração abstrata de \code{<} na classe \code{Ord}. Os outros métodos de 
+comparação herdados referem-se, então, a esta implementação nos seus corpos.
+%----------
+
+
+
 
 The clause ``\code{Rational(d, d) with Ord}'' is an instance of {\em
 mixin composition}. It describes a template for an object that is

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -294,10 +294,18 @@ que é definido como uma aplicação pós-fixa da função na classe \code{Objec
 (\sref{sec:class-object}).
 %--------
 
-The functions \code{domain} and \code{range} return their results as
-lazily constructed lists. The \code{Stream} class is an alias of
-\code{List} which should be used to indicate the fact that its values
-are constructed lazily.
+%--------
+%The functions \code{domain} and \code{range} return their results as
+%lazily constructed lists. The \code{Stream} class is an alias of
+%\code{List} which should be used to indicate the fact that its values
+%are constructed lazily.
+
+As funções \code{domain} e \code{range} retornam seus resultados como
+listas construídas de forma ``preguiçoza'' (lazy-lists). A classe \code{Stream}
+é um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
+o fato que seus valores foram construídos de modo preguiçozo.
+%--------
+
 
 \begin{figure}[thb]
 \begin{lstlisting}
@@ -339,16 +347,28 @@ class OOBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   }
 }
 \end{lstlisting}
+%--------
 \caption{\label{fig:oobintree}Object-oriented implementation of binary
 search trees}
+\caption{\label{fig:oobintree}Implementação orientada a objetos de 
+árvores binárias de busca}
+%--------
 \end{figure}
 
+%--------
 The second implementation of maps is given in
 Figure~\ref{fig:oobintree}.  Class \code{OOBinTree} implements the
 type \code{Map} with a module \code{empty} and a class
 \code{Node}, which define the behavior of empty and non-empty trees,
 respectively.
 
+A segunda implementação dos mapas é dada na
+Figura~\ref{fig:oobintree}.  A classe \code{OOBinTree} implementa o 
+tipo \code{Map} com um módulo \code{empty} e uma classe \code{Node},
+que define o comportamento de árvores vazias e não-vazias, respectivamente.
+%--------
+
+%--------
 Note the different nesting structure of \code{AlgBinTree} and
 \code{OOBinTree}. In the former, all methods form part of the base
 class \code{Map}. The different behavior of empty and non-empty trees
@@ -357,7 +377,9 @@ latter, each subclass of \code{Map} defines its own set of
 methods, which override the methods in the base class. The pattern
 matches of the algebraic implementation have been replaced by the
 dynamic binding that comes with method overriding.
+%--------
 
+%--------
 Which of the two schemes is preferable depends to a large degree on
 which extensions of the type are anticipated. If the type is later
 extended with a new alternative, it is best to keep methods in each
@@ -366,6 +388,7 @@ hand, if the type is extended with additional methods, then it is
 preferable to keep only one implementation of methods and to rely on
 pattern matching, since this way existing subclasses need not be
 modified.
+%--------
 
 \begin{figure}
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -102,7 +102,12 @@ especificarão Scala de modo mais detalhado e preciso.
 %examples make use of Scala's object-oriented constructs where
 %appropriate.
 Temos um grande débito ao maravilhoso livro de Abelson e Sussman
-
+``Structure and Interpretation of Computer
+Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exercícios 
+deles também estão presentes aqui. Naturalmente a linguagem de trabalho em
+cada caso foi mudada do Scheme para o Scala. Além disso, os exemplos
+fazem uso de construções da orientação a objetos do Scala onde isto é
+apropriado. 
 
 
 \input{ExamplesPart}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -35,43 +35,57 @@
 \sloppy
 
 \chapter{\label{chap:intro}Introdução}
+%--------
 %Scala smoothly integrates object-oriented and functional
 %programming. It is designed to express common programming patterns in
 %a concise, elegant, and type-safe way.  Scala introduces several
 %innovative language constructs. For instance:
+
 Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
 Foi criada para expressar padrões de programação comuns de modo conciso, elegante e fortemente tipada. 
 Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
-\begin{itemize}
+%--------
 
-\item 
+\begin{itemize}
+%--------
+%\item 
 %Abstract types and mixin composition unify concepts from object and module systems.
+\item
 Tipos abstratos e composições mistas unificam conceitos de objetos e módulos de sistema.
-\item 
+%--------
+
+%--------
+%\item 
 %Pattern matching over class hierarchies unifies functional and
 %  object-oriented data access. It greatly simplifies the processing of XML trees.
+\item
 Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
 objetos. Simplifica bastante o processamento de árvores XML.
-\item
+%--------
+
+%--------
+%\item
 %A flexible syntax and type system enables the construction of advanced
 %  libraries and new domain specific languages.
+\item
 Sintaxe flexível e sistema de tipos habilitam a construção de avançadas 
 bibliotecas e um novo dom¿nio específico de linguagens.
+%--------
 \end{itemize}
 
+%--------
 %At the same time, Scala is compatible with Java.  Java libraries and
 %frameworks can be used without glue code or additional declarations.
-
 %This document introduces Scala in an informal way, through a sequence
 %of examples.
 
 Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
 podem ser usados sem código extra ou declarações adicionais.
-
 Este documento introduz Scala de um modo informal, através de uma sequência
 de exemplos.
+%--------
 
-
+%--------
 %Chapters~\ref{chap:example-one} and \ref{chap:example-auction}
 %highlight some of the features that make Scala interesting. The
 %following chapters introduce the language constructs of Scala in a
@@ -91,9 +105,10 @@ mutável, casamento de padrões até exemplos mais completos que mostram
 interessantes técnicas de programação. A presente exposição informal
 pretende ser complementada por um Manual de Referência da Linguagem Scala, que
 especificarão Scala de modo mais detalhado e preciso. 
-
+%--------
 
 \paragraph{Acknowledgment}
+%--------
 %We owe a great debt to Abelson's and Sussman's wonderful book
 %``Structure and Interpretation of Computer
 %Programs''\cite{abelson-sussman:structure}. Many of their examples and
@@ -101,6 +116,7 @@ especificarão Scala de modo mais detalhado e preciso.
 %in each case been changed from Scheme to Scala. Furthermore, the
 %examples make use of Scala's object-oriented constructs where
 %appropriate.
+
 Temos um grande débito ao maravilhoso livro de Abelson e Sussman
 ``Structure and Interpretation of Computer
 Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exercícios 
@@ -108,7 +124,7 @@ deles também estão presentes aqui. Naturalmente a linguagem de trabalho em
 cada caso foi mudada do Scheme para o Scala. Além disso, os exemplos
 fazem uso de construções da orientação a objetos do Scala onde isto é
 apropriado. 
-
+%--------
 
 \input{ExamplesPart}
 \bibliographystyle{alpha}
@@ -116,19 +132,19 @@ apropriado.
 
 \end{document}
 
-
+%--------
 %\chapter{Implementing Abstract Types: Search Trees}
-
 %This chapter presents unbalanced binary search trees, implemented in
 %three different styles: algebraic, object-oriented, and imperative.
 %In each case, a search tree package is seen as an implementation
 %of a class {\em MapStruct}.
+
 \chapter{Implementando Tipos Abstratos: Árvores de Busca}
 Este capítulo apresenta árvores binárias de busca não balanceadas, implementadas em
 três diferentes estilos: algébrico, orientado a objetos, e imperativo.
 Em cada caso, um pacote de árvore de busca é visto como uma implementação
 de uma classe {\em MapStruct}.
-
+%--------
 
 \begin{lstlisting}
   trait MapStruct[kt, vt] {
@@ -143,21 +159,7 @@ de uma classe {\em MapStruct}.
   }
 \end{lstlisting}
 
-A classe \code{MapStruct} é parametrizada com um tipo de chaves
-\code{kt} e um tipo de valores \code{vt}. Específica um tipo
-abstrato \code{Map} e um valor abstrato \code{empty}, o qual
-denota mapas vazios. Cada implementação \code{Map} precisa
-conformar com aquele tipo abstrato, o qual estende a função tipo
- \code{kt => vt} com quatro novos métodos. O método \code{domain}
-herda um stream que enumera o domínio do mapa, ou seja, o conjunto
-de chaves que são mapeadas com valores não nulos. O método 
-\code{range} herda um stream que enumera a imagem da função, ou seja,
-os valores obtidos pela aplicação dos argumentos da função no seu
-domínio. O método \code{extend} estende o mapa com uma dada ligação
-chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
-Ambos os métodos herdam um novo mapa de valores como resultado, o qual
-tem a mesma representação do objeto recebedor.
-
+%--------
 %The \code{MapStruct} class is parameterized with a type of keys
 %\code{kt} and a type of values \code{vt}. It
 %specifies an abstract type \code{Map} and an abstract value
@@ -174,6 +176,22 @@ tem a mesma representação do objeto recebedor.
 %\code{remove} removes a given key from the map's domain. Both
 %methods yield a new map value as result, which has the same
 %representation as the receiver object.
+
+A classe \code{MapStruct} é parametrizada com um tipo de chaves
+\code{kt} e um tipo de valores \code{vt}. Específica um tipo
+abstrato \code{Map} e um valor abstrato \code{empty}, o qual
+denota mapas vazios. Cada implementação \code{Map} precisa
+conformar com aquele tipo abstrato, o qual estende a função tipo
+ \code{kt => vt} com quatro novos métodos. O método \code{domain}
+herda um stream que enumera o domínio do mapa, ou seja, o conjunto
+de chaves que são mapeadas com valores não nulos. O método 
+\code{range} herda um stream que enumera a imagem da função, ou seja,
+os valores obtidos pela aplicação dos argumentos da função no seu
+domínio. O método \code{extend} estende o mapa com uma dada ligação
+chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
+Ambos os métodos herdam um novo mapa de valores como resultado, o qual
+tem a mesma representação do objeto recebedor.
+%--------
 
 \begin{figure}[t]
 \begin{lstlisting}
@@ -224,11 +242,17 @@ class AlgBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   def empty: Map = Empty
 }
 \end{lstlisting}
-\caption{\label{fig:algbintree}Implementação algébrica de árvores 
-binárias de busca}
+%--------
 %\caption{\label{fig:algbintree}Algebraic implementation of binary
 %search trees}
+
+\caption{\label{fig:algbintree}Implementação algébrica de árvores 
+binárias de busca}
+%--------
 \end{figure}
+
+
+%--------
 %We now present three implementations of \code{Map}, which are all
 %based on binary search trees. The \code{apply} method of a map is
 %implemented in each case by the usual search function over binary
@@ -246,8 +270,9 @@ e dependendo do resultado da comparação, segue a busca por sua sub-árvore
 esquerda ou direita. O tipo das chaves deve implementar a classe \code{Ord},
 que contém métodos de comparação (ver Capítulo~\ref{chap:classes} para uma
 definição da classe \code{Ord}).
+%--------
 
-
+%--------
 %The first implementation, \code{AlgBinTree}, is given in
 %Figure~\ref{fig:algbintree}. It represents a map with a
 %data type \code{Map} with two cases, \code{Empty} and \code{Node}.
@@ -255,13 +280,19 @@ definição da classe \code{Ord}).
 A primeira implementação, \code{AlgBinTree}, é dada na 
 Figura~\ref{fig:algbintree}. Representa um mapa com um 
 tipo de dados \code{Map} com dois casos, \code{Empty} e \code{Node}.
+%--------
 
+%--------
+%Every method of \code{AlgBinTree[kt, vt].Map} performs a pattern
+%match on the value of
+%\code{this} using the \code{match} method which is defined as postfix
+%function application in class \code{Object} (\sref{sec:class-object}).
 
-
-Every method of \code{AlgBinTree[kt, vt].Map} performs a pattern
-match on the value of
-\code{this} using the \code{match} method which is defined as postfix
-function application in class \code{Object} (\sref{sec:class-object}).
+Cada método do \code{AlgBinTree[kt, vt].Map} executa um casamento
+de padrões sobre o valor do \code{this} usando o método \code{match}
+que é definido como uma aplicação pós-fixa da função na classe \code{Object} 
+(\sref{sec:class-object}).
+%--------
 
 The functions \code{domain} and \code{range} return their results as
 lazily constructed lists. The \code{Stream} class is an alias of

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -750,6 +750,18 @@ construtores nos padrões deveriam iniciar com uma letra maiúscula.
 %l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
 %\end{lstlisting}
 %As another example, consider the following class
+
+O efeito da expressão escolhida é selecionar a primeira alternativa
+cujo padrão casa com um dado valor selecionado, e avaliar o corpo
+desta alternativa no contexto onde variáveis padrão são ligadas às
+partes correspondentes do seletor. Por exemplo, a aplicação
+\code{sumLeaves(tree1)} deveria selecionar a primeira alternativa
+com o padrão \code{Branch(l,r)}, e deveria avaliar a expressão
+\code{sumLeaves(l) + sumLeaves(r)} com ligações
+\begin{lstlisting}
+l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
+\end{lstlisting}
+Como outro exemplo, considere a seguinte classe
 %-----------
 
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -356,11 +356,11 @@ search trees}
 \end{figure}
 
 %--------
-The second implementation of maps is given in
-Figure~\ref{fig:oobintree}.  Class \code{OOBinTree} implements the
-type \code{Map} with a module \code{empty} and a class
-\code{Node}, which define the behavior of empty and non-empty trees,
-respectively.
+%The second implementation of maps is given in
+%Figure~\ref{fig:oobintree}.  Class \code{OOBinTree} implements the
+%type \code{Map} with a module \code{empty} and a class
+%\code{Node}, which define the behavior of empty and non-empty trees,
+%respectively.
 
 A segunda implementação dos mapas é dada na
 Figura~\ref{fig:oobintree}.  A classe \code{OOBinTree} implementa o 
@@ -369,14 +369,14 @@ que define o comportamento de árvores vazias e não-vazias, respectivamente.
 %--------
 
 %--------
-Note the different nesting structure of \code{AlgBinTree} and
-\code{OOBinTree}. In the former, all methods form part of the base
-class \code{Map}. The different behavior of empty and non-empty trees
-is expressed using a pattern match on the tree itself. In the
-latter, each subclass of \code{Map} defines its own set of
-methods, which override the methods in the base class. The pattern
-matches of the algebraic implementation have been replaced by the
-dynamic binding that comes with method overriding.
+%Note the different nesting structure of \code{AlgBinTree} and
+%\code{OOBinTree}. In the former, all methods form part of the base
+%class \code{Map}. The different behavior of empty and non-empty trees
+%is expressed using a pattern match on the tree itself. In the
+%latter, each subclass of \code{Map} defines its own set of
+%methods, which override the methods in the base class. The pattern
+%matches of the algebraic implementation have been replaced by the
+%dynamic binding that comes with method overriding.
 
 Observe a estrutura de aninhamento diferente de \code{AlgBinTree} e
 \code{OOBinTree}. No primeiro, todos os métodos são parte da classe base
@@ -389,14 +389,14 @@ dinâmica que veio com o método sobrescrito.
 %--------
 
 %--------
-Which of the two schemes is preferable depends to a large degree on
-which extensions of the type are anticipated. If the type is later
-extended with a new alternative, it is best to keep methods in each
-alternative, the way it was done in \code{OOBinTree}.  On the other
-hand, if the type is extended with additional methods, then it is
-preferable to keep only one implementation of methods and to rely on
-pattern matching, since this way existing subclasses need not be
-modified.
+%Which of the two schemes is preferable depends to a large degree on
+%which extensions of the type are anticipated. If the type is later
+%extended with a new alternative, it is best to keep methods in each
+%alternative, the way it was done in \code{OOBinTree}.  On the other
+%hand, if the type is extended with additional methods, then it is
+%preferable to keep only one implementation of methods and to rely on
+%pattern matching, since this way existing subclasses need not be
+%modified.
 
 
 Qual dos dois esquemas é preferível depende em grande parte de quais
@@ -453,27 +453,27 @@ class MutBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
 }
 \end{lstlisting}
 %--------
-\caption{\label{fig:impbintree}Side-effecting implementation of binary
-search trees}
+%\caption{\label{fig:impbintree}Side-effecting implementation of binary
+%search trees}
 \caption{\label{fig:impbintree}Implementação com efeitos colaterais de
 árvores binárias de busca}
 \end{figure}
 %--------
 
 %--------
-The two versions of binary trees presented so far are {\em
-persistent}, in the sense that maps are values that cannot be changed
-by side effects. By contrast, in the next implementation of binary
-trees, the implementations of \code{extend} and
-\code{remove} do have an effect on the state of their receiver
-object. This corresponds to the way binary trees are usually
-implemented in imperative languages. The new implementation can lead
-to some savings in computing time and memory allocation, but care is
-required not to use the original tree after it has been modified by a
-side-effecting operation.
+%The two versions of binary trees presented so far are {\em
+%persistent}, in the sense that maps are values that cannot be changed
+%by side effects. By contrast, in the next implementation of binary
+%trees, the implementations of \code{extend} and
+%\code{remove} do have an effect on the state of their receiver
+%object. This corresponds to the way binary trees are usually
+%implemented in imperative languages. The new implementation can lead
+%to some savings in computing time and memory allocation, but care is
+%required not to use the original tree after it has been modified by a
+%side-effecting operation.
 
-As duas versões apresentadas de árvores binárias de fato são {\em
-persistentes}, no sentido que mapas são valores que não podem ser
+As duas versões apresentadas de árvores binárias de fato são 
+\em{persistentes}, no sentido que mapas são valores que não podem ser
 alterados através de efeitos colaterais. Em contraste, a próxima 
 implementação de árvores binárias, as implementações de \code{extend} e 
 \code{remove} têm um efeito sobre o estado de seus objetos recebedores.
@@ -484,18 +484,18 @@ para não usar a árvore original após sua modificação por efeito colateral.
 %--------
 
 %--------
-In this implementation, \code{value}, \code{l} and \code{r} are
-variables that can be affected by method calls.  The
-class \code{MutBinTree[kt, vt].Map} takes two instance parameters
-which define the \code{key} value and the initial value of the
-\code{value} variable. Empty trees are represented by a
-value \code{empty}, which has \code{null} (signifying undefined) in
-both its key and value fields. Note that this value needs to be
-defined lazily using \code{let} since its definition involves the
-creation of a \code{Map} object,
-which accesses \code{empty} recursively as part of its initialization.
-All methods test first whether the current tree is empty using the
-reference equality operator \code{eq} (\sref{sec:class-object}).
+%In this implementation, \code{value}, \code{l} and \code{r} are
+%variables that can be affected by method calls.  The
+%class \code{MutBinTree[kt, vt].Map} takes two instance parameters
+%which define the \code{key} value and the initial value of the
+%\code{value} variable. Empty trees are represented by a
+%value \code{empty}, which has \code{null} (signifying undefined) in
+%both its key and value fields. Note that this value needs to be
+%defined lazily using \code{let} since its definition involves the
+%creation of a \code{Map} object,
+%which accesses \code{empty} recursively as part of its initialization.
+%All methods test first whether the current tree is empty using the
+%reference equality operator \code{eq} (\sref{sec:class-object}).
 
 Nesta implementação, \code{value}, \code{l} e \code{r} são variáveis
 que podem ser afetadas por chamadas de métodos. A classe
@@ -510,9 +510,12 @@ vazia usando a referência ao operandor de igualdade \code{eq} (\sref{sec:class-
 %--------
 
 %--------
-As a program using the \code{MapStruct} abstraction, consider a function
-which creates a map from strings to integers and then applies it to a
-key string:
+%As a program using the \code{MapStruct} abstraction, consider a function
+%which creates a map from strings to integers and then applies it to a
+%key string:
+
+Como um programa usando a abstração \code{MapStruct}, considere uma função
+que cria um mapa de cadeias de caracteres a inteiros e então o aplica à cadeia chave:
 %--------
 
 \begin{lstlisting}
@@ -521,9 +524,16 @@ def mapTest(mapImpl: => MapStruct[String, int]): int = {
   val x = map("ab")             // returns 1
 }
 \end{lstlisting}
-The function is parameterized with the particular implementation of
-\code{MapStruct}. It can be applied to any one of the three implementations
-described above. E.g.:
+
+%--------
+%The function is parameterized with the particular implementation of
+%\code{MapStruct}. It can be applied to any one of the three implementations
+%described above. E.g.:
+
+A função é parametrizada com a implementação particular de \code{MapStruct}. 
+Pode ser aplicada a qualquer uma das três implementações descritas acima.
+Por exemplo:
+%--------
 \begin{lstlisting}
 mapTest(AlgBinTree[String, int])
 mapTest(OOBinTree[String, int])
@@ -531,13 +541,11 @@ mapTest(MutBinTree[String, int])
 \end{lstlisting}
 }
  
-
-
-
-
+%--------
 \paragraph{Mixin Composition}
 We can now define a class of \code{Rational} numbers that
 support comparison operators.
+%--------
 \begin{lstlisting}
 final class OrderedRational(n: int, d: int)
  extends Rational(n, d) with Ord {

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -94,13 +94,16 @@ especificarão Scala de modo mais detalhado e preciso.
 
 
 \paragraph{Acknowledgment}
-We owe a great debt to Abelson's and Sussman's wonderful book
-``Structure and Interpretation of Computer
-Programs''\cite{abelson-sussman:structure}. Many of their examples and
-exercises are also present here. Of course, the working language has
-in each case been changed from Scheme to Scala. Furthermore, the
-examples make use of Scala's object-oriented constructs where
-appropriate.
+%We owe a great debt to Abelson's and Sussman's wonderful book
+%``Structure and Interpretation of Computer
+%Programs''\cite{abelson-sussman:structure}. Many of their examples and
+%exercises are also present here. Of course, the working language has
+%in each case been changed from Scheme to Scala. Furthermore, the
+%examples make use of Scala's object-oriented constructs where
+%appropriate.
+Temos um grande débito 
+
+
 
 \input{ExamplesPart}
 \bibliographystyle{alpha}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -8,7 +8,7 @@
 \usepackage[utf8]{inputenc}
 \renewcommand{\todo}[1]{}
 
-\renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile éáãção}
+\renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
 
 
 \ifpdf
@@ -42,7 +42,7 @@
 %innovative language constructs. For instance:
 
 Scala facilita a integração entre a  programação orientada a objetos e a programação funcional.
-Foi criada para expressar padrões de programação comuns de modo conciso, elegante e fortemente tipada. 
+Foi criada para expressar padrões de programação comuns de forma concisa, elegante e fortemente tipada. 
 Scala introduz diversas construções de linguagem inovadoras. Por exemplo:
 %--------
 
@@ -60,7 +60,7 @@ Tipos abstratos e composições mistas unificam conceitos de objetos e módulos 
 %  object-oriented data access. It greatly simplifies the processing of XML trees.
 \item
 Casamento de padrões sobre hierarquias de classe unificam o acesso a dados funcional e orientado a 
-objetos. Simplifica bastante o processamento de árvores XML.
+objetos, simplificando bastante o processamento de árvores XML.
 %--------
 
 %--------
@@ -68,8 +68,8 @@ objetos. Simplifica bastante o processamento de árvores XML.
 %A flexible syntax and type system enables the construction of advanced
 %  libraries and new domain specific languages.
 \item
-Sintaxe flexível e sistema de tipos habilitam a construção de avançadas 
-bibliotecas e um novo domínio específico de linguagens.
+Sintaxe flexível e sistema de tipos que habilitam a construção de avançadas 
+bibliotecas e um novas linguagens específicas a um domínio.
 %--------
 \end{itemize}
 
@@ -101,7 +101,7 @@ salientam alguns dos aspectos que tornam Scala interessante. Os
 capítulos seguintes introduzem as construções da linguagem Scala de um
 modo mais completo, começando com expressões e funções simples, e 
 desenvolvendo até objetos e classes, listas e streams, estado 
-mutável, casamento de padrões até exemplos mais completos que mostram
+mutável, reconhecimento de padrões até exemplos mais completos que mostram
 interessantes técnicas de programação. A presente exposição informal
 pretende ser complementada por um Manual de Referência da Linguagem Scala, que
 especificarão Scala de modo mais detalhado e preciso. 
@@ -120,10 +120,10 @@ especificarão Scala de modo mais detalhado e preciso.
 Temos um grande débito ao maravilhoso livro de Abelson e Sussman
 ``Structure and Interpretation of Computer
 Programs''\cite{abelson-sussman:structure}. Muitos exemplos e exercícios 
-deles também estão presentes aqui. Naturalmente a linguagem de trabalho em
+deles também estão presentes aqui. Naturalmente a linguagem utilizada em
 cada caso foi mudada do Scheme para o Scala. Além disso, os exemplos
-fazem uso de construções da orientação a objetos do Scala onde isto é
-apropriado. 
+fazem uso de construções da orientação a objetos do Scala onde isto foi
+considerado apropriado. 
 %--------
 
 \input{ExamplesPart}
@@ -140,7 +140,7 @@ apropriado.
 %of a class {\em MapStruct}.
 
 \chapter{Implementando Tipos Abstratos: Árvores de Busca}
-Este capítulo apresenta árvores binárias de busca não balanceadas, implementadas em
+Este capítulo apresenta árvores binárias de busca não balanceadas implementadas em
 três diferentes estilos: algébrico, orientado a objetos, e imperativo.
 Em cada caso, um pacote de árvore de busca é visto como uma implementação
 de uma classe {\em MapStruct}.
@@ -178,9 +178,10 @@ de uma classe {\em MapStruct}.
 %representation as the receiver object.
 
 A classe \code{MapStruct} é parametrizada com um tipo de chaves
-\code{kt} e um tipo de valores \code{vt}. Específica um tipo
-abstrato \code{Map} e um valor abstrato \code{empty}, o qual
-denota mapas vazios. Cada implementação \code{Map} precisa
+\code{kt} e um tipo de valores \code{vt}. Também especifica um tipo
+abstrato \code{Map} e um valor abstrato \code{empty} que serve para
+denotar mapas vazios. Cada implementação de \code{Map} precisa
+% parei de revisar aqui - Vinicius
 estar de acordo com aquele tipo abstrato, o qual estende a função tipo
  \code{kt => vt} com quatro novos métodos. O método \code{domain}
 herda um stream que enumera o domínio do mapa, ou seja, o conjunto

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -25,7 +25,8 @@
     }
 \fi
 
-\renewcommand{\doctitle}{Scala Através de Exemplos\\[43mm]\ }
+\renewcommand{\doctitle}{Scala Através de Exemplos\\ \\
+\Large  }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 
 \begin{document}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -101,7 +101,7 @@ especificarão Scala de modo mais detalhado e preciso.
 %in each case been changed from Scheme to Scala. Furthermore, the
 %examples make use of Scala's object-oriented constructs where
 %appropriate.
-Temos um grande débito 
+Temos um grande débito ao maravilhoso livro de Abelson e Sussman
 
 
 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -142,22 +142,38 @@ de uma classe {\em MapStruct}.
     val empty: map;
   }
 \end{lstlisting}
-The \code{MapStruct} class is parameterized with a type of keys
-\code{kt} and a type of values \code{vt}. It
-specifies an abstract type \code{Map} and an abstract value
-\code{empty}, which represents empty maps.  Every implementation
-\code{Map} needs to conform to that abstract type, which
-extends the function type \code{kt => vt}
-with four new
-methods. The method \code{domain} yields a stream that enumerates the
-map's domain, i.e. the set of keys that are mapped to non-null values.
-The method \code{range} yields a stream that enumerates the function's
-range, i.e.\ the values obtained by applying the function to arguments
-in its domain.  The method
-\code{extend} extends the map with a given key/value binding, whereas
-\code{remove} removes a given key from the map's domain. Both
-methods yield a new map value as result, which has the same
-representation as the receiver object.
+
+A classe \code{MapStruct} é parametrizada com um tipo de chaves
+\code{kt} e um tipo de valores \code{vt}. Específica um tipo
+abstrato \code{Map} e um valor abstrato \code{empty}, o qual
+denota mapas vazios. Cada implementação \code{Map} precisa
+conformar com aquele tipo abstrato, o qual estende a função tipo
+ \code{kt => vt} com quatro novos métodos. O método \code{domain}
+herda um stream que enumera o domínio do mapa, ou seja, o conjunto
+de chaves que são mapeadas com valores não nulos. O método 
+\code{range} herda um stream que enumera a imagem da função, ou seja,
+os valores obtidos pela aplicação dos argumentos da função no seu
+domínio. O método \code{extend} estende o mapa com uma dada ligação
+chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
+Ambos os métodos herdam um novo mapa de valores como resultado, o qual
+tem a mesma representação do objeto recebedor.
+
+%The \code{MapStruct} class is parameterized with a type of keys
+%\code{kt} and a type of values \code{vt}. It
+%specifies an abstract type \code{Map} and an abstract value
+%\code{empty}, which represents empty maps.  Every implementation
+%\code{Map} needs to conform to that abstract type, which
+%extends the function type \code{kt => vt}
+%with four new
+%methods. The method \code{domain} yields a stream that enumerates the
+%map's domain, i.e. the set of keys that are mapped to non-null values.
+%The method \code{range} yields a stream that enumerates the function's
+%range, i.e.\ the values obtained by applying the function to arguments
+%in its domain.  The method
+%\code{extend} extends the map with a given key/value binding, whereas
+%\code{remove} removes a given key from the map's domain. Both
+%methods yield a new map value as result, which has the same
+%representation as the receiver object.
 
 \begin{figure}[t]
 \begin{lstlisting}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -69,7 +69,7 @@ objetos. Simplifica bastante o processamento de árvores XML.
 %  libraries and new domain specific languages.
 \item
 Sintaxe flexível e sistema de tipos habilitam a construção de avançadas 
-bibliotecas e um novo dom¿nio específico de linguagens.
+bibliotecas e um novo domínio específico de linguagens.
 %--------
 \end{itemize}
 
@@ -433,10 +433,15 @@ class MutBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   let empty = new Map(null, null)
 }
 \end{lstlisting}
+%--------
 \caption{\label{fig:impbintree}Side-effecting implementation of binary
 search trees}
+\caption{\label{fig:impbintree}Implementação com efeitos colaterais de
+árvores binárias de busca}
 \end{figure}
+%--------
 
+%--------
 The two versions of binary trees presented so far are {\em
 persistent}, in the sense that maps are values that cannot be changed
 by side effects. By contrast, in the next implementation of binary
@@ -448,6 +453,16 @@ to some savings in computing time and memory allocation, but care is
 required not to use the original tree after it has been modified by a
 side-effecting operation.
 
+As duas versões apresentadas de árvores binárias de fato são {\em
+persistentes}, no sentido que mapas são valores que não podem ser
+alterados através de efeitos colaterais. Em contraste, a próxima 
+implementação de árvores binárias, as implementações de \code{extend} e 
+\code{remove} têm um efeito sobre o estado de seus objetos recebedores.
+Isto corresponde ao modo como árvores binárias são geralmente implementadas
+em linguagens imperativas. A nova implementação pode 
+%--------
+
+%--------
 In this implementation, \code{value}, \code{l} and \code{r} are
 variables that can be affected by method calls.  The
 class \code{MutBinTree[kt, vt].Map} takes two instance parameters
@@ -456,15 +471,18 @@ which define the \code{key} value and the initial value of the
 value \code{empty}, which has \code{null} (signifying undefined) in
 both its key and value fields. Note that this value needs to be
 defined lazily using \code{let} since its definition involves the
-creation of a
-\code{Map} object,
+creation of a \code{Map} object,
 which accesses \code{empty} recursively as part of its initialization.
 All methods test first whether the current tree is empty using the
 reference equality operator \code{eq} (\sref{sec:class-object}).
+%--------
 
+%--------
 As a program using the \code{MapStruct} abstraction, consider a function
 which creates a map from strings to integers and then applies it to a
 key string:
+%--------
+
 \begin{lstlisting}
 def mapTest(mapImpl: => MapStruct[String, int]): int = {
   val map: mapImpl.Map = mapImpl.empty.extend("ab", 1).extend("bx", 3)

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -399,7 +399,6 @@ dinâmica que veio com o método sobrescrito.
 %pattern matching, since this way existing subclasses need not be
 %modified.
 
-% parei de revisar aqui - Vinicius
 Qual dos dois esquemas é preferível depende em grande parte de quais
 estensões do tipo são antecipadas. Se o tipo for mais tarde estendido
 com uma nova alternativa, é melhor manter os métodos em cada 
@@ -479,7 +478,7 @@ alterados através de efeitos colaterais. Em contraste, a próxima
 implementação de árvores binárias, as implementações de \code{extend} e 
 \code{remove} têm um efeito sobre o estado de seus objetos recebedores.
 Isto corresponde ao modo como árvores binárias são geralmente implementadas
-em linguagens imperativas. A nova implementação pode levar a alguma economia 
+em linguagens imperativas. A nova implementação pode levar a uma economia 
 de tempo computacional e alocação de memória, mas é preciso tomar cuidado
 para não usar a árvore original após sua modificação por efeito colateral.
 %--------
@@ -507,7 +506,7 @@ definem o valor de \code{key} e o valor inicial da variável \code{value}.
 precisa ser definido de modo lazy (preguiçoso) usando \code{let}, pois sua definição
 envolve a criação de um objeto \code{Map}, que acessa \code{empty} recursivamente como
 parte da sua inicialização. Todos os métodos primeiro testam se a árvore corrente é 
-vazia usando a referência ao operandor de igualdade \code{eq} (\sref{sec:class-object}).
+vazia usando a referência ao operador de igualdade \code{eq} (\sref{sec:class-object}).
 %--------
 
 %--------
@@ -591,6 +590,7 @@ comparação herdados referem-se, então, a esta implementação nos seus corpos
 %{\em mixin class}. The type of this template is the {\em compound
 %type} ``\code{Rational with Ord}''.
 
+% parei de revisar aqui - Vinicius
 A cláusula ``\code{Rational(d, d) with Ord}'' é uma instância da {\em
 composição mixin}. Descreve um template para um objeto que é compatível
 com ambos \code{Rational} e \code{Ord} e que contém todos os membros de 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -496,6 +496,17 @@ creation of a \code{Map} object,
 which accesses \code{empty} recursively as part of its initialization.
 All methods test first whether the current tree is empty using the
 reference equality operator \code{eq} (\sref{sec:class-object}).
+
+Nesta implementação, \code{value}, \code{l} e \code{r} são variáveis
+que podem ser afetadas por chamadas de métodos. A classe
+\code{MutBinTree[kt, vt].Map} leva dois parâmetros de instância que 
+definem o valor de \code{key} e o valor inicial da variável \code{value}.
+Árvores vazias são representadas por um valor \code{empty}, que tem \code{null} 
+(significando indefinido) em seus campos chave e valor. Observe que este valor
+precisa ser definido de modo lazy (preguiçoso) usando \code{let}, pois sua definição
+envolve a criação de um objeto \code{Map}, que acessa \code{empty} recursivamente como
+parte da sua inicialização. Todos os métodos primeiro testam se a árvore corrente é 
+vazia usando a referência ao operandor de igualdade \code{eq} (\sref{sec:class-object}).
 %--------
 
 %--------

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -8,7 +8,7 @@
 \usepackage[utf8]{inputenc}
 \renewcommand{\todo}[1]{}
 
-\renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile}
+\renewcommand{\translatedby}{Traduzido por: Vinicius Miana e Antonio Basile éáãção}
 
 
 \ifpdf

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -398,8 +398,15 @@ preferable to keep only one implementation of methods and to rely on
 pattern matching, since this way existing subclasses need not be
 modified.
 
+
 Qual dos dois esquemas é preferível depende em grande parte de quais
-estensões do tipo são antecipadas. Se o tipo é
+estensões do tipo são antecipadas. Se o tipo for mais tarde estendido
+com uma nova alternativa, é melhor manter os métodos em cada 
+alternativa, do modo como foi feito em \code{OOBinTree}. Por outro 
+lado, se o tipo for estendido com métodos adicionais, então é preferível
+manter apenas uma implementação dos métodos e confiar no casamento de
+padrões, pois desta forma subclasses existentes não precisarão ser
+modificadas. 
 %--------
 
 \begin{figure}

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -712,30 +712,41 @@ def sumLeaves(t: Tree): int = t match {
 }
 \end{lstlisting}
 
+%-----------
+%The function \code{sumLeaves} sums up all the integer values in the
+%leaves of a given tree \code{t}. It is is implemented by calling the
+%\code{match} method of \code{t} with a {\em choice expression} as
+%argument (\code{match} is a predefined method in class \code{Object}).
+%The choice expression consists of two cases which botrelate a pattern 
+%with an expression. The pattern of the first case,
+%\code{Branch(l, r)} matches all instances of class \code{Branch}
+%and binds the {\em pattern variables} \code{l} and \code{r} to the
+%constructor arguments, i.e.\ the left and right subtrees of the
+%branch.  Pattern variables always start with a lower case letter; to
+%avoid ambiguities, constructors in patterns should start with an upper
+%case letter.
 
-The function \code{sumLeaves} sums up all the integer values in the
-leaves of a given tree \code{t}. It is is implemented by calling the
-\code{match} method of \code{t} with a {\em choice expression} as
-argument (\code{match} is a predefined method in class \code{Object}).
-The choice expression consists of two cases which botrelate a pattern with an expression. The pattern of the first case,
-\code{Branch(l, r)} matches all instances of class \code{Branch}
-and binds the {\em pattern variables} \code{l} and \code{r} to the
-constructor arguments, i.e.\ the left and right subtrees of the
-branch.  Pattern variables always start with a lower case letter; to
-avoid ambiguities, constructors in patterns should start with an upper
-case letter.
+A função \code{sumLeaves} soma todos os valores inteiros das folhas de
+uma dada árvore \code{t}. É implementada chamando o método \code{match}
+de \code{t}. com uma {\em expressão escolhida} como argumento (\code{match}
+é um método prédefinido dentro da classe \code{Object}). A expressão 
+escolhida consiste de dois cases que 
+%-----------
 
-The effect of the choice expression is to select the first alternative
-whose pattern matches the given select value, and to evaluate the body
-of this alternative in a context where pattern variables are bound to
-corresponding parts of the selector. For instance, the application
-\code{sumLeaves(tree1)} would select the first alternative with the
-\code{Branch(l,r)} pattern, and would evaluate the expression
-\code{sumLeaves(l) + sumLeaves(r)} with bindings
-\begin{lstlisting}
-l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
-\end{lstlisting}
-As another example, consider the following class
+%-----------
+%The effect of the choice expression is to select the first alternative
+%whose pattern matches the given select value, and to evaluate the body
+%of this alternative in a context where pattern variables are bound to
+%corresponding parts of the selector. For instance, the application
+%\code{sumLeaves(tree1)} would select the first alternative with the
+%\code{Branch(l,r)} pattern, and would evaluate the expression
+%\code{sumLeaves(l) + sumLeaves(r)} with bindings
+%\begin{lstlisting}
+%l = Branch(Leaf(1), Leaf(2)), r = Branch(Leaf(3), Leaf(4)).
+%\end{lstlisting}
+%As another example, consider the following class
+%-----------
+
 \begin{lstlisting}
 abstract final class Option[+a];
 case object None extends Option[All];

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -101,7 +101,7 @@ salientam alguns dos aspectos que tornam Scala interessante. Os
 capítulos seguintes introduzem as construções da linguagem Scala de um
 modo mais completo, começando com expressões e funções simples, e 
 desenvolvendo até objetos e classes, listas e streams, estado 
-mutável, reconhecimento de padrões até exemplos mais completos que mostram
+mutável, casamento de padrões até exemplos mais completos que mostram
 interessantes técnicas de programação. A presente exposição informal
 pretende ser complementada por um Manual de Referência da Linguagem Scala, que
 especificarão Scala de modo mais detalhado e preciso. 
@@ -180,17 +180,17 @@ de uma classe {\em MapStruct}.
 A classe \code{MapStruct} é parametrizada com um tipo de chaves
 \code{kt} e um tipo de valores \code{vt}. Também especifica um tipo
 abstrato \code{Map} e um valor abstrato \code{empty} que serve para
-denotar mapas vazios. Cada implementação de \code{Map} precisa
-% parei de revisar aqui - Vinicius
-estar de acordo com aquele tipo abstrato, o qual estende a função tipo
+representar mapas vazios. 
+Toda implementação de \code{Map} precisa atender à interface definida
+por este tipo abstrato, que por sua vez, estende a função do tipo
  \code{kt => vt} com quatro novos métodos. O método \code{domain}
-herda um stream que enumera o domínio do mapa, ou seja, o conjunto
+retorna um stream que enumera o domínio do mapa, ou seja, o conjunto
 de chaves que são mapeadas com valores não nulos. O método 
-\code{range} herda um stream que enumera a imagem da função, ou seja,
+\code{range} retorna um stream que enumera a imagem da função, ou seja,
 os valores obtidos pela aplicação dos argumentos da função no seu
-domínio. O método \code{extend} estende o mapa com uma dada ligação
+domínio. O método \code{extend} retorna o mapa acrescido de um novo par 
 chave/valor, onde \code{remove} remove uma dada chave do mapa do domínio.
-Ambos os métodos herdam um novo mapa de valores como resultado, o qual
+Ambos os métodos retornam um novo mapa de valores como resultado, o qual
 tem a mesma representação do objeto recebedor.
 %--------
 
@@ -302,9 +302,9 @@ que é definido como uma aplicação pós-fixa da função na classe \code{Objec
 %are constructed lazily.
 
 As funções \code{domain} e \code{range} retornam seus resultados como
-listas construídas de forma ``preguiçoza'' (lazy-lists). A classe \code{Stream}
+listas construídas de forma ``preguiçosa'' (lazy-lists). A classe \code{Stream}
 é um ``apelido'' (alias) de \code{List} que pode ser usado para indicar
-o fato que seus valores foram construídos de modo preguiçozo.
+o fato que seus valores foram construídos de modo preguiçoso.
 %--------
 
 
@@ -365,7 +365,7 @@ search trees}
 
 A segunda implementação dos mapas é dada na
 Figura~\ref{fig:oobintree}.  A classe \code{OOBinTree} implementa o 
-tipo \code{Map} com um módulo \code{empty} e uma classe \code{Node},
+tipo \code{Map} com um módulo \code{empty} e uma classe \code{Node}
 que define o comportamento de árvores vazias e não-vazias, respectivamente.
 %--------
 
@@ -380,10 +380,10 @@ que define o comportamento de árvores vazias e não-vazias, respectivamente.
 %dynamic binding that comes with method overriding.
 
 Observe a estrutura de aninhamento diferente de \code{AlgBinTree} e
-\code{OOBinTree}. No primeiro, todos os métodos são parte da classe base
+\code{OOBinTree}. Na primeira, todos os métodos são parte da classe base
 \code{Map}. O comportamento distinto para árvores vazias e não vazias 
-é expresso usando um casamento de padrões na própria árvore. No 
-último, cada subclasse do \code{Map} define seu próprio conjunto de 
+é expresso usando um casamento de padrões na própria árvore. Na segunda,
+ cada subclasse do \code{Map} define seu próprio conjunto de 
 métodos, que sobrescrevem os métodos da classe base. O casamento de 
 padrões da implementação algébrica foi substituído pela ligação 
 dinâmica que veio com o método sobrescrito.
@@ -399,7 +399,7 @@ dinâmica que veio com o método sobrescrito.
 %pattern matching, since this way existing subclasses need not be
 %modified.
 
-
+% parei de revisar aqui - Vinicius
 Qual dos dois esquemas é preferível depende em grande parte de quais
 estensões do tipo são antecipadas. Se o tipo for mais tarde estendido
 com uma nova alternativa, é melhor manter os métodos em cada 

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -69,7 +69,7 @@ Ao mesmo tempo, Scala é compatível com Java. Bibliotecas Java e frameworks
 podem ser usados sem código extra ou declarações adicionais.
 
 Este documento introduz Scala de um modo informal, através de uma sequência
-de examplos.
+de exemplos.
 
 
 %Chapters~\ref{chap:example-one} and \ref{chap:example-auction}
@@ -224,17 +224,29 @@ class AlgBinTree[kt extends Ord, vt] extends MapStruct[kt, vt] {
   def empty: Map = Empty
 }
 \end{lstlisting}
-\caption{\label{fig:algbintree}Algebraic implementation of binary
-search trees}
+\caption{\label{fig:algbintree}Implementação algébrica de árvores 
+binárias de busca}
+%\caption{\label{fig:algbintree}Algebraic implementation of binary
+%search trees}
 \end{figure}
-We now present three implementations of \code{Map}, which are all
-based on binary search trees. The \code{apply} method of a map is
-implemented in each case by the usual search function over binary
-trees, which compares a given key with the key stored in the topmost
-tree node, and depending on the result of the comparison, searches the
-left or the right hand sub-tree. The type of keys must implement the
-\code{Ord} class, which contains comparison methods
-(see Chapter~\ref{chap:classes} for a definition of class \code{Ord}).
+%We now present three implementations of \code{Map}, which are all
+%based on binary search trees. The \code{apply} method of a map is
+%implemented in each case by the usual search function over binary
+%trees, which compares a given key with the key stored in the topmost
+%tree node, and depending on the result of the comparison, searches the
+%left or the right hand sub-tree. The type of keys must implement the
+%\code{Ord} class, which contains comparison methods
+%(see Chapter~\ref{chap:classes} for a definition of class \code{Ord}).
+
+Nós agora apresentaremos três implementações de \code{Map}, todas elas
+baseadas em árvores binárias de busca. O método \code{apply} de um mapa é
+implementado em cada caso pela função de busca usual sobre árvores binárias, 
+que comparam uma dada chave com a chave guardada no mais alto nó da árvore, 
+e dependendo do resultado da comparação, segue a busca por sua sub-árvore 
+esquerda ou direita. O tipo das chaves deve implementar a classe \code{Ord},
+que contém métodos de comparação (ver Capítulo~\ref{chap:classes} para uma
+definição da classe \code{Ord}).
+
 
 The first implementation, \code{AlgBinTree}, is given in
 Figure~\ref{fig:algbintree}. It represents a map with a

--- a/documentation/src/reference/pt-BR/ScalaByExample.tex
+++ b/documentation/src/reference/pt-BR/ScalaByExample.tex
@@ -478,7 +478,9 @@ alterados através de efeitos colaterais. Em contraste, a próxima
 implementação de árvores binárias, as implementações de \code{extend} e 
 \code{remove} têm um efeito sobre o estado de seus objetos recebedores.
 Isto corresponde ao modo como árvores binárias são geralmente implementadas
-em linguagens imperativas. A nova implementação pode 
+em linguagens imperativas. A nova implementação pode levar a alguma economia 
+de tempo computacional e alocação de memória, mas é preciso tomar cuidado
+para não usar a árvore original após sua modificação por efeito colateral.
 %--------
 
 %--------

--- a/documentation/src/tutorial/ScalaTutorial.tex
+++ b/documentation/src/tutorial/ScalaTutorial.tex
@@ -19,10 +19,10 @@
     }
 \fi
 
-\renewcommand{\doctitle}{A Scala Tutorial \\
-\large  for Java programmers \ }
+\renewcommand{\doctitle}{A Scala Tutorial \\  for Java programmers \\ 
+\Large }
 \renewcommand{\docsubtitle}{Version 1.3}
-\renewcommand{\docauthor}{Michel Schinz, Philipp Haller\\[65mm]}
+\renewcommand{\docauthor}{Michel Schinz, Philipp Haller\\[53mm]}
 
 \newcommand{\langname}[1]{#1\xspace}
 


### PR DESCRIPTION
This pull contains:
1) A revised build to properly acess the bibliography in the localized scala-by-example build
2) A translated by optional command in scaladoc.sty
3) Adjusts in covers to keep looking nice due to change in scaladoc.sty
4) Fix of typo in build documentation structure
5) Fix of typo in English ScalaByExample book
6) Translation of chapters 1->8 and 12->15 to Brazilian Portuguese.
Hope to get with translation of  9,10, 11, 16 and 17 soon.
