### PR TITLE
Import CI scripts from 2.11.x.

### DIFF
--- a/conf/repositories
+++ b/conf/repositories
@@ -1,0 +1,7 @@
+[repositories]
+  plugins: http://dl.bintray.com/sbt/sbt-plugin-releases/, [organisation]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  private-repo: http://private-repo.typesafe.com/typesafe/scala-release-temp/
+  typesafe-ivy-releases: http://repo.typesafe.com/typesafe/ivy-releases/, [organization]/[module]/[revision]/[type]s/[artifact](-[classifier]).[ext], bootOnly
+  sbt-plugin-releases: http://scalasbt.artifactoryonline.com/scalasbt/sbt-plugin-releases, [organization]/[module]/(scala_[scalaVersion]/)(sbt_[sbtVersion]/)[revision]/[type]s/[artifact](-[classifier]).[ext]
+  maven-central
+  local

--- a/scripts/jobs/release/package/generic
+++ b/scripts/jobs/release/package/generic
@@ -34,4 +34,4 @@ java $JAVA_OPTS -Dsbt.log.noformat=true -Dsbt.ivy.home=$WORKSPACE/.ivy2 \
   -Dsbt.override.build.repos=true -Dsbt.repository.config="$repositoriesFile" \
   -jar $sbtLauncher \
   "set version := \"$version\"" \
-  clean update scala-dist-finish $sbtDistTarget
+  scala-dist-finish $sbtDistTarget

--- a/scripts/jobs/release/package/generic
+++ b/scripts/jobs/release/package/generic
@@ -1,0 +1,37 @@
+# @pre current directory == repo root
+# must run on both windows (cygwin) and linux
+
+# invoked from scala-release-2.11.x-[unix|windows]
+
+# uses the following env vars:
+#   - WORKSPACE, JAVA_OPTS (jenkins standard)
+#   - version checked for consistency against HEAD's tag
+#   - sbtLauncher is a global jenkins configuration variable
+#   - sbtDistTarget the target (beyond clean and update) to run
+#   - sbtDistVersionOverride may be -Dproject.version=....  to override the version of the dist to build (only for testing, you should use tags for real releases!)
+
+# requires git (>= 1.8), java, bash
+
+repositoriesFile="$WORKSPACE/conf/repositories"
+
+tags="$(git tag --points-at HEAD)"
+
+# version is set by the scala-release-2.11.x-dist build flow, make sure it's consistent with the tag
+# this is also a backstop for https://github.com/sbt/sbt-git/issues/35
+# ignore when there is no version (job is running outside of the flow)
+[[ -z $sbtDistVersionOverride ]] && [[ -n $version ]] && if [ "$tags" != "v$version" ]; then
+  echo "Inconsistent tag/version combo detected. Abort-abort."
+  exit 255
+fi
+
+mkdir -p target/dist
+curl -s -k https://downloads.typesafe.com/scala/tmp/scala-dist-$version.tar.gz -o - | tar -C target/dist -xvz
+# || echo &quot;ignoring symlink problem&quot;
+#rm target/dist/archives/scala-latest-sources.tgz &amp;&amp; mv scala-latest-sources.tgz target/dist/archives
+
+# want full control over sbt, so invoke the launcher directly
+java $JAVA_OPTS -Dsbt.log.noformat=true -Dsbt.ivy.home=$WORKSPACE/.ivy2 \
+  -Dsbt.override.build.repos=true -Dsbt.repository.config="$repositoriesFile" \
+  -jar $sbtLauncher \
+  "set version := \"$version\"" \
+  clean update scala-dist-finish $sbtDistTarget

--- a/scripts/jobs/release/package/unix
+++ b/scripts/jobs/release/package/unix
@@ -1,0 +1,6 @@
+# @pre current directory == repo root
+
+# to be extra-sure we don't pollute
+rm -rf $WORKSPACE/.ivy2
+
+. scripts/jobs/release/package/generic

--- a/scripts/jobs/release/package/windows
+++ b/scripts/jobs/release/package/windows
@@ -1,0 +1,6 @@
+# @pre current directory == repo root
+
+# to be extra-sure we don't pollute
+rm -rf "$(/usr/bin/cygpath --unix $WORKSPACE/.ivy2)"
+
+. scripts/jobs/release/package/generic

--- a/scripts/jobs/release/website/archives
+++ b/scripts/jobs/release/website/archives
@@ -1,0 +1,36 @@
+#!/bin/bash -ex
+# need to re-declare it as an array, not sure how to do that directly in jenkins
+declare -a sshCharaArgs="$sshCharaArgs"
+
+url="http://downloads.typesafe.com/scala/$version"
+
+if [[ "$version" =~ .*-nightly ]]
+then archivesDir="~linuxsoft/archives/scala/nightly/2.11.x"
+else archivesDir="~linuxsoft/archives/scala"
+fi
+
+# make this build restartable (if interrupted, partial files may remain, and resuming isn't very reliable)
+[[ -n $version ]] && ssh "${sshCharaArgs[@]}" "rm -f $archivesDir/scala-*$version* && rm -rf $archivesDir/api/$version/ ||:"
+
+cacheBuster="$(date +%s | tail -c2 | head -c1)"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-$version.msi       '$url/scala-$version.msi?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-$version.zip       '$url/scala-$version.zip?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-$version.tgz       '$url/scala-$version.tgz?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-$version.deb       '$url/scala-$version.deb?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-$version.rpm       '$url/scala-$version.rpm?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-docs-$version.zip  '$url/scala-docs-$version.zip?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-docs-$version.tgz  '$url/scala-docs-$version.tgz?$cacheBuster'"
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && wget -nv -O scala-docs-$version.txz  '$url/scala-docs-$version.txz?$cacheBuster'"
+
+echo "Expanding scala-library API docs for $version to api/$version (with subdirectories for scala-compiler and scala-reflect)."
+ssh "${sshCharaArgs[@]}" "cd $archivesDir && mkdir -p api/$version && tar -xvz --strip-component 2 -f scala-docs-$version.tgz -C api/$version && mv api/$version/scala-library/* api/$version/" # tar on jenkins does not support the -s option
+
+echo "Expanding the Scaladoc for other bundled modules"
+# treat scala-actors separately because it's not cross-versioned
+ssh "${sshCharaArgs[@]}" "(set -x; cd $archivesDir && mkdir -p api/$version/scala-actors && unzip \$(find api/$version/jars -name 'scala-actors-2.11*javadoc.jar' -o -name scala-actors-${version}-javadoc.jar) -d api/$version/scala-actors;)"
+
+modules="scala-actors-migration scala-continuations-library scala-parser-combinators scala-swing scala-xml"
+for m in $modules; do 
+ssh "${sshCharaArgs[@]}" "(set -x; cd $archivesDir && mkdir -p api/$version/$m && unzip \$(find api/$version/jars -name ${m}_'*javadoc.jar' -o -name ${m}-${version}-javadoc.jar) -d api/$version/$m;)"
+done
+

--- a/scripts/jobs/release/website/update-api
+++ b/scripts/jobs/release/website/update-api
@@ -1,0 +1,16 @@
+#!/bin/bash -ex
+# need to re-declare it as an array, not sure how to do that directly in jenkins
+declare -a sshCharaArgs="$sshCharaArgs"
+
+if [[ "$version" =~ .*-nightly ]]
+then archivesDir="~linuxsoft/archives/scala/nightly/2.11.x"
+else archivesDir="~linuxsoft/archives/scala"
+fi
+
+echo "Symlinking $archivesDir/api/$version to $archivesDir/api/2.11.x."
+
+ssh "${sshCharaArgs[@]}" "cd $archivesDir/api/ ; [[ -d $version ]] && ln -sfn $version 2.11.x"
+
+# needs to run once on new major release:
+# ssh "${sshCharaArgs[@]}" "cd $archivesDir/api/ ; [[ -d $version ]] && ln -sfn 2.11.x current"
+


### PR DESCRIPTION
To build a 2.10.x release, the required changes were:
- scala-dist comes from s3, not maven
- set version differently, call scala-dist-finish

```
--- c/scripts/jobs/release/package/generic
+++ i/scripts/jobs/release/package/generic
@@ -24,14 +24,9 @@ tags="$(git tag --points-at HEAD)"
   exit 255
 fi

+mkdir -p target/dist
+curl -s -k https://downloads.typesafe.com/scala/tmp/scala-dist-$version.tar.gz -o - | tar -C target/dist -xvz
+# || echo &quot;ignoring symlink problem&quot;
+#rm target/dist/archives/scala-latest-sources.tgz &amp;&amp; mv scala-latest-sources.tgz target/dist/archives
+
 # want full control over sbt, so invoke the launcher directly
 java $JAVA_OPTS -Dsbt.log.noformat=true -Dsbt.ivy.home=$WORKSPACE/.ivy2 \
   -Dsbt.override.build.repos=true -Dsbt.repository.config="$repositoriesFile" \
   -jar $sbtLauncher \
-  $sbtDistVersionOverride \
-  clean update $sbtDistTarget
+  "set version := \"$version\"" \
+  scala-dist-finish $sbtDistTarget
```

the targets must exactly work out to scala-dist-finish s3-upload, or you get a weird `java.util.NoSuchElementException`

validated at
- unix (success): https://scala-ci.typesafe.com/job/scala-2.11.x-release-package-unix/32/console
- windows (success -- failure is spurious): https://scala-ci.typesafe.com/job/scala-2.11.x-release-package-windows/30/console
