### PR TITLE
Refined exuberant-ctags extension for Scala

### DIFF
--- a/tool-support/src/emacs/contrib/README
+++ b/tool-support/src/emacs/contrib/README
@@ -13,11 +13,13 @@ Scala
     o  objects 
     t  traits 
     m  case-classes 
+    M  case-objects
     a  abstract-classes 
     f  functions 
     V  values 
     v  variables 
     T  types 
+    p  packages
 
 The default in the scala mode is to parse scala files for all the
 above kinds to produce tags. This can give a rather huge amount of

--- a/tool-support/src/emacs/contrib/dot-ctags
+++ b/tool-support/src/emacs/contrib/dot-ctags
@@ -6,8 +6,8 @@
 --regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<case\s+class\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/m,case-classes/e
 --regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<case\s+object\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/M,case-objects/e
 --regex-scala=/^\s*.*\<abstract\>.*\<class\s+(\<[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\>)/\1/a,abstract-classes/e
---regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<def\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/f,functions/e
---regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<val\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/V,values/e
---regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<var\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/v,variables/e
---regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<type\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/T,types/e
+--regex-scala=/^\s*((\<(override|abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<def\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/f,functions/e
+--regex-scala=/^\s*((\<(override|abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<val\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/V,values/e
+--regex-scala=/^\s*((\<(override|abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<var\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/v,variables/e
+--regex-scala=/^\s*((\<(override|abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<type\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/T,types/e
 --regex-scala=/^\s*\<package\>\s+([[:alpha:]][[:alnum:][:punct:]]*)/\1/p,packages/e

--- a/tool-support/src/emacs/contrib/dot-ctags
+++ b/tool-support/src/emacs/contrib/dot-ctags
@@ -1,11 +1,13 @@
 --langdef=Scala
 --langmap=Scala:.scala
---regex-Scala=/^[^\*\/]*class[ \t]*([a-zA-Z0-9_]+)/\1/c,classes/
---regex-Scala=/^[^\*\/]*object[ \t]*([a-zA-Z0-9_]+)/\1/o,objects/
---regex-scala=/^[^\*\/]*trait[ \t]*([a-zA-Z0-9_]+)/\1/t,traits/
---regex-Scala=/^[^\*\/]*case[ \t]*class[ \t]*([a-zA-Z0-9_]+)/\1/m,case-classes/
---regex-Scala=/^[^\*\/]*abstract[ \t]*class[ \t]*([a-zA-Z0-9_]+)/\1/a,abstract-classes/
---regex-Scala=/^[^\*\/]*def[ \t]*([a-zA-Z0-9_]+)[ \t]*.*[:=]/\1/f,functions/
---regex-Scala=/^[^\*\/]*val[ \t]*([a-zA-Z0-9_]+)[ \t]*[:=]/\1/V,values/
---regex-Scala=/^[^\*\/]*var[ \t]*([a-zA-Z0-9_]+)[ \t]*[:=]/\1/v,variables/
---regex-Scala=/^[^\*\/]*type[ \t]*([a-zA-Z0-9_]+)[ \t]*[\[<>=]/\1/T,types/
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<class\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/c,classes/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<object\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/o,objects/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<trait\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/t,traits/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<case\s+class\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/m,case-classes/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<case\s+object\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/M,case-objects/e
+--regex-scala=/^\s*.*\<abstract\>.*\<class\s+(\<[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\>)/\1/a,abstract-classes/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<def\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/f,functions/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<val\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/V,values/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<var\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/v,variables/e
+--regex-scala=/^\s*((\<(abstract|final|sealed|implicit|lazy|private|protected)\>|(\[[[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?\]))\s*)*\<type\s+([[:alpha:]][[:alnum:]]*(_[[:alnum:][:punct:]])?)/\6/T,types/e
+--regex-scala=/^\s*\<package\>\s+([[:alpha:]][[:alnum:][:punct:]]*)/\1/p,packages/e


### PR DESCRIPTION
The original ctags extension performs poorly when locating various tags, for example, here are some bad cases:
- `evaluator`: the `val` substring in `evaluator` is parsed as the keyword `val` and a value tag named `uator` is generated.
- `private[this] class T`: (case) classes/(case) objects/values/variables with access qualifiers are not recognized.
- `notaclass T`: generates a wrong class tag `T`

The new extension refined all `--regex-scala` options to locate tags much more accurately, and added two new tag types, namely `case-objects` and `packages`.
