### PR TITLE
depend on headless java

### DIFF
--- a/project/Unix.scala
+++ b/project/Unix.scala
@@ -87,7 +87,7 @@ object Unix {
 
     // Debian Specific
     name in Debian    := "scala",
-    debianPackageDependencies += "openjdk-6-jre | java6-runtime",
+    debianPackageDependencies += "openjdk-7-jre-headless | java6-runtime",
     // debianPackageDependencies += "libjansi-java",
 
     linuxPackageMappings in Debian += (packageMapping(


### PR DESCRIPTION
openjdk-6-jre depends on x11-common and in turn depends on a lot of things unnecessary for scala.
