### PR TITLE
Configure new GitHub API token like a pro

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
     # AWS_SECRET_ACCESS_KEY
     - secure: "dv0pR9uqnLyKVHu1L1nvl5TVpo3bOxh4icLNybwFyCFQd9XiM/RU8Vhx3svZqqnAG+GiCDSiCaBQkTLUS5u9e+9eVw3cUj5meNr9EW673f8D6H8Tr433jlvu54CynD9DsBjhNo/xIrECOKTq+0wu480OLSjOkuNoclG2dSm4Dis="
     # GITHUB_OAUTH_TOKEN (for GitHub user scala-jenkins, same token as scabot)
-    - secure: "Bk0IRAPGF9ZjQZQRe618KgXG2VLXRcJgJN7dvomxFdjZOqn/46TrFa6RlLLmicu9F4UrbgpSazfDgr7S8qER6GIyr+hDpv/sdi//EcYql2A0ww2r5QPaA9gW4wiTO8Cy0m/ZsK8IAjvOcdDXW19JH7b0HygDAnJOBiOR9S9wWuI="
+    - secure: "KetupmuH5L7nJjouavdPpvuc7imL9T01zI/OdTYhzOmuTSHV8tP6TVykRcVl73ZBkEre+Es7TYw46HjlhTqGtj//6V+8XCNZ4hIt1IYEA2v+IBmIBCtuVnZdlY09/DqM8vxZjhnLFhjQlTvkCZdzc1lfzN1AVtceUvKqJpnzGS0="
 script:
   - source scripts/common
   - postCommitStatus "pending"

--- a/scripts/common
+++ b/scripts/common
@@ -15,16 +15,21 @@ function postCommitStatus() {
   if [[ "$scala_sha" != "" ]]; then
     local jsonTemplate='{ "state": "%s", "target_url": "%s", "description": "%s", "context": "%s"}'
     local json=$(printf "$jsonTemplate" "$1" "https://travis-ci.com/scala/scala-dist/builds/$TRAVIS_BUILD_ID" "$1" "travis/scala-dist/$version/$mode")
+    [[ -z "$GITHUB_OAUTH_TOKEN" ]] && (echo "Missing environment variable GITHUB_OAUTH_TOKEN!"; exit 1)
+    TMPFILE=$(mktemp -t curl.XXXXXXXXXX)
+
+    local tmpfile=$(mktemp -t curl.XXXXXXXXXX) || exit 1
 
     local curlStatus=$(curl \
-      -s -o /dev/null -w "%{http_code}" \
+      -s -o $tmpfile -w "%{http_code}" \
       -H "Accept: application/vnd.github.v3+json" \
       -H "Authorization: token $GITHUB_OAUTH_TOKEN" \
       -d "$json" \
       https://api.github.com/repos/scala/scala/statuses/$scala_sha)
 
     [[ "$curlStatus" == "201" ]] || {
-      echo "Failed to publish GitHub commit status"
+      echo "Failed to publish GitHub commit status. Got: $curlStatus"
+      cat $tmpfile
       exit 1
     }
   fi


### PR DESCRIPTION
Encrypted, this time, with:

```
travis encrypt --pro GITHUB_OAUTH_TOKEN=ghp_XXXXXXXXXXX
```

Last time I forgot the `--pro` part, which is needed for `travis-ci.com`.

I've also added a better diagnostic for failures in updating the GitHub commit status.