### PR TITLE
fix travis setting. use openjdk instead of oraclejdk

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,13 @@
 # we need rpmbuild but it's unlikely to be whitelisted, according to
 # https://github.com/travis-ci/apt-package-whitelist/pull/1700
 sudo: required
-
+dist: xenial
 install:
   - sudo apt-get -qq update
   - sudo apt-get install -y rpm
 
 language: scala
-jdk: oraclejdk8
+jdk: openjdk8
 
 env:
   global:


### PR DESCRIPTION
https://github.com/travis-ci/travis-ci/issues/10290#issuecomment-432331802

> `oraclejdk8` is not preinstalled on Xenial anymore, and cannot be retrieved from Oracle itself anymore. We'd suggest using either openjdk, or the currently supported Oracle JDK.

https://travis-ci.org/scala/scala-dist/builds

![builds](https://user-images.githubusercontent.com/389787/61919626-6c15d680-af91-11e9-9d1a-815b26d57345.png)
