### PR TITLE
please pull: updated syntax highlighting file for gedit

### DIFF
--- a/tool-support/src/gedit/scala.lang
+++ b/tool-support/src/gedit/scala.lang
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
  Usage:
- 1.  Place this file in ~/.gnome2/gtksourceview-1.0/language-specs/scala.lang
+ 1.  Place this file in ~/.local/share/gtksourceview-3.0/language-specs/
  2.  Create a /usr/share/mime/packages/scala-mime.xml with this text:
      <?xml version="1.0" encoding="UTF-8"?>
      <mime-info xmlns='http://www.freedesktop.org/standards/shared-mime-info'>
@@ -15,7 +15,7 @@
 <language id="scala" _name="Scala" version="2.0" _section="Sources">
 
   <metadata>
-    <property name="mimetypes">text/plain;text/x-scala</property>
+    <property name="mimetypes">text/x-scala</property>
     <property name="globs">*.scala</property>
     <property name="line-comment-start">//</property>
     <property name="block-comment-start">/*</property>


### PR DESCRIPTION
text/plain shouldn't appear in this file, since that causes
gedit to apply Scala highlighting to plain text files.
I also updated the install path in the comment at the top of the
file.
