### PR TITLE
replaced uses of deprecated variable "last-command-char"

### DIFF
--- a/tool-support/src/emacs/scala-mode-feature-electric.el
+++ b/tool-support/src/emacs/scala-mode-feature-electric.el
@@ -134,7 +134,7 @@ closing bracket or not."
 
 (defun scala-mode-feature-electric-is-last-command-char-expandable-punct-p()
   (or (memq 'all scala-mode-feature:electric-expand-delimiters-list)
-      (memq last-command-char scala-mode-feature:electric-expand-delimiters-list)))
+      (memq last-command-event scala-mode-feature:electric-expand-delimiters-list)))
 
 (defun scala-mode-feature-electric-curlies(arg)
   (interactive "P")
@@ -159,7 +159,7 @@ closing bracket or not."
   (and (scala-mode-feature-electric-is-last-command-char-expandable-punct-p)
        (scala-mode-feature-electric-code-at-point-p)
        (save-excursion
-         (insert (cdr (assoc last-command-char
+         (insert (cdr (assoc last-command-event
                              scala-mode-feature-electric-matching-delimeter-alist))))))
 
 (defun scala-mode-feature-electric-install ()


### PR DESCRIPTION
`last-command-char` is long obsolete and recently was removed in GNU Emacs trunk, which broke "scala-mode-feature-electric.el".

From emacs documentation:

```
last-command-char is a variable defined in `subr.el'.

  This variable is an alias for `last-command-event'.
  This variable is obsolete since at least 19.34;
  use `last-command-event' instead.

Documentation:
Last input event that was part of a command.
```

This patch simply replaces uses of `last-command-char` with `last-command-event`.
