### PR TITLE
Simplify finding the distribution to release.

### DIFF
--- a/project/scaladistrofinder.scala
+++ b/project/scaladistrofinder.scala
@@ -12,83 +12,65 @@ trait ScalaDistroDeps {
 }
 
 object ScalaDistroFinder {
-  val jenkinsUrl = SettingKey[String]("typesafe-build-server-url")
-  val scalaDistJenkinsUrl = SettingKey[String]("scala-dist-jenkins-url")
-  val scalaDistZipFile = SettingKey[File]("scala-dist-zip-file")
+  // TODO - Use Ivy or something to pull these in...
+  def modules = Map(
+    "lib/typesafe-config.jar"        -> "https://oss.sonatype.org/content/repositories/releases/com/typesafe/config/1.0.0/config-1.0.0.jar",
+    "lib/akka-actors.jar"            -> "https://oss.sonatype.org/content/repositories/releases/com/typesafe/akka/akka-actor_2.10/2.1.0/akka-actor_2.10-2.1.0.jar",
+    "lib/scala-actors-migration.jar" -> "https://oss.sonatype.org/content/repositories/releases/org/scala-lang/scala-actors-migration_2.10/1.0.0/scala-actors-migration_2.10-1.0.0.jar"
+  )
 
-  val scalaDistZipLocation = SettingKey[File]("scala-dist-zip-location")  
-  val scalaDistDir = SettingKey[File]("scala-dist-dir", "Resolves the Scala distribution and opens it into the desired location.")
-
-  val scalaDistChecked = AttributeKey[Boolean]("scala-dist-location-checked")
+  val scalaDistDir     = SettingKey[File]("scala-dist-dir", "Resolves the Scala distribution and opens it into the desired location.")
   val scalaDistVersion = SettingKey[String]("scala-dist-version")
 
-
-  def scalaDistInstance: Setting[_] = 
-    scalaInstance <<=  (scalaDistDir, appConfiguration) map { (dir, app) => 
-      val jars = (dir / "lib" ** "*.jar").get
-      val lib = jars find (_.getName == "scala-library.jar") getOrElse sys.error("Could not find scala library in distro.")
-      val comp = jars find (_.getName == "scala-compiler.jar") getOrElse sys.error("Could not find scala library in distro.")
+  def scalaDistInstance: Setting[_] =
+    scalaInstance <<=  (scalaDistDir, appConfiguration) map { (scalaDistDir, app) =>
+      val jars      = (scalaDistDir / "lib" ** "*.jar").get
+      val lib       = jars find (_.getName == "scala-library.jar")  getOrElse sys.error("Could not find scala library in distro.")
+      val comp      = jars find (_.getName == "scala-compiler.jar") getOrElse sys.error("Could not find scala library in distro.")
       val extraJars = jars filterNot { f => (f.getName == "scala-library.jar") || (f.getName == "scala-compiler.jar") }
       ScalaInstance(lib, comp, app.provider.scalaProvider.launcher, extraJars:_*)
     }
 
-  def findDistroSettings: Seq[Setting[_]] = Seq(
-    jenkinsUrl := "http://10.0.1.211/",
-    scalaDistJenkinsUrl <<= jenkinsUrl apply (_ + "job/scala-release-main/ws/dists/latest/*zip*/latest.zip"),
-    commands += distCheckCommand,
-    onLoad in Global <<= (onLoad in Global) ?? idFun[State],
-    onLoad in Global <<= (onLoad in Global) apply ( _ andThen ("scala-dist-check" :: _))    
-  )
-
-  def extractDistroSettings: Seq[Setting[_]] = Seq(
-     // Pulling latest distro code. TODO - something useful....
-    scalaDistZipLocation <<= baseDirectory apply (_ / "target" / "dist"),
-    scalaDistDir <<= scalaDistZipLocation apply findScalaDistro
-  )
-
   def useDistroSettings: Seq[Setting[_]] = Seq(
+    scalaDistDir <<= baseDirectory apply (_ / "target" / "dist" / "latest"),
     scalaDistInstance,
-    scalaDistVersion <<= (scalaDistDir, version) apply { (dir, v) =>
-      Versioning.getScalaVersionOr(dir / "lib" / "scala-library.jar", v)
-    }
+    scalaDistVersion <<= (scalaDistDir, version) apply { (scalaDistDir, v) =>
+      Versioning.getScalaVersionOr(scalaDistDir / "lib" / "scala-library.jar", v)
+    },
+    commands += distFinishCommand
   )
 
-  def allSettings: Seq[Setting[_]] = findDistroSettings ++ extractDistroSettings ++ useDistroSettings
-  def rootSettings: Seq[Setting[_]] = useDistroSettings ++ extractDistroSettings
-
-
-
-  def distCheckCommand = Command.command("scala-dist-check") { (state: State) =>
+  def distFinishCommand = Command.command("scala-dist-finish") { (state: State) =>
     val extracted = Project.extract(state)
-    import extracted._ 
-    val distDir = extracted get scalaDistZipLocation
-    val marker = distDir / "dist.exploded"
-    if(marker.exists) state
-    else {
-      // TODO - Don't run if already run.
-      val targetdir = extracted get target
-      val scalaDistZip = targetdir / "tmp" / "scala-dist.zip"
-      val downloadUrl = extracted get scalaDistJenkinsUrl
-      if(!scalaDistZip.exists) {
-        System.err.println("")
-        System.err.println("[error]: Could not find: " + scalaDistZip.getAbsolutePath)
-        System.err.println("")
-        System.err.println("\tYou can build a scala-dist.zip from a scala project, or this build")
-        System.err.println("\twill attempt to download it from the latest jenkins build:")
-        System.err.println("\t" + downloadUrl)
-        System.err.println()
-      }
-      // We need ot extract the dist *now* so we have settings available to our build....
-      val zip = findOrDownloadZipFile(extracted get scalaDistJenkinsUrl, targetdir)
-      extractAndCleanScalaDistro(zip, distDir)
-      // Reload settings
-      val newStructure = Load.reapply(session.original, structure)
-      Project.setProject(session, newStructure, state).put(scalaDistChecked, true)
-    }
+    finishScalaDistro(extracted get scalaDistDir)
+    state
   }
 
-  def findOrDownloadZipFile(uri: String, dir: File): File =
-   download(uri, dir / "tmp" / "scala-dist.zip")
+  def allSettings: Seq[Setting[_]]  = useDistroSettings
+  def rootSettings: Seq[Setting[_]] = useDistroSettings
+
+  def finishScalaDistro(scalaDistDir: File): Unit = {
+    removeScalacheck(scalaDistDir)
+    obtainModules(scalaDistDir)
+
+    if(!(System.getProperty("os.name").toLowerCase contains "windows"))
+      fixBatFiles(scalaDistDir)
+  }
+
+  def removeScalacheck(scalaDistDir: File): Unit =
+    for {
+       f <- (scalaDistDir / "lib" ** "*.jar").get
+       _ = println("Checking: " + f.getName)
+       if f.getName contains "scalacheck"
+       _ = println("Removing " + f.getAbsolutePath)
+    } IO.delete(f)
+
+  def obtainModules(scalaDistDir: File): Unit = {
+    for {
+      (path, uri) <- modules
+      val file = scalaDistDir / path
+    } download(uri, file)
+  }
 
   def download(uri: String, to: File): File = {
     if(!to.exists) {
@@ -101,58 +83,11 @@ object ScalaDistroFinder {
     to
   }
 
-  def cleanScalaDistro(dir: File): Unit = {
-    fixBatFiles(dir)
-    removeScalacheck(dir)
-    obtainModules(dir)
-  }
-
-  def removeScalacheck(dir: File): Unit = 
+  def fixBatFiles(scalaDistDir: File): Unit =
     for {
-       f <- (dir / "lib" ** "*.jar").get
-       _ = println("Checking: " + f.getName)
-       if f.getName contains "scalacheck"
-       _ = println("Removing " + f.getAbsolutePath)
-    } IO.delete(f)
-
-  // TODO - Use Ivy or something to pull these in...
-  def modules = Map(
-    "lib/akka-actors.jar"            -> "https://oss.sonatype.org/content/repositories/releases/com/typesafe/akka/akka-actor_2.10/2.1.0/akka-actor_2.10-2.1.0.jar",
-    "lib/typesafe-config.jar"        -> "https://oss.sonatype.org/content/repositories/releases/com/typesafe/config/1.0.0/config-1.0.0.jar",
-    "lib/scala-actors-migration.jar" -> "https://oss.sonatype.org/content/repositories/releases/org/scala-lang/scala-actors-migration_2.10/1.0.0/scala-actors-migration_2.10-1.0.0.jar"
-  )
-    
-  def obtainModules(dir: File): Unit = {
-    for {
-      (path, uri) <- modules
-      val file = dir / path
-    } download(uri, file)
-  }
-
-  def fixBatFiles(dir: File): Unit =
-    for {
-     f <- (dir ** "*.bat").get
-    } Process(Seq("unix2dos", f.getAbsolutePath), None).! match {
+     f <- (scalaDistDir ** "*.bat").get
+    } Process(Seq("todos", f.getAbsolutePath), None).! match {
       case 0 => ()
-      case n => sys.error("Could not unix2dos: " + f.getAbsolutePath + ".  Exit code: " + n)
+      case n => sys.error("Could not execute todos: " + f.getAbsolutePath + ".  Exit code: " + n)
     }
-
-  // Attempts to find the correct scala distribution directory...
-  def findScalaDistro(dir: File): File = 
-    IO listFiles dir  find (_.isDirectory) getOrElse dir
-
-  def extractAndCleanScalaDistro(zip: File, dir: File): File = {
-    if(!dir.exists) dir.mkdirs()
-    val marker = dir / "dist.exploded"
-    if(!marker.exists) {
-      // Unzip distro to local filesystem.
-      IO.unzip(zip, dir)   
-      // TODO - Fix cleaning so it works on windows
-      if(!(System.getProperty("os.name").toLowerCase contains "windows")) {
-        cleanScalaDistro(findScalaDistro(dir))
-      }
-      IO.touch(marker)
-    }
-    IO listFiles dir  find (_.isDirectory) getOrElse error("could not find scala distro from " + zip.getAbsolutePath)
-  }
 }


### PR DESCRIPTION
The scala-dist-{unix, windows} jobs are run downstream from scala-dist.
The latter builds a distribution once, which is then packaged for the
two platforms. The distribution is put in the target/dist/tmp by the
Jenkins job so we don't have pull crazy tricks in the SBT build.
