### PR TITLE
Ensure archive fetch script uses HTTPS download

### DIFF
--- a/scripts/jobs/release/website/archives
+++ b/scripts/jobs/release/website/archives
@@ -2,7 +2,7 @@
 # need to re-declare it as an array, not sure how to do that directly in jenkins
 declare -a sshCharaArgs="$sshCharaArgs"
 
-url="http://downloads.lightbend.com/scala/$version"
+url="https://downloads.lightbend.com/scala/$version"
 
 if [[ "$version" =~ ^.*-(bin|pre)-[0-9a-f]+$ ]]
 then archivesDir="~linuxsoft/archives/scala/nightly/2.12.x"


### PR DESCRIPTION
This is to prevent an MitM possible by downloading the releases
in plain text (using HTTP). Per scala/scala-lang#627 this script
appears to make artifacts available on scala-lang.org and so any
form of attack here could be problematic.