### PR TITLE
Dummy commit to workaround bug in release script.

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,3 +52,4 @@ and sign the [CLA](http://typesafe.com/contribute/cla/scala).
 The branching structure mimics that of [scala/scala](https://github.com/scala/scala):
 master is the upcoming 2.11.0 release,
 and the 2.10.x branch is your target for 2.10.x features.
+


### PR DESCRIPTION
If one commit in this repo is tagged with two different tags,
the scala-dist-2.11.x jobs on Jenkins can pick the wrong
version of scala-dist to build the release!

Review by @adriaanm
