### PR TITLE
please pull: updated install instructions for gedit syntax coloring file

### DIFF
--- a/tool-support/src/gedit/README
+++ b/tool-support/src/gedit/README
@@ -12,7 +12,7 @@ The latest revisions of the GTK language specifications are available from:
 
 Copy the file "scala.lang" to the following location:
 
-   ~/.gnome2/gtksourceview-3.0/language-specs/
+   ~/.local/share/gtksourceview-3.0/language-specs/
 
 or alternatively to the location:
 


### PR DESCRIPTION
Please pull this change into the scala-dist repo.  I've updated the README for the gedit syntax coloring file to use a path that works for the current version of gedit.
