### PR TITLE
SI-8155 Qualified private members are inherited unconditionally.

### DIFF
--- a/documentation/src/reference/ReferencePart.tex
+++ b/documentation/src/reference/ReferencePart.tex
@@ -3258,8 +3258,7 @@ The modifier can be {\em qualified} with an identifier $C$ (e.g.
 enclosing the definition.  Members labeled with such a modifier are
 accessible respectively only from code inside the package $C$ or only
 from code inside the class $C$ and its companion module
-(\sref{sec:object-defs}). Such members are also inherited only from
-templates inside $C$.
+(\sref{sec:object-defs}).
 
 An different form of qualification is \code{private[this]}. A member
 $M$ marked with this modifier is called {\em object-protected}; it can be accessed only from within


### PR DESCRIPTION
The qualification is only used to determine accessibility.

This brings the spec into line with the implementation.
