### PR TITLE
Update version information to 2.9

### DIFF
--- a/documentation/lib/scaladoc.sty
+++ b/documentation/lib/scaladoc.sty
@@ -225,7 +225,7 @@
 
 \newcommand{\docauthor}{Author}
 \newcommand{\doctitle}{Title}
-\newcommand{\docsubtitle}{DRAFT}
+\newcommand{\docsubtitle}{}
 \newcommand{\docdate}{\today}
 \newcommand{\translatedby}{}
 \newcommand{\makedoctitle}{%

--- a/documentation/src/reference/ScalaReference.tex
+++ b/documentation/src/reference/ScalaReference.tex
@@ -66,7 +66,7 @@
 \renewcommand{\doctitle}{Scala By Example\\[33mm]\ }
 \renewcommand{\docauthor}{Martin Odersky\\[53mm]\ }
 \renewcommand{\doctitle}{The Scala Language \\ Specification \\
-\Large  Version 2.8 \ }
+\Large  Version 2.9 \ }
 
 \comment{
 \renewcommand{\docauthor}{Martin Odersky \\


### PR DESCRIPTION
While 2.10 is already released, the spec covers only the features of 2.9. Essential parts like string interpolation are completely missing from the spec.

Review by @odersky
