### PR TITLE
[Branch changed to 2.10.x] Fixed Emacs scala-mode indent (nil bug)

### DIFF
--- a/tool-support/src/emacs/scala-mode-indent.el
+++ b/tool-support/src/emacs/scala-mode-indent.el
@@ -161,8 +161,8 @@
   (save-excursion
     (scala-backward-ignorable)
     ;; only '{' or '(' can start a lambda
-    (and (or (= (char-before) ?\{)
-             (= (char-before) ?\())
+    (and (or (= (preceding-char) ?\{)
+             (= (preceding-char) ?\())
          ;; jump over sexp untill we see '=>' or something
          ;; that does not belong. TODO: the real pattern
          ;; that we would like to skip over is id: Type


### PR DESCRIPTION
Currently, the Emacs scala-mode tool has bugs on my Emacs 23.3 in Ubuntu 12.04. I am using Evil, the Vi layer on top of Emacs, but the bug happens even in normal Emacs mode. For me, this code bugs out:

``` scala
object Main {
  def fibs(x : Int) = {
    stuff
  }
}
```

On the bracket closing `fibs`, if I type a newline, it would not indent and throw a `(wrong-type-argument number-or-marker-p nil)` error. Strangely, though, if I simply add a newline at the beginning of the entire file, there's no bug at all.

I went through the backtrace and found that it's the `(char-before)` at line 164 in scala-lambda-p in scala-mode-indent.el that was the problem. `(char-before)` returns nil if the pointer is out of range. I'm not sure why this would happen, but I've made a simple fix and it seems to work for me. Simply replace `(char-before)` with `(preceding-char)` on both lines 164 and 165. Someone should double-check that the bug occurs for them too and that the solution doesn't change anything, but otherwise this is an easy fix.
