### PR TITLE
Include doc/ subdir as-is, including doc/licenses/

### DIFF
--- a/project/scalainstaller.scala
+++ b/project/scalainstaller.scala
@@ -114,25 +114,19 @@ trait ScalaInstallerBuild extends Build with Versioning with ExamplesBuild with 
     mappings in Universal <++= scalaDistDir map { dir => (dir / "src").*** --- dir x relativeTo(dir) },
     mappings in Universal <++= scalaDistDir map { dir => (dir / "misc").*** --- dir x relativeTo(dir) },
     mappings in Universal <++= scalaDistDir map { dir => (dir / "man").*** --- dir x relativeTo(dir) },
-    mappings in Universal <++= scalaDistDir map { dir => 
-      val toolshtmldir = dir / "doc" / "scala-devel-docs" / "tools"
-      for( (file,path) <- (toolshtmldir).*** --- toolshtmldir x relativeTo(toolshtmldir))
-      yield file -> ("doc/tools/"+path)
-    },
-    mappings in Universal <++= scalaDistDir map { dir => 
-      Seq(dir / "doc" / "LICENSE" -> "doc/LICENSE",
-          dir / "doc" / "README" -> "doc/README")
-    },
-    mappings in UniversalDocs <++= scalaDistDir map { dir => 
-      val ddir = dir / "doc" / "scala-devel-docs" / "api"
-      ddir.*** --- ddir x relativeTo(ddir)
-    },
+    mappings in Universal <++= scalaDistDir map { dir => (dir / "doc").*** --- dir x relativeTo(dir) },
     mappings in Universal <++= scalaSource in examples in Compile map { dir => 
       for {
         (file, name) <- (dir.*** --- dir x relativeTo(dir))
       } yield file -> ("examples/" + name)
     },
-    name in UniversalDocs <<= version apply ("scala-docs-"+_)
+
+    // Universal docs
+    name in UniversalDocs <<= version apply ("scala-docs-"+_),
+    mappings in UniversalDocs <++= scalaDistDir map { dir =>
+      val ddir = dir / "api"
+      ddir.*** --- ddir x relativeTo(ddir)
+    }
   )
   settings(addUniversalToDistro:_*)
   settings(addDocsToDistro:_*)

--- a/project/scalawindows.scala
+++ b/project/scalawindows.scala
@@ -25,7 +25,8 @@ object ScalaWindowsPackaging {
     val docdir = dir / "doc"
     val (readmeId, readmeXml) = generateComponentsAndDirectoryXml(docdir / "README")
     val (licenseId, licenseXml) = generateComponentsAndDirectoryXml(docdir / "LICENSE")
-    val develdocdir = docdir / "scala-devel-docs"
+    val (licensesIds, licensesDirXml) = generateComponentsAndDirectoryXml(docdir / "licenses", "licenses_")
+    val develdocdir = dir / "api"
     val (apiIds, apiDirXml) = generateComponentsAndDirectoryXml(develdocdir / "api", "api_")
     val (exampleIds, exampleDirXml) = generateComponentsAndDirectoryXml(examplesDir, "ex_")
     val (tooldocIds, tooldocDirXml) = generateComponentsAndDirectoryXml(develdocdir / "tools", "tools_")
@@ -64,6 +65,7 @@ object ScalaWindowsPackaging {
             <Directory Id='DOCDIRECTORY' Name='doc'>
               {readmeXml}
               {licenseXml}
+              {licensesDirXml}
               {apiDirXml}
               {tooldocDirXml}
             </Directory>
@@ -87,7 +89,7 @@ object ScalaWindowsPackaging {
       <Feature Id='Complete' Title='The Scala Programming Language' Description='The windows installation of the Scala Programming Language'
          Display='expand' Level='1' ConfigurableDirectory='INSTALLDIR'>
         <Feature Id='lang' Title='The core scala language.' Level='1' Absent='disallow'>
-          { for(ref <- (binIds ++ libIds ++ miscIds ++ licenseId ++ readmeId)) yield <ComponentRef Id={ref}/> }
+          { for(ref <- (binIds ++ libIds ++ miscIds ++ licenseId ++ readmeId ++ licensesIds)) yield <ComponentRef Id={ref}/> }
         </Feature>
          <Feature Id='ScalaPathF' Title='Update system PATH' Description='This will add scala binaries (scala, scalac, scaladoc, scalap) to your windows system path.' Level='1'>
           <ComponentRef Id='ScalaBinPath'/>


### PR DESCRIPTION
`doc/scala-devel-docs` moved to `api/`, as the scaladocs
go to a different tar ball
