### PR TITLE
Clarify allowed members in object definitions

### DIFF
--- a/documentation/src/reference/ReferencePart.tex
+++ b/documentation/src/reference/ReferencePart.tex
@@ -3890,6 +3890,9 @@ the same name as the class and is defined in the same scope and
 compilation unit. Conversely, the class is called the {\em companion class}
 of the module.
 
+Very much like a concrete class definition, an object definition may
+still contain declarations of abstract type members, but not of
+abstract term members.
 
 \comment{
 Let $ct$ be a class template. 


### PR DESCRIPTION
Clarification of allowed declarations, as requested in scala/scala#3407
