### PR TITLE
[emacs] Fix malformed header line

### DIFF
--- a/tool-support/src/emacs/scala-mode.el
+++ b/tool-support/src/emacs/scala-mode.el
@@ -1,4 +1,4 @@
-;;; scala-mode.el - Major mode for editing Scala code.
+;;; scala-mode.el --- Major mode for editing Scala code.
 
 ;; Copyright (C) 2009-2011 Scala Dev Team at EPFL
 ;; Authors: See AUTHORS file


### PR DESCRIPTION
package.el requires a specific format for source files.

This subtle error therefore prevented MELPA from extracting a description when building packages of scala-mode.
