### PR TITLE
use local temporary directory

### DIFF
--- a/scripts/jobs/release/package/generic
+++ b/scripts/jobs/release/package/generic
@@ -24,9 +24,15 @@ tags="$(git tag --points-at HEAD)"
   exit 255
 fi
 
+# to avoid running out of disk space in the root partition,
+# we'll use this for temporary files
+TMP=$WORKSPACE/tmp
+mkdir -p $TMP
+
 # want full control over sbt, so invoke the launcher directly
 java $JAVA_OPTS -Dsbt.log.noformat=true -Dsbt.ivy.home=$WORKSPACE/.ivy2 \
   -Dsbt.override.build.repos=true -Dsbt.repository.config="$repositoriesFile" \
+  -Djava.io.tmpdir="$TMP" \
   -jar $sbtLauncher \
   $sbtDistVersionOverride \
   clean update $sbtDistTarget


### PR DESCRIPTION
our temporary disk space usage needs are high.
so use the Jenkins workspace directory rather than a shared
systemwide temp directory which might be on an undersized
partition.

reference: https://github.com/scala/scala-dev/issues/261