### PR TITLE
Set ACL as public-read for uploads to S3

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -2,9 +2,10 @@ scalacOptions ++= Seq("-deprecation", "-feature", "-Xlint")
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.0.6")
 
-addSbtPlugin("com.typesafe.sbt" % "sbt-s3" % "0.9")
+libraryDependencies += "com.amazonaws" % "aws-java-sdk-s3" % "1.11.277"
 
 // git plugin
 resolvers += "jgit-repo" at "http://download.eclipse.org/jgit/maven"
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-git" % "0.6.4")
+


### PR DESCRIPTION
Now that we're using IAM instance profiles instead of credentials,
our upload is coming from a different account than before
(now: typesafe-scala, before: typesafe-www). This means the 
default ACL does not allow access to our uploads, unless 
we set it to public-read.

That then set off another chain of events, which resulted in
inlining the tiny part of the s3 plugin that we use, since the plugin
doesn't provide this extension point (see https://github.com/sbt/sbt-s3/issues/37). 

(And our usage of S3 is pretty trivial otherwise.)

