### PR TITLE
Rewrite \` found in listing to a real \`

### DIFF
--- a/documentation/lib/scaladoc.sty
+++ b/documentation/lib/scaladoc.sty
@@ -186,6 +186,9 @@
     numberstyle=\tiny,%
 }
 
+% rewrite \` found in a listing to a real \`
+\lstset{literate={\\`}{{\`{}}}1}
+
 \lstdefinestyle{floating}{%
     xleftmargin=10pt,%
     xrightmargin=5pt,%

--- a/documentation/lib/scaladoc.sty
+++ b/documentation/lib/scaladoc.sty
@@ -186,8 +186,9 @@
     numberstyle=\tiny,%
 }
 
-% rewrite \` found in a listing to a real \`
-\lstset{literate={\\`}{{\`{}}}1}
+\RequirePackage{textcomp}
+% rewrite \` found in a listing to a real \` and \' to a single apostrophe
+\lstset{literate={\\`}{{\`{}}}1 {\\'}{{\textquotesingle{}}}1}
 
 \lstdefinestyle{floating}{%
     xleftmargin=10pt,%

--- a/documentation/src/reference/SyntaxSummary.tex
+++ b/documentation/src/reference/SyntaxSummary.tex
@@ -49,7 +49,7 @@ form.
                      |  charEscapeSeq
   multiLineChars   ::=  {[`"'] [`"'] charNoDoubleQuote} {`"'}
 
-  symbolLiteral    ::=  `'' plainid
+  symbolLiteral    ::=  `\'' plainid
 
   comment          ::=  `/*' $\mbox{\rm\em ``any sequence of characters''}$ `*/'
                      |  `//' $\mbox{\rm\em ``any sequence of characters up to end of line''}$
@@ -199,7 +199,7 @@ grammar.
   ClassParamClauses ::=  {ClassParamClause} 
                          [[nl] `(' `implicit' ClassParams `)']
   ClassParamClause  ::=  [nl] `(' [ClassParams] ')'
-  ClassParams       ::=  ClassParam {`' ClassParam}
+  ClassParams       ::=  ClassParam {`,' ClassParam}
   ClassParam        ::=  {Annotation} [{Modifier} (`val' | `var')] 
                          id `:' ParamType [`=' Expr]
   Bindings          ::=  `(' Binding {`,' Binding `)'

--- a/tool-support/src/latex/scaladoc.sty
+++ b/tool-support/src/latex/scaladoc.sty
@@ -182,8 +182,9 @@
     numberstyle=\tiny,%
 }
 
-% rewrite \` found in a listing to a real \`
-\lstset{literate={\\`}{{\`{}}}1}
+\RequirePackage{textcomp}
+% rewrite \` found in a listing to a real \` and \' to a single apostrophe
+\lstset{literate={\\`}{{\`{}}}1 {\\'}{{\textquotesingle{}}}1}
 
 \lstdefinestyle{floating}{%
     xleftmargin=10pt,%

--- a/tool-support/src/latex/scaladoc.sty
+++ b/tool-support/src/latex/scaladoc.sty
@@ -182,6 +182,9 @@
     numberstyle=\tiny,%
 }
 
+% rewrite \` found in a listing to a real \`
+\lstset{literate={\\`}{{\`{}}}1}
+
 \lstdefinestyle{floating}{%
     xleftmargin=10pt,%
     xrightmargin=5pt,%


### PR DESCRIPTION
A ` that occurs in a listing is shown as two signs whereas one
wants to display it as a single `. This change is required because
a single` that is written to a listing is already rewritten to and
therefore displayed as a beginning apostrophe.

This style bug can be seen in the syntax summary for `id`.

Review by @odersky
