### PR TITLE
sane vim indentation defaults for new files

### DIFF
--- a/tool-support/src/vim/plugin/31-create-scala.vim
+++ b/tool-support/src/vim/plugin/31-create-scala.vim
@@ -45,8 +45,8 @@ function! MakeScalaFile()
     "norm G
     "call append(".", "} /// end of " . class)
     
-    call append(".", "// vim: set ts=4 sw=4 et:")
-    call append(".", "")
+    "call append(".", "// vim: set ts=2 sw=2 et:")
+    "call append(".", "")
     
 endfunction
 


### PR DESCRIPTION
Currently vim puts a modeline to new scala files and sets `ts=4 sw=4` which conflicts with the standard 2 space indentation as also discussed in #5 and #6. This is probably just forgotton like this. I also commented this out since vim already sets these values in the indent file and modeline templates can (and imo should) always go to personal vimrc files instead.
